### PR TITLE
feat(adapter): add MLflow traces namespace with search, get, and materialize operations

### DIFF
--- a/src/evalhub/adapter/mlflow.py
+++ b/src/evalhub/adapter/mlflow.py
@@ -9,6 +9,7 @@ Modelled after github.com/opendatahub-io/mlflow-go.
 
 from __future__ import annotations
 
+import json
 import logging
 import mimetypes
 import os
@@ -97,6 +98,43 @@ class MlflowArtifact:
     path: str
     content: bytes
     content_type: str = "application/octet-stream"
+
+
+@dataclass
+class SpanInfo:
+    """A single span within an MLflow trace."""
+
+    span_id: str
+    name: str
+    parent_span_id: str | None = None
+    status: str = ""
+    start_time_ns: int = 0
+    end_time_ns: int = 0
+    attributes: dict[str, Any] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    inputs: Any = None
+    outputs: Any = None
+
+
+@dataclass
+class TraceInfo:
+    """Metadata for an MLflow trace."""
+
+    request_id: str
+    experiment_id: str
+    timestamp_ms: int = 0
+    execution_time_ms: int = 0
+    status: str = ""
+    tags: dict[str, str] = field(default_factory=dict)
+    request_metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class Trace:
+    """An MLflow trace (info + span data)."""
+
+    info: TraceInfo
+    data: dict[str, Any] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +275,7 @@ class MlflowClient:
             verify=verify,
             headers=req_headers,
         )
+        self._traces = TracesNamespace(self)
 
     def close(self) -> None:
         self._client.close()
@@ -587,11 +626,208 @@ class MlflowClient:
             for f in data.get("files", [])
         ]
 
+    # -- Trace operations (delegated to namespace) ---------------------------
+
+    @property
+    def traces(self) -> TracesNamespace:
+        """Namespace for trace operations: ``client.traces.search(...)``, etc."""
+        return self._traces
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 
+def _parse_trace(raw: dict[str, Any]) -> Trace:
+    """Build a ``Trace`` from the MLflow REST API JSON shape."""
+    info_raw = raw.get("info", {})
+    tags: dict[str, str] = {}
+    for t in info_raw.get("tags", []):
+        tags[t.get("key", "")] = t.get("value", "")
+    req_meta: dict[str, str] = {}
+    for m in info_raw.get("request_metadata", []):
+        req_meta[m.get("key", "")] = m.get("value", "")
+
+    info = TraceInfo(
+        request_id=info_raw.get("request_id", ""),
+        experiment_id=info_raw.get("experiment_id", ""),
+        timestamp_ms=info_raw.get("timestamp_ms", 0),
+        execution_time_ms=info_raw.get("execution_time_ms", 0),
+        status=info_raw.get("status", ""),
+        tags=tags,
+        request_metadata=req_meta,
+    )
+    return Trace(info=info, data=raw.get("data", {}))
+
+
 def _now_ms() -> int:
     return int(time.time() * 1000)
+
+
+# ---------------------------------------------------------------------------
+# Traces namespace
+# ---------------------------------------------------------------------------
+
+_TRACE_PARAM_EXPERIMENT_ID = "mlflow_traces_experiment_id"
+_TRACE_PARAM_EXPERIMENT_NAME = "mlflow_traces_experiment_name"
+_TRACE_PARAM_MAX_RESULTS = "mlflow_traces_max_results"
+_TRACE_PARAM_FILTER = "mlflow_traces_filter"
+_TRACE_PARAM_RUN_ID = "mlflow_traces_run_id"
+
+
+class TracesNamespace:
+    """Trace operations on an ``MlflowClient``.
+
+    Access via ``client.traces``::
+
+        traces, token = client.traces.search(experiment_ids=["1"])
+        trace = client.traces.get("tr-abc", experiment_id="1")
+        out = client.traces.materialize(params, "/tmp/out")
+    """
+
+    def __init__(self, client: MlflowClient) -> None:
+        self._client = client
+
+    def search(
+        self,
+        experiment_ids: list[str],
+        max_results: int = 100,
+        filter_string: str | None = None,
+        order_by: list[str] | None = None,
+        page_token: str | None = None,
+    ) -> tuple[list[Trace], str | None]:
+        """Search traces via ``GET /api/2.0/mlflow/traces``.
+
+        Returns (traces, next_page_token).  Token is ``None`` when there
+        are no more pages.
+        """
+        params: dict[str, str] = {
+            "experiment_ids": ",".join(experiment_ids),
+            "max_results": str(max_results),
+        }
+        if filter_string:
+            params["filter"] = filter_string
+        if order_by:
+            params["order_by"] = ",".join(order_by)
+        if page_token:
+            params["page_token"] = page_token
+
+        data = self._client._get("/traces", params)
+        traces: list[Trace] = []
+        for raw in data.get("traces", []):
+            traces.append(_parse_trace(raw))
+
+        next_token = data.get("next_page_token") or None
+        return traces, next_token
+
+    def get(self, request_id: str, experiment_id: str) -> Trace:
+        """Fetch a single trace by request_id."""
+        data = self._client._get(
+            f"/traces/{request_id}",
+            {"experiment_id": experiment_id},
+        )
+        return _parse_trace(data.get("trace", data))
+
+    @staticmethod
+    def is_source_configured(parameters: dict[str, Any] | None) -> bool:
+        """True when job parameters reference an MLflow experiment for trace input."""
+        if not parameters:
+            return False
+        exp_id = parameters.get(_TRACE_PARAM_EXPERIMENT_ID)
+        if exp_id is not None and str(exp_id).strip():
+            return True
+        name = parameters.get(_TRACE_PARAM_EXPERIMENT_NAME)
+        return isinstance(name, str) and bool(name.strip())
+
+    def materialize(
+        self,
+        parameters: dict[str, Any],
+        output_dir: str | Path,
+    ) -> Path:
+        """Fetch traces from MLflow and write one JSON file per trace.
+
+        Returns the output directory (populated with ``tr-<id>.json`` files).
+        """
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+
+        # Resolve experiment ID
+        exp_id_raw = parameters.get(_TRACE_PARAM_EXPERIMENT_ID)
+        exp_name = parameters.get(_TRACE_PARAM_EXPERIMENT_NAME)
+        if exp_id_raw is not None and str(exp_id_raw).strip():
+            experiment_id = str(exp_id_raw).strip()
+        elif isinstance(exp_name, str) and exp_name.strip():
+            exp = self._client.get_experiment_by_name(exp_name.strip())
+            if exp is None:
+                raise ValueError(f"MLflow experiment not found: {exp_name.strip()!r}")
+            experiment_id = exp.experiment_id
+        else:
+            raise ValueError(
+                f"Set parameters.{_TRACE_PARAM_EXPERIMENT_ID} or "
+                f"parameters.{_TRACE_PARAM_EXPERIMENT_NAME}"
+            )
+
+        max_results = int(parameters.get(_TRACE_PARAM_MAX_RESULTS, 500))
+        filter_string = parameters.get(_TRACE_PARAM_FILTER)
+        if not isinstance(filter_string, str) or not filter_string.strip():
+            filter_string = None
+
+        run_id = parameters.get(_TRACE_PARAM_RUN_ID)
+        if isinstance(run_id, str) and run_id.strip():
+            run_filter = f"tags.mlflow.runId = '{run_id.strip()}'"
+            filter_string = (
+                f"({filter_string}) AND ({run_filter})" if filter_string else run_filter
+            )
+
+        collected = 0
+        page_token: str | None = None
+        while collected < max_results:
+            page_size = min(100, max_results - collected)
+            traces, page_token = self.search(
+                experiment_ids=[experiment_id],
+                max_results=page_size,
+                filter_string=filter_string,
+                page_token=page_token,
+            )
+            if not traces:
+                break
+            for trace in traces:
+                tid = trace.info.request_id
+                prefix = "" if tid.startswith("tr-") else "tr-"
+                file_path = out / f"{prefix}{tid}.json"
+                trace_dict = {
+                    "info": {
+                        "request_id": trace.info.request_id,
+                        "experiment_id": trace.info.experiment_id,
+                        "timestamp_ms": trace.info.timestamp_ms,
+                        "execution_time_ms": trace.info.execution_time_ms,
+                        "status": trace.info.status,
+                        "tags": trace.info.tags,
+                        "request_metadata": trace.info.request_metadata,
+                    },
+                    "data": trace.data,
+                }
+                file_path.write_text(
+                    json.dumps(trace_dict, indent=2, default=str),
+                    encoding="utf-8",
+                )
+                collected += 1
+                if collected >= max_results:
+                    break
+            if not page_token:
+                break
+
+        if collected == 0:
+            raise ValueError(
+                f"No traces returned from MLflow (experiment_id={experiment_id!r}, "
+                f"filter={filter_string!r}). Confirm traces exist."
+            )
+
+        logger.info(
+            "Materialized %d trace(s) from MLflow experiment %s -> %s",
+            collected,
+            experiment_id,
+            out,
+        )
+        return out

--- a/src/evalhub/adapter/mlflow.py
+++ b/src/evalhub/adapter/mlflow.py
@@ -775,7 +775,8 @@ class TracesNamespace:
 
         run_id = parameters.get(_TRACE_PARAM_RUN_ID)
         if isinstance(run_id, str) and run_id.strip():
-            run_filter = f"tags.mlflow.runId = '{run_id.strip()}'"
+            safe_run_id = run_id.strip().replace("'", "''")
+            run_filter = f"tags.mlflow.runId = '{safe_run_id}'"
             filter_string = (
                 f"({filter_string}) AND ({run_filter})" if filter_string else run_filter
             )

--- a/src/evalhub/adapter/mlflow.py
+++ b/src/evalhub/adapter/mlflow.py
@@ -15,6 +15,7 @@ import mimetypes
 import os
 import re
 import time
+import uuid
 from collections.abc import Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -794,7 +795,9 @@ class TracesNamespace:
             if not traces:
                 break
             for trace in traces:
-                tid = trace.info.request_id
+                tid = re.sub(r"[^a-zA-Z0-9_\-]", "_", trace.info.request_id)
+                if not tid:
+                    tid = uuid.uuid4().hex
                 prefix = "" if tid.startswith("tr-") else "tr-"
                 file_path = out / f"{prefix}{tid}.json"
                 trace_dict = {

--- a/src/evalhub/adapter/models/adapter.py
+++ b/src/evalhub/adapter/models/adapter.py
@@ -12,6 +12,7 @@ from evalhub.adapter.config import EvalHubMode
 from .job import JobCallbacks, JobResults, JobSpec
 
 if TYPE_CHECKING:
+    from ..mlflow import MlflowClient
     from ..settings import AdapterSettings
 
 logger = logging.getLogger(__name__)
@@ -118,6 +119,7 @@ class FrameworkAdapter(ABC):
             )
 
         self._job_spec = self._load_job_spec()
+        self._mlflow: MlflowClient | None = None
 
     def _load_job_spec(self) -> JobSpec:
         """Load JobSpec from configured path.
@@ -150,6 +152,25 @@ class FrameworkAdapter(ABC):
             JobSpec: The job specification for this adapter instance
         """
         return self._job_spec
+
+    @property
+    def mlflow(self) -> MlflowClient | None:
+        """Pre-configured MLflow client, or ``None`` when MLflow is unavailable.
+
+        Lazily created on first access from ``MLFLOW_TRACKING_URI``.
+        In Kubernetes the URI points to the sidecar (``http://localhost:8080``),
+        so all traffic is authenticated and proxied automatically.
+        """
+        if self._mlflow is None:
+            import os
+
+            tracking_uri = os.environ.get("MLFLOW_TRACKING_URI")
+            if not tracking_uri:
+                return None
+            from ..mlflow import MlflowClient as _MlflowClient
+
+            self._mlflow = _MlflowClient(tracking_uri=tracking_uri)
+        return self._mlflow
 
     @property
     def local_jobs_base_path(self) -> Path | None:

--- a/tests/unit/test_mlflow_traces.py
+++ b/tests/unit/test_mlflow_traces.py
@@ -1,0 +1,230 @@
+"""MLflow trace search, parsing, and materialization via TracesNamespace."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from evalhub.adapter.mlflow import (
+    MlflowClient,
+    TracesNamespace,
+    _parse_trace,
+)
+
+# -- TracesNamespace.is_source_configured -----------------------------------
+
+
+def test_configured_with_experiment_id() -> None:
+    assert TracesNamespace.is_source_configured({"mlflow_traces_experiment_id": "42"})
+
+
+def test_configured_with_experiment_name() -> None:
+    assert TracesNamespace.is_source_configured(
+        {"mlflow_traces_experiment_name": "my-exp"}
+    )
+
+
+def test_not_configured_empty() -> None:
+    assert not TracesNamespace.is_source_configured({})
+
+
+def test_not_configured_none() -> None:
+    assert not TracesNamespace.is_source_configured(None)
+
+
+def test_not_configured_blank_values() -> None:
+    assert not TracesNamespace.is_source_configured(
+        {"mlflow_traces_experiment_id": "", "mlflow_traces_experiment_name": "  "}
+    )
+
+
+# -- _parse_trace -----------------------------------------------------------
+
+
+def test_parse_trace_basic() -> None:
+    raw = {
+        "info": {
+            "request_id": "tr-abc123",
+            "experiment_id": "1",
+            "timestamp_ms": 1700000000000,
+            "execution_time_ms": 500,
+            "status": "OK",
+            "tags": [
+                {"key": "framework", "value": "langgraph"},
+            ],
+            "request_metadata": [
+                {"key": "source", "value": "test"},
+            ],
+        },
+        "data": {"spans": [{"name": "root"}]},
+    }
+    trace = _parse_trace(raw)
+    assert trace.info.request_id == "tr-abc123"
+    assert trace.info.experiment_id == "1"
+    assert trace.info.status == "OK"
+    assert trace.info.tags == {"framework": "langgraph"}
+    assert trace.info.request_metadata == {"source": "test"}
+    assert trace.data == {"spans": [{"name": "root"}]}
+
+
+def test_parse_trace_missing_fields() -> None:
+    trace = _parse_trace({})
+    assert trace.info.request_id == ""
+    assert trace.info.tags == {}
+    assert trace.data == {}
+
+
+# -- TracesNamespace.search (mocked HTTP) -----------------------------------
+
+
+def test_search_traces_parses_response() -> None:
+    mock_response = {
+        "traces": [
+            {
+                "info": {
+                    "request_id": "tr-001",
+                    "experiment_id": "5",
+                    "timestamp_ms": 1700000000000,
+                    "execution_time_ms": 200,
+                    "status": "OK",
+                    "tags": [],
+                    "request_metadata": [],
+                },
+                "data": {},
+            },
+            {
+                "info": {
+                    "request_id": "tr-002",
+                    "experiment_id": "5",
+                    "timestamp_ms": 1700000001000,
+                    "execution_time_ms": 150,
+                    "status": "ERROR",
+                    "tags": [{"key": "k", "value": "v"}],
+                    "request_metadata": [],
+                },
+                "data": {"spans": []},
+            },
+        ],
+        "next_page_token": "tok123",
+    }
+    mock_client = MagicMock(spec=MlflowClient)
+    mock_client._get = MagicMock(return_value=mock_response)
+    ns = TracesNamespace(mock_client)
+
+    traces, token = ns.search(experiment_ids=["5"], max_results=10)
+    assert len(traces) == 2
+    assert traces[0].info.request_id == "tr-001"
+    assert traces[1].info.status == "ERROR"
+    assert traces[1].info.tags == {"k": "v"}
+    assert token == "tok123"
+
+
+def test_search_traces_no_results() -> None:
+    mock_client = MagicMock(spec=MlflowClient)
+    mock_client._get = MagicMock(return_value={"traces": []})
+    ns = TracesNamespace(mock_client)
+
+    traces, token = ns.search(experiment_ids=["1"])
+    assert traces == []
+    assert token is None
+
+
+# -- TracesNamespace.materialize --------------------------------------------
+
+
+def test_materialize_writes_files(tmp_path: Path) -> None:
+    mock_client = MagicMock(spec=MlflowClient)
+    mock_client.get_experiment_by_name.return_value = MagicMock(experiment_id="10")
+    ns = TracesNamespace(mock_client)
+    mock_client._get = MagicMock(
+        return_value={
+            "traces": [
+                {
+                    "info": {
+                        "request_id": "abc",
+                        "experiment_id": "10",
+                        "timestamp_ms": 1700000000000,
+                        "execution_time_ms": 300,
+                        "status": "OK",
+                        "tags": [],
+                        "request_metadata": [],
+                    },
+                    "data": {"spans": [{"name": "root"}]},
+                },
+                {
+                    "info": {
+                        "request_id": "tr-def",
+                        "experiment_id": "10",
+                        "timestamp_ms": 0,
+                        "execution_time_ms": 0,
+                        "status": "ERROR",
+                        "tags": [],
+                        "request_metadata": [],
+                    },
+                    "data": {},
+                },
+            ],
+            "next_page_token": None,
+        }
+    )
+
+    out = ns.materialize(
+        parameters={
+            "mlflow_traces_experiment_name": "test-exp",
+            "mlflow_traces_max_results": 10,
+        },
+        output_dir=tmp_path / "traces",
+    )
+
+    files = sorted(out.iterdir())
+    assert len(files) == 2
+    names = [f.name for f in files]
+    assert "tr-abc.json" in names
+    assert "tr-def.json" in names
+
+    content = json.loads((out / "tr-abc.json").read_text())
+    assert content["info"]["request_id"] == "abc"
+    assert content["data"]["spans"] == [{"name": "root"}]
+
+
+def test_materialize_resolves_experiment_name(tmp_path: Path) -> None:
+    mock_client = MagicMock(spec=MlflowClient)
+    mock_client.get_experiment_by_name.return_value = MagicMock(experiment_id="42")
+    ns = TracesNamespace(mock_client)
+    mock_client._get = MagicMock(
+        return_value={
+            "traces": [
+                {
+                    "info": {
+                        "request_id": "x",
+                        "experiment_id": "42",
+                        "timestamp_ms": 0,
+                        "execution_time_ms": 0,
+                        "status": "OK",
+                        "tags": [],
+                        "request_metadata": [],
+                    },
+                    "data": {},
+                },
+            ],
+            "next_page_token": None,
+        }
+    )
+
+    ns.materialize(
+        parameters={"mlflow_traces_experiment_name": "my-exp"},
+        output_dir=tmp_path,
+    )
+    mock_client.get_experiment_by_name.assert_called_once_with("my-exp")
+
+
+def test_materialize_no_results_raises(tmp_path: Path) -> None:
+    mock_client = MagicMock(spec=MlflowClient)
+    mock_client._get = MagicMock(return_value={"traces": [], "next_page_token": None})
+    ns = TracesNamespace(mock_client)
+
+    with pytest.raises(ValueError, match="No traces returned"):
+        ns.materialize(
+            parameters={"mlflow_traces_experiment_id": "99"},
+            output_dir=tmp_path,
+        )


### PR DESCRIPTION
## What and why

Adds first-class MLflow trace support to the adapter SDK, enabling adapters to fetch, search, and materialise traces from an MLflow tracking server.
This makes traces a usable data source for evaluation adapters (e.g. IBM CLEAR adapter) without requiring direct HTTP calls.

## Type

- [x] feat

## Changes

- Add `TracesNamespace` to `evalhub.adapter.mlflow` with `search()`, `get()`, `materialize()`, and `is_source_configured()` methods
- Add `Trace`, `TraceInfo`, and `SpanInfo` dataclasses for typed trace data
- Add `FrameworkAdapter.mlflow` property for lazy-initialised, pre-configured `MlflowClient` access from adapters
- Expose traces via `client.traces` namespace on `MlflowClient`

## Examples

### Using traces inside an adapter

The most common pattern: access traces via `self.mlflow` in a `FrameworkAdapter` subclass. The client is pre-configured from `MLFLOW_TRACKING_URI` (set to the sidecar in Kubernetes).

```python
from evalhub.adapter import FrameworkAdapter, JobSpec, JobCallbacks, JobResults
from evalhub.adapter.mlflow import TracesNamespace


class MyTracesAdapter(FrameworkAdapter):
    def run_benchmark_job(self, config: JobSpec, callbacks: JobCallbacks) -> JobResults:
        client = self.mlflow  # lazy-init from MLFLOW_TRACKING_URI
        if client is None:
            raise ValueError("MLflow is not configured")

        # Check if the job parameters specify a trace source
        if not TracesNamespace.is_source_configured(config.parameters):
            raise ValueError("No trace source configured in parameters")

        # Materialise traces to a temp directory
        traces_dir = client.traces.materialize(config.parameters, "/tmp/traces")

        # traces_dir now contains tr-<request_id>.json files
        for f in traces_dir.glob("*.json"):
            print(f"Trace file: {f.name}")

        # ... analyse and return JobResults
```

### Searching traces with pagination

```python
from evalhub.adapter.mlflow import MlflowClient

client = MlflowClient(tracking_uri="http://localhost:5000")

# First page
traces, next_token = client.traces.search(
    experiment_ids=["1"],
    max_results=50,
    filter_string="status = 'OK'",
)
print(f"Got {len(traces)} traces")

# Iterate pages
while next_token:
    traces, next_token = client.traces.search(
        experiment_ids=["1"],
        max_results=50,
        page_token=next_token,
    )
    print(f"Got {len(traces)} more traces")
```

### Fetching a single trace

```python
trace = client.traces.get(request_id="tr-abc123", experiment_id="1")

print(f"Status: {trace.info.status}")
print(f"Duration: {trace.info.execution_time_ms}ms")
print(f"Tags: {trace.info.tags}")
print(f"Spans: {len(trace.data.get('spans', []))}")
```

### Materialising traces to disk

`materialize()` is the high-level method that handles experiment resolution, pagination, filtering, and file writing in one call.

```python
params = {
    "mlflow_traces_experiment_name": "my-agent-experiment",
    "mlflow_traces_max_results": 100,
    "mlflow_traces_filter": "status = 'OK'",
    "mlflow_traces_run_id": "abc123",  # optional: filter to a specific run
}

output_dir = client.traces.materialize(params, "/tmp/traces")
# Writes tr-<request_id>.json files, each containing:
# {
#   "info": {
#     "request_id": "tr-...",
#     "experiment_id": "1",
#     "execution_time_ms": 500,
#     "status": "OK",
#     "tags": {"framework": "langgraph"},
#     ...
#   },
#   "data": {"spans": [...]}
# }
```

### Checking if parameters specify a trace source

A static method useful for validation before attempting materialisation.

```python
from evalhub.adapter.mlflow import TracesNamespace

# Returns True if experiment_id or experiment_name is set
TracesNamespace.is_source_configured({"mlflow_traces_experiment_id": "1"})     # True
TracesNamespace.is_source_configured({"mlflow_traces_experiment_name": "foo"}) # True
TracesNamespace.is_source_configured({})                                        # False
TracesNamespace.is_source_configured(None)                                      # False
```

## Testing

- [x] Tests added or updated
- [ ] Tested manually

## Breaking changes

None — additive only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive MLflow trace support: search, retrieval, paginated results, and per-trace JSON export.
  * Trace operations can resolve experiments by ID or name and support optional tag-based filtering.
* **Integration**
  * Adapter now auto-configures a lazy MLflow client from environment settings.
* **Tests**
  * New unit tests covering trace parsing, search/pagination, experiment resolution, and materialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub-sdk/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->