### PR TITLE
fix(cli): use 'status' query parameter instead of 'status_filter' for job

### DIFF
--- a/src/evalhub/client/resources/jobs.py
+++ b/src/evalhub/client/resources/jobs.py
@@ -132,7 +132,7 @@ class AsyncJobsResource:
         """
         params = {}
         if status:
-            params["status_filter"] = status.value
+            params["status"] = status.value
         if limit:
             params["limit"] = str(limit)
 
@@ -295,7 +295,7 @@ class SyncJobsResource:
         """
         params = {}
         if status:
-            params["status_filter"] = status.value
+            params["status"] = status.value
         if limit:
             params["limit"] = str(limit)
 

--- a/tests/unit/test_evalhub_client.py
+++ b/tests/unit/test_evalhub_client.py
@@ -43,6 +43,19 @@ from evalhub.models.api import (
 # Environment variable to enable real server testing
 EVALHUB_TEST_BASE_URL = os.environ.get("EVALHUB_TEST_BASE_URL")
 
+JOBS_LIST_PARAM_CASES = [
+    pytest.param(
+        {"status": JobStatus.RUNNING}, {"status": "running"}, id="status-only"
+    ),
+    pytest.param({"limit": 10}, {"limit": "10"}, id="limit-only"),
+    pytest.param(
+        {"status": JobStatus.COMPLETED, "limit": 5},
+        {"status": "completed", "limit": "5"},
+        id="status-and-limit",
+    ),
+    pytest.param({}, {}, id="no-params"),
+]
+
 
 @pytest.fixture
 def use_real_server() -> bool:
@@ -387,6 +400,49 @@ class TestEvalHubClient:
             assert job.name == "oci-export-eval"
 
         client.close()
+
+    @pytest.mark.skipif(
+        EVALHUB_TEST_BASE_URL is not None,
+        reason="Skipping in real server mode",
+    )
+    @pytest.mark.parametrize("kwargs, expected_params", JOBS_LIST_PARAM_CASES)
+    def test_sync_jobs_list_query_params(
+        self, kwargs: dict[str, Any], expected_params: dict[str, str]
+    ) -> None:
+        """Test that jobs.list sends correct query parameter names to the server."""
+        with SyncEvalHubClient() as client:
+            mock_response = Mock()
+            mock_response.json.return_value = {"total_count": 0, "items": []}
+
+            with patch.object(
+                client, "_request_get", return_value=mock_response
+            ) as mock_get:
+                client.jobs.list(**kwargs)
+                mock_get.assert_called_once()
+                _, call_kwargs = mock_get.call_args
+                assert call_kwargs.get("params", {}) == expected_params
+
+    @pytest.mark.skipif(
+        EVALHUB_TEST_BASE_URL is not None,
+        reason="Skipping in real server mode",
+    )
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kwargs, expected_params", JOBS_LIST_PARAM_CASES)
+    async def test_async_jobs_list_query_params(
+        self, kwargs: dict[str, Any], expected_params: dict[str, str]
+    ) -> None:
+        """Test that async jobs.list sends correct query parameter names to the server."""
+        async with AsyncEvalHubClient() as client:
+            mock_response = Mock()
+            mock_response.json.return_value = {"total_count": 0, "items": []}
+
+            with patch.object(
+                client, "_request_get", return_value=mock_response
+            ) as mock_get:
+                await client.jobs.list(**kwargs)
+                mock_get.assert_called_once()
+                _, call_kwargs = mock_get.call_args
+                assert call_kwargs.get("params", {}) == expected_params
 
     def test_sync_client_context_manager(self) -> None:
         """Test SyncEvalHubClient as context manager."""


### PR DESCRIPTION
… listing

The server expects 'status' as the query parameter name but the CLI was sending 'status_filter', causing a 400 error. Fixed in both sync and async job resources, with parametrized tests covering all query parameter combinations.

## What and why

Closes # NA

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually
```
pytest
```
Before fix:
<img width="1082" height="136" alt="Screenshot 2026-04-27 at 3 57 15 PM" src="https://github.com/user-attachments/assets/324c4626-6cf4-4550-b2b4-fd542fea822c" />


After fix:
<img width="1171" height="304" alt="Screenshot 2026-04-27 at 3 57 50 PM" src="https://github.com/user-attachments/assets/c1cf1caa-52b7-4038-a940-6c7dba10b6d9" />

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the query parameter name for job list status filtering from `status_filter` to `status`.

* **Tests**
  * Added unit tests for job list request parameter serialization across synchronous and asynchronous endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->