### PR TITLE
fix: use http for oci/oras to sidecar

### DIFF
--- a/src/evalhub/adapter/oci/persister.py
+++ b/src/evalhub/adapter/oci/persister.py
@@ -120,7 +120,15 @@ class OCIArtifactPersister:
                     elif item.is_dir():
                         logger.debug("  Dir:  %s", item.relative_to(temp_path))
 
-            provider = oras.provider.Registry(insecure=self.oci_insecure)
+            # python-oras: Registry(insecure=...) chooses the URL scheme for registry calls:
+            #   insecure=True  -> http://   (plain HTTP)
+            #   insecure=False -> https://  (TLS)
+            # Push targets are host/path only (no scheme); the flag only affects which scheme is used.
+            # Use HTTP when (1) OCI_INSECURE is set for a plain-HTTP registry, or (2) oci_proxy_host
+            # is set: the in-pod sidecar accepts HTTP on :8080, and we must not use https:// to it
+            # when OCI_INSECURE is false.
+            registry_uses_http = self.oci_insecure or (self.oci_proxy_host is not None)
+            provider = oras.provider.Registry(insecure=registry_uses_http)
             if not self.oci_proxy_host:
                 provider.auth.hostname = spec.coordinates.oci_host
                 if self.oci_auth_config_path:


### PR DESCRIPTION
## What and why

<!-- What does this PR do and why? Link to related issues. -->

Closes # https://redhat.atlassian.net/browse/RHOAIENG-59731
 
## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

Earlier error message:
```
2026-04-23 11:00:32,766 - evalhub.adapter.callbacks - INFO - Creating OCI artifact for job 7f132728-8695-413a-91bc-72117488f53b
2026-04-23 11:00:32,777 - __main__ - ERROR - Evaluation failed
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.11/site-packages/oras/layout/layout.py", line 289, in push_to_registry
    blob_data = json.loads(manifest_bytes)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/__init__.py", line 341, in loads
    s = s.decode(detect_encoding(s), 'surrogatepass')
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 464, in _make_request
    self._validate_conn(conn)
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 1093, in _validate_conn
    conn.connect()
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connection.py", line 796, in connect
    sock_and_verified = _ssl_wrap_socket_and_match_hostname(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connection.py", line 975, in _ssl_wrap_socket_and_match_hostname
    ssl_sock = ssl_wrap_socket(
               ^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/util/ssl_.py", line 483, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/util/ssl_.py", line 527, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/ssl.py", line 517, in wrap_socket
    return self.sslsocket_class._create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/ssl.py", line 1104, in _create
    self.do_handshake()
  File "/usr/lib64/python3.11/ssl.py", line 1382, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL] record layer failure (_ssl.c:1004)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 488, in _make_request
    raise new_e
urllib3.exceptions.SSLError: [SSL] record layer failure (_ssl.c:1004)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.11/site-packages/requests/adapters.py", line 644, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 841, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/util/retry.py", line 535, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='localhost', port=8080): Max retries exceeded with url: /v2/rh-ee-scheruku/sobhatest/blobs/sha256:749eab0b4203cfcf90623d02ad3d2edc2e01dc45a21f56a536d726a9f36ccfb6 (Caused by SSLError(SSLError(1, '[SSL] record layer failure (_ssl.c:1004)')))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/src/main.py", line 445, in run_benchmark_job
    oci_result = callbacks.create_oci_artifact(oci_spec)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/evalhub/adapter/callbacks.py", line 566, in create_oci_artifact
    result = self.persister.persist(spec)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/evalhub/adapter/oci/persister.py", line 139, in persist
    response = Layout(str(temp_path)).push_to_registry(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/oras/layout/layout.py", line 340, in push_to_registry
    response = provider.upload_blob(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/oras/provider.py", line 281, in upload_blob
    if self.blob_exists(layer, container):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/oras/provider.py", line 574, in blob_exists
    response = self.do_request(f"{self.prefix}://{blob_url}", "HEAD")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/oras/decorator.py", line 42, in inner
    res = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/oras/provider.py", line 1001, in do_request
    response = self.session.request(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/requests/adapters.py", line 675, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='localhost', port=8080): Max retries exceeded with url: /v2/rh-ee-scheruku/sobhatest/blobs/sha256:749eab0b4203cfcf90623d02ad3d2edc2e01dc45a21f56a536d726a9f36ccfb6 (Caused by SSLError(SSLError(1, '[SSL] record layer failure (_ssl.c:1004)')))
2026-04-23 11:00:32,810 - httpx - INFO - HTTP Request: POST http://localhost:8080/api/v1/evaluations/jobs/7f132728-8695-413a-91bc-72117488f53b/events "HTTP/1.1 204 No Content"
2026-04-23 11:00:32,810 - __main__ - ERROR - Fatal error: Evaluation failed: HTTPSConnectionPool(host='localhost', port=8080): Max retries exceeded with url: /v2/rh-ee-scheruku/sobhatest/blobs/sha256:749eab0b4203cfcf90623d02ad3d2edc2e01dc45a21f56a536d726a9f36ccfb6 (Caused by SSLError(SSLError(1, '[SSL] record layer failure (_ssl.c:1004)')))
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.11/site-packages/oras/layout/layout.py", line 289, in push_to_registry
    blob_data = json.loads(manifest_bytes)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/json/__init__.py", line 341, in loads
    s = s.decode(detect_encoding(s), 'surrogatepass')
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 464, in _make_request
    self._validate_conn(conn)
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 1093, in _validate_conn
    conn.connect()
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connection.py", line 796, in connect
    sock_and_verified = _ssl_wrap_socket_and_match_hostname(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connection.py", line 975, in _ssl_wrap_socket_and_match_hostname
    ssl_sock = ssl_wrap_socket(
               ^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/util/ssl_.py", line 483, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/util/ssl_.py", line 527, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/ssl.py", line 517, in wrap_socket
    return self.sslsocket_class._create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/ssl.py", line 1104, in _create
    self.do_handshake()
  File "/usr/lib64/python3.11/ssl.py", line 1382, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL] record layer failure (_ssl.c:1004)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
               ^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 488, in _make_request
    raise new_e
urllib3.exceptions.SSLError: [SSL] record layer failure (_ssl.c:1004)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.11/site-packages/requests/adapters.py", line 644, in send
    resp = conn.urlopen(
           ^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/connectionpool.py", line 841, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/urllib3/util/retry.py", line 535, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='localhost', port=8080): Max retries exceeded with url: /v2/rh-ee-scheruku/sobhatest/blobs/sha256:749eab0b4203cfcf90623d02ad3d2edc2e01dc45a21f56a536d726a9f36ccfb6 (Caused by SSLError(SSLError(1, '[SSL] record layer failure (_ssl.c:1004)')))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/src/main.py", line 445, in run_benchmark_job
    oci_result = callbacks.create_oci_artifact(oci_spec)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/evalhub/adapter/callbacks.py", line 566, in create_oci_artifact
    result = self.persister.persist(spec)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/evalhub/adapter/oci/persister.py", line 139, in persist
    response = Layout(str(temp_path)).push_to_registry(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/oras/layout/layout.py", line 340, in push_to_registry
    response = provider.upload_blob(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/oras/provider.py", line 281, in upload_blob
    if self.blob_exists(layer, container):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/oras/provider.py", line 574, in blob_exists
    response = self.do_request(f"{self.prefix}://{blob_url}", "HEAD")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.11/site-packages/oras/decorator.py", line 42, in inner
    res = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^

```

With the fix, able to export the OCI artifact. 
```
{"resource":{"id":"1869b911-c9e8-4c7c-ae90-a291b4c4bffd","tenant":"dataplane","created_at":"2026-04-24T10:54:29.662735Z","updated_at":"2026-04-24T10:55:12.323221Z","owner":"system:serviceaccount:dataplane:dataplane-sa"},"status":{"state":"completed","message":{"message":"Evaluation job is completed","message_code":"evaluation_job_updated"},"benchmarks":[{"provider_id":"lm_evaluation_harness","id":"arc_easy","benchmark_index":0,"status":"completed","completed_at":"2026-04-24T10:55:10.440085+00:00"}]},"results":{"test":{"score":0.5,"threshold":0.5,"pass":true},"benchmarks":[{"id":"arc_easy","provider_id":"lm_evaluation_harness","benchmark_index":0,"metrics":{"acc":0.4,"acc_norm":0.5,"acc_norm_stderr":0.16666666666666666,"acc_stderr":0.1632993161855452},"artifacts":{"oci_digest":"sha256:deec784901d5920ec4f7a83d613f4141258420187543c0befdd483c42830ba3c","oci_reference":"quay.io/rh-ee-nbs/nbs-dev:evalhub-ea08100a9db74bceeabc29b234eba8b62da3dee9bbd8cb1effba5cdba5c795bd@sha256:deec784901d5920ec4f7a83d613f4141258420187543c0befdd483c42830ba3c"},"test":{"primary_score":0.5,"primary_score_metric":"acc_norm","threshold":0.25,"pass":true}}]},"name":"test","model":{"url":"http://granite-llm-metrics.prabhu.svc.cluster.local:8080/v1","name":"granite-llm"},"benchmarks":[{"id":"arc_easy","provider_id":"lm_evaluation_harness","parameters":{"limit":5,"num_examples":10,"tokenizer":"google/flan-t5-small"}}],"exports":{"oci":{"coordinates":{"oci_host":"quay.io","oci_repository":"rh-ee-nbs/nbs-dev"},"k8s":{"connection":"sagar-oci-secret"}}}}

```
## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OCI registry communication to properly use HTTP when a proxy host is configured, resolving issues with artifact persistence where HTTPS was incorrectly attempted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->