### PR TITLE
feat: add TestDataRef/S3TestDataRef models and CLI S3 test data flags

### DIFF
--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -26,6 +26,8 @@ from evalhub.models import (
     OCIConnectionConfig,
     OCICoordinates,
     QueueConfig,
+    S3TestDataRef,
+    TestDataRef,
 )
 
 from . import config as cfg
@@ -166,6 +168,7 @@ def _build_request_from_flags(
     exports: EvaluationExports | None = None,
     extra_params: dict[str, Any] | None = None,
     queue: QueueConfig | None = None,
+    test_data_ref: TestDataRef | None = None,
 ) -> JobSubmissionRequest:
     """Build a JobSubmissionRequest from CLI flags."""
     parameters: dict[str, Any] = {}
@@ -176,7 +179,7 @@ def _build_request_from_flags(
     if dataset:
         parameters["dataset"] = dataset
     benchmarks = [
-        BenchmarkConfig(id=b, provider_id=provider, parameters=parameters)
+        BenchmarkConfig(id=b, provider_id=provider, parameters=parameters, test_data_ref=test_data_ref)
         for b in benchmark
     ]
     return JobSubmissionRequest(
@@ -249,6 +252,21 @@ def _build_request_from_flags(
     help="Kueue LocalQueue name for workload scheduling (inline flags only).",
 )
 @click.option(
+    "--test-data-s3-bucket",
+    default=None,
+    help="S3 bucket name for custom test data (inline flags only).",
+)
+@click.option(
+    "--test-data-s3-key",
+    default=None,
+    help="S3 object key or prefix for custom test data (inline flags only).",
+)
+@click.option(
+    "--test-data-s3-secret",
+    default=None,
+    help="Kubernetes Secret name with S3 credentials for custom test data (inline flags only).",
+)
+@click.option(
     "--wait", "wait_for", is_flag=True, default=False, help="Block until job completes."
 )
 @click.option(
@@ -281,6 +299,9 @@ def eval_run(
     oci_repository: str | None,
     oci_connection: str | None,
     queue: str | None,
+    test_data_s3_bucket: str | None,
+    test_data_s3_key: str | None,
+    test_data_s3_secret: str | None,
     wait_for: bool,
     timeout: float | None,
     poll_interval: float,
@@ -310,6 +331,10 @@ def eval_run(
       evalhub eval run --name my-eval --model-url http://vllm:8000/v1 \\
           --model-name llama3 --provider lm_evaluation_harness -b mmlu \\
           --queue my-local-queue
+      evalhub eval run --name my-eval --model-url http://vllm:8000/v1 \\
+          --model-name llama3 --provider lm_evaluation_harness -b your_benchmark_id \\
+          --test-data-s3-bucket evalhub-test --test-data-s3-key dataset/ \\
+          --test-data-s3-secret evalhub-s3-credentials
     """
     client = get_client(ctx)
 
@@ -358,6 +383,21 @@ def eval_run(
         queue_config: QueueConfig | None = None
         if queue:
             queue_config = QueueConfig(name=queue)
+        s3_flags = (test_data_s3_bucket, test_data_s3_key, test_data_s3_secret)
+        if any(s3_flags) and not all(s3_flags):
+            raise click.ClickException(
+                "S3 test data requires --test-data-s3-bucket, --test-data-s3-key, "
+                "and --test-data-s3-secret to all be specified."
+            )
+        test_data_ref: TestDataRef | None = None
+        if all(s3_flags):
+            test_data_ref = TestDataRef(
+                s3=S3TestDataRef(
+                    bucket=cast(str, test_data_s3_bucket),
+                    key=cast(str, test_data_s3_key),
+                    secret_ref=cast(str, test_data_s3_secret),
+                )
+            )
         request = _build_request_from_flags(
             name=cast(str, name),
             model_url=cast(str, model_url),
@@ -371,6 +411,7 @@ def eval_run(
             exports=exports,
             extra_params=extra_params,
             queue=queue_config,
+            test_data_ref=test_data_ref,
         )
 
     job = client.jobs.submit(request)

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -179,7 +179,12 @@ def _build_request_from_flags(
     if dataset:
         parameters["dataset"] = dataset
     benchmarks = [
-        BenchmarkConfig(id=b, provider_id=provider, parameters=parameters, test_data_ref=test_data_ref)
+        BenchmarkConfig(
+            id=b,
+            provider_id=provider,
+            parameters=parameters,
+            test_data_ref=test_data_ref,
+        )
         for b in benchmark
     ]
     return JobSubmissionRequest(

--- a/src/evalhub/models/__init__.py
+++ b/src/evalhub/models/__init__.py
@@ -3,6 +3,8 @@
 from .api import (
     Benchmark,
     BenchmarkConfig,
+    S3TestDataRef,
+    TestDataRef,
     BenchmarkInfo,
     BenchmarkReference,
     BenchmarkResult,
@@ -69,6 +71,8 @@ __all__ = [
     "Benchmark",
     "BenchmarkConfig",
     "BenchmarkInfo",
+    "S3TestDataRef",
+    "TestDataRef",
     "BenchmarkResult",
     "BenchmarksList",
     "BenchmarkReference",

--- a/src/evalhub/models/__init__.py
+++ b/src/evalhub/models/__init__.py
@@ -3,8 +3,6 @@
 from .api import (
     Benchmark,
     BenchmarkConfig,
-    S3TestDataRef,
-    TestDataRef,
     BenchmarkInfo,
     BenchmarkReference,
     BenchmarkResult,
@@ -43,6 +41,8 @@ from .api import (
     ProviderList,
     QueueConfig,
     Resource,
+    S3TestDataRef,
+    TestDataRef,
 )
 
 __all__ = [

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -233,6 +233,22 @@ class EvaluationJobResults(BaseModel):
     )
 
 
+class S3TestDataRef(BaseModel):
+    """S3 source for custom test data."""
+
+    bucket: str = Field(..., description="S3 bucket name")
+    key: str = Field(..., description="S3 object key or prefix")
+    secret_ref: str = Field(
+        ..., description="Kubernetes Secret name containing S3 credentials"
+    )
+
+
+class TestDataRef(BaseModel):
+    """Reference to an external test data source."""
+
+    s3: S3TestDataRef | None = Field(default=None, description="S3 data source")
+
+
 class BenchmarkConfig(BaseModel):
     """Benchmark configuration for job submission."""
 
@@ -240,6 +256,9 @@ class BenchmarkConfig(BaseModel):
     provider_id: str = Field(..., description="Provider identifier")
     parameters: dict[str, Any] = Field(
         default_factory=dict, description="Benchmark-specific parameters"
+    )
+    test_data_ref: TestDataRef | None = Field(
+        default=None, description="Reference to custom external test data"
     )
 
 


### PR DESCRIPTION
RHOAIENG-60776: Add S3TestDataRef and TestDataRef Pydantic models to evalhub.models.api matching the Go API schema, add test_data_ref field to BenchmarkConfig, and export both classes from the models package.

RHOAIENG-60777: Add --test-data-s3-bucket, --test-data-s3-key, and --test-data-s3-secret flags to 'evalhub eval run', wiring them into BenchmarkConfig.test_data_ref on job submission.

## What and why

<!-- What does this PR do and why? Link to related issues. -->


Closes #
https://redhat.atlassian.net/browse/RHOAIENG-60776
https://redhat.atlassian.net/browse/RHOAIENG-60776

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

```
 evalhub eval run \
    --name my-eval \
    --model-url https://vllm-llama-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1 \
    --model-name meta-llama/Llama-3.2-1B-Instruct \
    --provider lm_evaluation_harness \
    -b arc_easy \
    --param limit=5 \
    --param tokenizer=google/flan-t5-small \
    --test-data-s3-bucket mlpipeline --test-data-s3-key offline_arc_easy/ \
            --test-data-s3-secret minio-test
Job submitted: 4d930869-4286-4cf5-80ba-c7d0558ba38e

```
Validated from within the pod that init container has downloaded the required data in /test_data:
```
oc rsh 4d930869-4286-4cf5-80ba-c7-85800e5d-bf15-4a0d-9d94-a81b0c86glsx 
Defaulted container "adapter" out of: adapter, init (init), sidecar (init)
(app-root) sh-5.1$ 
(app-root) sh-5.1$ 
(app-root) sh-5.1$ 
(app-root) sh-5.1$ 
(app-root) sh-5.1$ cd /test_data/
(app-root) sh-5.1$ ls
allenai--ai2_arc--ARC-Easy  tokenizer
(app-root) sh-5.1$ ls -l
total 0
drwxr-sr-x. 5 1000900000 1000900000  74 May  7 12:45 allenai--ai2_arc--ARC-Easy
drwxr-sr-x. 3 1000900000 1000900000 102 May  7 12:45 tokenizer
```

Similarly validated the SDK client changes as well.

```
ython /Users/scheruku/Documents/Redhat/git-repo/eval-hub.github.io/src/content/docs/getting-started/quickstart.py
TLS verification disabled - skipping CA bundle detection
TLS verification disabled (insecure mode)
Job submitted: 9365ced3-8f38-48b8-8390-676cc6d0276a
Status: state=<JobStatus.COMPLETED: 'completed'> message=MessageInfo(message='Evaluation job is completed', message_code='evaluation_job_updated') benchmarks=[BenchmarkStatus(id='arc_easy', provider_id='lm_evaluation_harness', benchmark_index=0, status=<JobStatus.COMPLETED: 'completed'>, error_message=None, started_at=None, completed_at=datetime.datetime(2026, 5, 7, 12, 50, 36, 630304, tzinfo=TzInfo(0)))]
State: completed
Results: benchmarks=[BenchmarkResult(id='arc_easy', provider_id='lm_evaluation_harness', benchmark_index=0, metrics={'acc': 0.44, 'acc_norm': 0.44, 'acc_norm_stderr': 0.04988876515698589, 'acc_stderr': 0.04988876515698589}, artifacts={'evalhub.env_card': {'aggregate_results': {}, 'autograder_bias': {}, 'capture_completeness': 0.15, 'confidence_intervals': {}, 'cpu_model': 'x86_64', 'custom': {}, 'k8s_pod_labels': {}, 'k8s_resource_limits': {}, 'key_packages': {'lm_eval': '0.4.8', 'mlflow': '3.12.0', 'torch': '2.6.0', 'transformers': '4.48.0'}, 'os_info': 'Linux-5.14.0-570.78.1.el9_6.x86_64-x86_64-with-glibc2.34', 'per_task_results': {}, 'python_version': '3.11.13', 'scorer_ids': []}}, mlflow_run_id=None, logs_path=None)] mlflow_experiment_url=None
Status: state=<JobStatus.COMPLETED: 'completed'> message=MessageInfo(message='Evaluation job is completed', message_code='evaluation_job_updated') benchmarks=[BenchmarkStatus(id='arc_easy', provider_id='lm_evaluation_harness', benchmark_index=0, status=<JobStatus.COMPLETED: 'completed'>, error_message=None, started_at=None, completed_at=datetime.datetime(2026, 5, 7, 12, 50, 36, 630304, tzinfo=TzInfo(0)))]
State: completed
```
Inside pod:
```
oc rsh 9365ced3-8f38-48b8-8390-67-6d51076a-78d5-4f72-951f-f625078426j9
cd /Defaulted container "adapter" out of: adapter, init (init), sidecar (init)
(app-root) sh-5.1$ 
(app-root) sh-5.1$ 
(app-root) sh-5.1$ 
(app-root) sh-5.1$ cd /test_data
(app-root) sh-5.1$ ls -l
total 0
drwxr-sr-x. 5 1000900000 1000900000  74 May  7 12:50 allenai--ai2_arc--ARC-Easy
drwxr-sr-x. 3 1000900000 1000900000 102 May  7 12:50 tokenizer
```
## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom evaluation test data via S3: The `eval run` command now accepts S3 credentials (`--test-data-s3-bucket`, `--test-data-s3-key`, `--test-data-s3-secret`) to reference test datasets stored in Amazon S3 during evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->