### PR TITLE
fix: Make JobSpec consistent with latest EvalHub changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ job_spec = JobSpec(
         name="llama-2-7b"
     ),
     benchmark_config={},
-    callback_url="http://localhost:8080/callback",
+    callback_url="http://localhost:8080",
     num_examples=100
 )
 
@@ -456,7 +456,7 @@ class JobSpec(BaseModel):
     benchmark_id: str                 # Benchmark to evaluate
     model: ModelConfig                # Model configuration (url, name)
     benchmark_config: Dict[str, Any]  # Adapter-specific parameters
-    callback_url: str                 # URL for status and result callbacks
+    callback_url: str                 # Base URL for callbacks (SDK appends /status, /results)
 
     # Optional fields
     num_examples: Optional[int]       # Number of examples to evaluate

--- a/examples/simple_adapter/README.md
+++ b/examples/simple_adapter/README.md
@@ -146,7 +146,7 @@ Example job spec in ConfigMap:
     "num_few_shot": 5,
     "random_seed": 42
   },
-  "callback_url": "http://localhost:8080/callback",
+  "callback_url": "http://localhost:8080",
   "num_examples": 100
 }
 ```
@@ -189,7 +189,7 @@ spec = JobSpec(
     benchmark_id="mmlu",
     model={"url": "http://localhost:8000", "name": "test-model"},
     benchmark_config={},
-    callback_url="http://localhost:8080/callback",
+    callback_url="http://localhost:8080",
     num_examples=10
 )
 

--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -66,7 +66,10 @@ class JobSpec(BaseModel):
     )
 
     # Callback configuration (mandatory)
-    callback_url: str = Field(..., description="URL for status and result callbacks")
+    callback_url: str = Field(
+        ...,
+        description="Base URL for callbacks",
+    )
 
     # ============================================================================
     # OPTIONAL FIELDS

--- a/tests/e2e/test_persist_with_mock_persister.py
+++ b/tests/e2e/test_persist_with_mock_persister.py
@@ -27,7 +27,7 @@ def mock_job_spec_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         "model": {"url": "http://localhost:8000", "name": "test-model"},
         "num_examples": 10,
         "benchmark_config": {"random_seed": 42},
-        "callback_url": "http://localhost:8080/callback",
+        "callback_url": "http://localhost:8080",
     }
 
     # Write to temp file
@@ -123,7 +123,7 @@ class TestOCIArtifactPersistenceE2E:
             benchmark_id="mmlu",
             model=ModelConfig(url="http://localhost:8000", name="test-model"),
             benchmark_config={},
-            callback_url="http://localhost:8080/callback",
+            callback_url="http://localhost:8080",
             num_examples=10,
         )
 

--- a/tests/unit/test_adapter_models.py
+++ b/tests/unit/test_adapter_models.py
@@ -30,7 +30,7 @@ def mock_job_spec_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
         "model": {"url": "http://localhost:8000", "name": "test-model"},
         "num_examples": 10,
         "benchmark_config": {"random_seed": 42},
-        "callback_url": "http://localhost:8080/callback",
+        "callback_url": "http://localhost:8080",
     }
 
     # Write to temp file
@@ -54,7 +54,7 @@ class TestJobSpec:
             model=ModelConfig(url="http://localhost:8000", name="test-model"),
             num_examples=10,
             benchmark_config={"num_few_shot": 5, "random_seed": 42},
-            callback_url="http://localhost:8080/callback",
+            callback_url="http://localhost:8080",
         )
 
         assert spec.job_id == "test-job-001"
@@ -71,7 +71,7 @@ class TestJobSpec:
             benchmark_id="hellaswag",
             model=ModelConfig(url="http://localhost:8000", name="model"),
             benchmark_config={},
-            callback_url="http://localhost:8080/callback",
+            callback_url="http://localhost:8080",
         )
 
         assert spec.job_id == "test-job-002"
@@ -86,7 +86,7 @@ class TestJobSpec:
             benchmark_id="mmlu",
             model=ModelConfig(url="http://localhost:8000", name="model"),
             benchmark_config={"subject": "physics", "difficulty": "hard"},
-            callback_url="http://localhost:8080/callback",
+            callback_url="http://localhost:8080",
         )
 
         assert spec.benchmark_config == {"subject": "physics", "difficulty": "hard"}
@@ -98,7 +98,7 @@ class TestJobSpec:
             benchmark_id="arc",
             model=ModelConfig(url="http://localhost:8000", name="model"),
             benchmark_config={},
-            callback_url="http://localhost:8080/callback",
+            callback_url="http://localhost:8080",
             tags={"env": "test", "developer": "alice"},
         )
 
@@ -111,7 +111,7 @@ class TestJobSpec:
             benchmark_id="gsm8k",
             model=ModelConfig(url="http://localhost:8000", name="model"),
             benchmark_config={},
-            callback_url="http://localhost:8080/callback",
+            callback_url="http://localhost:8080",
             num_examples=50,
         )
 
@@ -507,7 +507,7 @@ class TestFrameworkAdapter:
             benchmark_id="mmlu",
             model=ModelConfig(url="http://localhost:8000", name="test-model"),
             benchmark_config={},
-            callback_url="http://localhost:8080/callback",
+            callback_url="http://localhost:8080",
         )
 
         results = adapter.run_benchmark_job(spec, callbacks)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job specification now requires a callback URL for status/result notifications.
  * Added optional retry attempts to control job retry behavior.
  * Introduced a nested benchmark configuration object for adapter-specific parameters and clearer field grouping.

* **Documentation**
  * Updated examples and guides to show the new callback URL, benchmark config structure, and mandatory vs optional field layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->