### PR TITLE
fix(adapter): update job spec tags to list-of-dicts format (#35)

### DIFF
--- a/examples/simple_adapter/k8s-example.yaml
+++ b/examples/simple_adapter/k8s-example.yaml
@@ -22,11 +22,11 @@ data:
         "subject": "all"
       },
       "experiment_name": "llama-2-evaluation",
-      "tags": {
-        "model_family": "llama-2",
-        "model_size": "7b",
-        "env": "production"
-      },
+      "tags": [
+        {"key": "model_family", "value": "llama-2"},
+        {"key": "model_size", "value": "7b"},
+        {"key": "env", "value": "production"}
+      ],
       "timeout_seconds": 3600
     }
 

--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -104,8 +104,8 @@ class JobSpec(BaseModel):
     experiment_name: str | None = Field(
         default=None, description="Name for this evaluation experiment"
     )
-    tags: dict[str, str] = Field(
-        default_factory=dict, description="Custom tags for the job"
+    tags: list[dict[str, str]] = Field(
+        default_factory=list, description="Custom tags for the job"
     )
 
     # Resource hints (optional)

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -116,8 +116,8 @@ class EvaluationRequest(BaseModel):
     experiment_name: str | None = Field(
         default=None, description="Name for this evaluation experiment"
     )
-    tags: dict[str, str] = Field(
-        default_factory=dict, description="Custom tags for the job"
+    tags: list[dict[str, str]] = Field(
+        default_factory=list, description="Custom tags for the job"
     )
     priority: int = Field(
         default=0, description="Job priority (higher = more priority)"


### PR DESCRIPTION
Align JobSpec and EvaluationRequest tags with the new format from eval-hub/eval-hub#166, changing from `dict[str, str]` to l`ist[dict[str, str]]` (e.g. `[{"key": "env", "value": "prod"}]`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Change: Tag Format Update**
  * Tag structure has changed from a flat key-value dictionary to a list of key-value pair objects. This affects how tags are specified in job definitions and evaluation requests. Users must update their configurations and integrations to use the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->