### PR TITLE
feat(sdk): forward evaluation_metadata["artifacts"] in DefaultCallbacks.report_results()

### DIFF
--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -685,6 +685,12 @@ class DefaultCallbacks(JobCallbacks):
                         exclude_none=True
                     )
 
+                eval_meta_artifacts = (results.evaluation_metadata or {}).get(
+                    "artifacts", {}
+                )
+                if eval_meta_artifacts:
+                    artifacts.update(eval_meta_artifacts)
+
                 if artifacts:
                     status_event["artifacts"] = artifacts
 


### PR DESCRIPTION
`DefaultCallbacks.report_results()` builds a status event payload and POSTs it to the EvalHub sidecar as the job's terminal COMPLETED event. Before this change, the `artifacts` block in that payload was populated exclusively from three SDK-managed sources:

- `results.oci_artifact` → `oci_reference` / `oci_digest`
- `results.eval_card` → `evalhub.eval_card`
- `results.env_card` → `evalhub.env_card`

`JobResults.evaluation_metadata` is a `dict[str, Any]` that adapters use to carry framework-specific output. One of its documented sub-keys is `"artifacts"`, a dict of named URLs (S3 links, presigned URLs, etc.) produced during a scan. Despite existing in the model, this sub-dict was silently dropped and never forwarded to the sidecar.

This PR adds the missing merge in `callbacks.py`:

```python
eval_meta_artifacts = (results.evaluation_metadata or {}).get("artifacts", {})
if eval_meta_artifacts:
    artifacts.update(eval_meta_artifacts)
```

Merge order: OCI → `eval_card` → `env_card` → `evaluation_metadata["artifacts"]`.
Adapter-supplied entries win on key collision against card metadata (see below).

Closes [RHOAIENG-52961](https://redhat.atlassian.net/browse/RHOAIENG-52961)

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Breaking changes

None. The `if eval_meta_artifacts:` guard means the new code path is only entered when an adapter explicitly populates `evaluation_metadata["artifacts"]`. All existing adapters that do not set this sub-key have identical behaviour. The field has `default_factory=dict` so it is always at least `{}`, and `.get("artifacts", {})` on an empty dict returns `{}`, no `None`-safety issue.

## Implications and edge cases

**Key precedence: adapter values win on collision.**

`artifacts.update(eval_meta_artifacts)` runs after the SDK inserts its own keys, so an adapter-supplied key silently overwrites `oci_reference`, `oci_digest`, or `evalhub.*` if names collide. In practice this is safe, known users of `evaluation_metadata["artifacts"]` (Garak KFP mode) use distinct keys (`html_report`, `report_jsonl`, `hitlog_jsonl`).
Adapters must not reuse the reserved key names for artifact URLs.

**The `if artifacts:` guard is unaffected.**
If an adapter sets only `evaluation_metadata["artifacts"]` (no OCI, no cards), the `artifacts` dict becomes non-empty via the merge, so the guard passes and the key is included in the payload.

**`_GarakCallbacks` workaround is now redundant.**
The Garak adapter carries a `_GarakCallbacks` subclass that duplicates the entire `report_results()` body to achieve this same merge. It can now be removed and `main()` updated to use `DefaultCallbacks.from_adapter(adapter)` directly. Left for a follow-up.

## Usage

Any `FrameworkAdapter` that produces downloadable artifacts can now use this without subclassing `DefaultCallbacks`:

```python
def run_benchmark_job(self, config: JobSpec, callbacks: Callbacks) -> JobResults:
    artifact_urls = self._upload_artifacts(scan_dir)
    return JobResults(
        id=config.id,
        benchmark_id=config.benchmark_id,
        # ...
        evaluation_metadata={
            "artifacts": artifact_urls,     # forwarded by SDK automatically
            "framework_version": "1.2.3",   # not forwarded (only "artifacts" key is)
        },
    )
```

**Before** (Garak KFP COMPLETED event):

```json
{
    "benchmark_status_event": {
      "state": "COMPLETED",
      "metrics": { "attack_success_rate": 12.5 },
      "artifacts": {}
    }
}
```

**After**:

  ```json
  {
    "benchmark_status_event": {
      "state": "COMPLETED",
      "metrics": { "attack_success_rate": 12.5 },
      "artifacts": {
        "html_report":  "s3://evalhub-artifacts/jobs/abc123/garak_report.html",
        "report_jsonl": "s3://evalhub-artifacts/jobs/abc123/garak.report.jsonl",
        "hitlog_jsonl": "s3://evalhub-artifacts/jobs/abc123/garak.hitlog.jsonl"
      }
    }
  }
```

## Testing

- [ ] Tests added or updated
- [x] Tested manually

`tests/unit/test_callbacks_events.py` has no coverage for this path yet. Two cases should be added:

1. `evaluation_metadata={"artifacts": {"html_report": "s3://..."}}`: `artifacts` block in the POST payload contains `html_report`.
2. `evaluation_metadata={}` (default): behaviour unchanged, no regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Enhanced artifact handling: Optional artifact entries from evaluation metadata are now extracted and automatically merged into the Eval Hub payload, alongside existing OCI references and card metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->