### PR TITLE
fix(cli): wrap long column data in table output instead of truncating

### DIFF
--- a/src/evalhub/cli/formatter.py
+++ b/src/evalhub/cli/formatter.py
@@ -73,7 +73,7 @@ def _print_table(
 
     table = Table(show_lines=False, padding=(0, 1))
     for c in cols:
-        table.add_column(c.upper(), no_wrap=True)
+        table.add_column(c.upper(), no_wrap=False, header_style="bold", overflow="fold")
 
     for row in data:
         table.add_row(*[str(row.get(c, "")) for c in cols])


### PR DESCRIPTION
## What and why

To improve readability of the evalhub cli output

Before:

<img width="1125" height="140" alt="Screenshot 2026-04-28 at 11 35 25 AM" src="https://github.com/user-attachments/assets/5906a397-21c5-4558-9841-1e8d8a56d416" />

After:
<img width="1118" height="165" alt="Screenshot 2026-04-28 at 11 35 36 AM" src="https://github.com/user-attachments/assets/2f1728c8-adc1-4990-baa1-ef2769f8790c" />

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced CLI table header formatting with bold styling and improved text wrapping to provide better readability and overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->