### PR TITLE
ci(gha): optional E2E with latest eval-hub-server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  MIN_PY_VER: "3.12"  # using same as in pyproject.toml
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -35,7 +38,7 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
     - name: Set up Python
-      run: uv python install 3.12  # using same as in pyproject.toml
+      run: uv python install ${{ env.MIN_PY_VER }}
     - name: Install dependencies
       run: uv sync --all-extras
     - name: Run ruff linting
@@ -46,7 +49,12 @@ jobs:
       run: uv run mypy src/evalhub
 
   e2e:
+    name: "Optional: E2E Tests (latest_eval_hub_server=${{ matrix.latest_eval_hub_server }})"
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        latest_eval_hub_server: [true, false]
     steps:
     - uses: actions/checkout@v4
     - name: Set up uv
@@ -55,13 +63,20 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
     - name: Set up Python
-      run: uv python install 3.12
+      run: uv python install ${{ env.MIN_PY_VER }}
     - name: Install dependencies
-      run: uv sync
+      run: uv sync --all-extras
+    - name: Fetch latest eval-hub server from eval-hub repo workflow
+      if: matrix.latest_eval_hub_server == true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        uv run ./scripts/fetch_latest_eval_hub_server.py
+        tree .venv/lib/python${{ env.MIN_PY_VER }}/site-packages/evalhub_server
     - name: Create kind cluster
       uses: helm/kind-action@v1
     - name: Deploy distribution registry
       run: ./scripts/deploy_distribution_registry.sh
     - name: Run E2E tests
       run: |
-        uv run pytest --e2e --cov=src/evalhub --cov-report=term-missing --cov-report=xml
+        make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@ pre-commit:
 
 .PHONY: test
 test:
-	uv run pytest
+	uv run pytest --color=yes -ra
 
 .PHONY: test-e2e
 test-e2e:
-	uv run pytest --e2e -s -x -q
+	@echo "*** WARN: Running E2E with uv run --no-sync so not to override any replacement for eval-hub-server ***"
+	uv run --no-sync uv pip show eval-hub-server
+	uv run --no-sync pytest --e2e -s -x --color=yes -ra
 
 .PHONY: ruff
 ruff:

--- a/tests/e2e/config/config.yaml
+++ b/tests/e2e/config/config.yaml
@@ -7,7 +7,7 @@ service:
 secrets:
   dir: /tmp
   mappings:
-    db_password: database.password
+    # db_password: database.password
 # These are here so that the config can be loaded from the environment variables when needed
 env_mappings:
   PORT: service.port


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E workflow with a parallel matrix to run alternate server variants and clearer job naming
  * Improved resilience with continue-on-error and updated E2E invocation for more reliable test runs
  * Increased test verbosity and diagnostics for easier troubleshooting
* **Chores**
  * Added conditional fetch of the latest server build during CI when applicable
  * Made dependency and Python-version handling in CI more explicit
* **Configuration**
  * Disabled a DB password mapping in E2E config to avoid using the mapped secret during those runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->