### PR TITLE
fix example and docs for 'tags'

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ class JobSpec(BaseModel):
     # Optional fields
     num_examples: Optional[int]       # Number of examples to evaluate
     experiment_name: Optional[str]    # Experiment name
-    tags: Dict[str, str]              # Custom tags (default: {})
+    tags: list[dict[str, str]]        # Custom tags (default: [])
 
     @classmethod
     def from_file(cls, path: Path | str) -> Self:

--- a/examples/simple_adapter/run_local.py
+++ b/examples/simple_adapter/run_local.py
@@ -98,10 +98,10 @@ def main() -> None:
             "random_seed": 42,
         },
         "experiment_name": "local-test",
-        "tags": {
-            "env": "local",
-            "test": "true",
-        },
+        "tags": [
+            {"key": "env", "value": "local"},
+            {"key": "test", "value": "true"},
+        ],
     }
 
     # For local testing, create a temporary job spec file


### PR DESCRIPTION
align to

https://github.com/eval-hub/eval-hub-sdk/blob/a79ea63619637508fde8a8a43ea475b865bfed16/src/evalhub/adapter/models/job.py#L105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated job specification format: the tags field now uses a list of key-value pair objects instead of a dictionary structure. Examples and documentation have been updated to reflect this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->