### PR TITLE
fix: export OCICoordinates from evalhub.adapter package

### DIFF
--- a/src/evalhub/adapter/__init__.py
+++ b/src/evalhub/adapter/__init__.py
@@ -71,6 +71,7 @@ from ..models.api import (
     EvaluationResult,
     JobStatus,
     ModelConfig,
+    OCICoordinates,
 )
 from .auth import ModelCredentials, read_model_auth_key, resolve_model_credentials
 from .callbacks import DefaultCallbacks
@@ -130,4 +131,5 @@ __all__ = [
     "JobStatus",
     "ModelConfig",
     "EvaluationResult",
+    "OCICoordinates",
 ]


### PR DESCRIPTION
Re-export OCICoordinates from evalhub.models.api in the adapter package so adapter authors can import it directly alongside other OCI-related types like OCIArtifactSpec and OCIArtifactResult.

## What and why
In one of our blogs we have this
```
from evalhub.adapter import (
    FrameworkAdapter,
    JobCallbacks,
    JobPhase,
    JobResults,
    JobSpec,
    JobStatusUpdate,
    MessageInfo,
    OCIArtifactSpec,
    OCICoordinates <<<--- not working 
)

```

Closes #

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adapter SDK now exports coordinate model support directly from the main package, simplifying imports for developers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub-sdk/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->