### PR TITLE
feat(client): add typed exceptions for job cancel error responses (#38)

### DIFF
--- a/src/evalhub/client/__init__.py
+++ b/src/evalhub/client/__init__.py
@@ -46,7 +46,13 @@ Example (synchronous):
 Note: EvalHubClient is an alias for AsyncEvalHubClient (async by default).
 """
 
-from .base import BaseAsyncClient, BaseSyncClient, ClientError
+from .base import (
+    BaseAsyncClient,
+    BaseSyncClient,
+    ClientError,
+    JobCanNotBeCancelledError,
+    JobNotFoundError,
+)
 from .evalhub import AsyncEvalHubClient, EvalHubClient, SyncEvalHubClient
 from .evaluations import AsyncEvaluationsClient, SyncEvaluationsClient
 from .providers import AsyncProvidersClient, SyncProvidersClient
@@ -56,6 +62,8 @@ __all__ = [
     "BaseAsyncClient",
     "BaseSyncClient",
     "ClientError",
+    "JobNotFoundError",
+    "JobCanNotBeCancelledError",
     # Main clients (recommended)
     "AsyncEvalHubClient",
     "SyncEvalHubClient",

--- a/src/evalhub/client/base.py
+++ b/src/evalhub/client/base.py
@@ -130,6 +130,28 @@ class ClientError(Exception):
         self.cause = cause
 
 
+class JobNotFoundError(ClientError):
+    """Raised when a job does not exist or has already been deleted."""
+
+    def __init__(self, job_id: str, cause: Exception | None = None) -> None:
+        super().__init__(f"Job '{job_id}' not found", cause=cause)
+        self.job_id = job_id
+
+
+class JobCanNotBeCancelledError(ClientError):
+    """Raised when a job cannot be cancelled (e.g. already completed, failed, or cancelled)."""
+
+    def __init__(
+        self, job_id: str, reason: str | None = None, cause: Exception | None = None
+    ) -> None:
+        msg = f"Job '{job_id}' cannot be cancelled"
+        if reason:
+            msg += f": {reason}"
+        super().__init__(msg, cause=cause)
+        self.job_id = job_id
+        self.reason = reason
+
+
 class BaseAsyncClient:
     """Base async client for EvalHub API communication.
 

--- a/src/evalhub/client/evaluations.py
+++ b/src/evalhub/client/evaluations.py
@@ -14,7 +14,12 @@ from ..models import (
     JobsList,
     JobStatus,
 )
-from .base import BaseAsyncClient, BaseSyncClient
+from .base import (
+    BaseAsyncClient,
+    BaseSyncClient,
+    JobCanNotBeCancelledError,
+    JobNotFoundError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -65,18 +70,28 @@ class AsyncEvaluationsClient(BaseAsyncClient):
             job_id: The job identifier
 
         Returns:
-            bool: True if job was cancelled, False otherwise
+            bool: True if job was successfully cancelled
 
         Raises:
-            httpx.HTTPError: If request fails
+            JobNotFoundError: If the job does not exist or was already deleted (HTTP 404)
+            JobCanNotBeCancelledError: If the job cannot be cancelled, e.g. already
+                completed, failed, or cancelled (HTTP 400)
+            httpx.HTTPError: If request fails for other reasons
         """
         try:
             await self._request_delete(f"/evaluations/jobs/{job_id}")
             return True
-        except Exception as e:
-            if isinstance(e, httpx.HTTPStatusError):
-                if e.response.status_code in [404, 409]:
-                    return False  # Job not found or cannot be cancelled
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise JobNotFoundError(job_id, cause=e) from e
+            if e.response.status_code in [400, 409]:
+                reason = None
+                try:
+                    body = e.response.json()
+                    reason = body.get("message")
+                except Exception:
+                    pass
+                raise JobCanNotBeCancelledError(job_id, reason=reason, cause=e) from e
             raise
 
     async def list(
@@ -186,18 +201,28 @@ class SyncEvaluationsClient(BaseSyncClient):
             job_id: The job identifier
 
         Returns:
-            bool: True if job was cancelled, False otherwise
+            bool: True if job was successfully cancelled
 
         Raises:
-            httpx.HTTPError: If request fails
+            JobNotFoundError: If the job does not exist or was already deleted (HTTP 404)
+            JobCanNotBeCancelledError: If the job cannot be cancelled, e.g. already
+                completed, failed, or cancelled (HTTP 400)
+            httpx.HTTPError: If request fails for other reasons
         """
         try:
             self._request_delete(f"/evaluations/jobs/{job_id}")
             return True
-        except Exception as e:
-            if isinstance(e, httpx.HTTPStatusError):
-                if e.response.status_code in [404, 409]:
-                    return False  # Job not found or cannot be cancelled
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise JobNotFoundError(job_id, cause=e) from e
+            if e.response.status_code in [400, 409]:
+                reason = None
+                try:
+                    body = e.response.json()
+                    reason = body.get("message")
+                except Exception:
+                    pass
+                raise JobCanNotBeCancelledError(job_id, reason=reason, cause=e) from e
             raise
 
     def list(


### PR DESCRIPTION
## Changes

New exception types (src/evalhub/client/base.py)

- `JobNotFoundError(ClientError)`, raised on HTTP 404 (job doesn't exist or was already deleted). Carries `job_id`.
- `JobCanNotBeCancelledError(ClientError)` — raised on HTTP 400 or 409 (job already completed/failed/cancelled). Carries `job_id`, `reason` (taken from the server's response body), and cause.

### Updated cancel methods (4 locations)

- src/evalhub/client/evaluations.py, AsyncEvaluationsClient.cancel, SyncEvaluationsClient.cancel
- src/evalhub/client/resources/jobs.py, AsyncJobsResource.cancel, SyncJobsResource.cancel

**Before**: caught 404/409 and returned False, losing the reason.
**After**: raises `JobNotFoundError` on 404, raises `JobCanNotBeCancelledError` on 400/409 (with server message parsed from response body). 409 is kept for backwards compatibility with older server versions.

Both new exceptions are exported from evalhub.client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced JobNotFoundError and JobCanNotBeCancelledError exception types to the public API, providing more granular error handling for job operations.

* **Bug Fixes**
  * Improved error handling for job cancellation to raise specific domain exceptions instead of generic HTTP errors, enhancing clarity and error diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->