### PR TITLE
fix(example): use JobSpec fields

### DIFF
--- a/examples/simple_adapter/run_local.py
+++ b/examples/simple_adapter/run_local.py
@@ -84,12 +84,13 @@ def main() -> None:
     # Create job specification
     # In production, this would be loaded from /meta/job.json
     spec_data = {
-        "job_id": "local-test-001",
+        "id": "local-test-001",
         "benchmark_id": "mmlu",
         "model": {
             "url": "http://localhost:8000/v1",  # Your local model server
             "name": "test-model",
         },
+        "callback_url": "unused",  # Mock URL for local testing
         "num_examples": 10,  # Small number for quick testing
         "benchmark_config": {
             "subject": "mathematics",


### PR DESCRIPTION
without this changes it would fail

with these changes:

<img width="819" height="180" alt="image" src="https://github.com/user-attachments/assets/e3ea3c46-a8fe-4cc4-aa26-c28ae576e596" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local configuration field naming for consistency.
  * Added callback URL support for local testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->