### PR TITLE
feat: add create and delete operations for providers in cli and client

### DIFF
--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -1062,8 +1062,9 @@ def providers_create(ctx: click.Context, spec_file: str, output_format: str) -> 
     request = ProviderCreateRequest(**data)
     client = get_client(ctx)
     provider = client.providers.create(request.model_dump(mode="json"))
-    click.echo(f"Provider created: {provider.resource.id}")
-    if output_format in ("json", "yaml"):
+    structured = output_format in ("json", "yaml")
+    click.echo(f"Provider created: {provider.resource.id}", err=structured)
+    if structured:
         output([provider.model_dump(mode="json")], output_format=output_format)
 
 

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -25,6 +25,7 @@ from evalhub.models import (
     ModelConfig,
     OCIConnectionConfig,
     OCICoordinates,
+    ProviderCreateRequest,
     QueueConfig,
     S3TestDataRef,
     TestDataRef,
@@ -937,7 +938,7 @@ def collections_run(
 
 @main.group()
 def providers() -> None:
-    """List and inspect evaluation providers.
+    """Manage evaluation providers.
 
     \b
     Providers are evaluation frameworks (e.g. lm-evaluation-harness,
@@ -948,6 +949,7 @@ def providers() -> None:
     Examples:
       evalhub providers list
       evalhub providers describe lm_evaluation_harness
+      evalhub providers create --file my-provider.yaml
     """
 
 
@@ -1034,6 +1036,34 @@ def providers_describe(
         )
     else:
         click.echo("  (none)")
+
+
+@providers.command("create")
+@click.option(
+    "--file",
+    "spec_file",
+    type=click.Path(exists=True),
+    required=True,
+    help="YAML or JSON file describing the provider.",
+)
+@format_option()
+@click.pass_context
+@handle_api_errors
+def providers_create(ctx: click.Context, spec_file: str, output_format: str) -> None:
+    """Create a new evaluation provider from a spec file.
+
+    \b
+    Examples:
+      evalhub providers create --file my-provider.yaml
+      evalhub providers create --file provider.json --format json
+    """
+    data = _load_config_file(spec_file)
+    request = ProviderCreateRequest(**data)
+    client = get_client(ctx)
+    provider = client.providers.create(request.model_dump(mode="json"))
+    click.echo(f"Provider created: {provider.resource.id}")
+    if output_format in ("json", "yaml"):
+        output([provider.model_dump(mode="json")], output_format=output_format)
 
 
 @main.command("health")

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -950,6 +950,7 @@ def providers() -> None:
       evalhub providers list
       evalhub providers describe lm_evaluation_harness
       evalhub providers create --file my-provider.yaml
+      evalhub providers delete my-provider
     """
 
 
@@ -1064,6 +1065,23 @@ def providers_create(ctx: click.Context, spec_file: str, output_format: str) -> 
     click.echo(f"Provider created: {provider.resource.id}")
     if output_format in ("json", "yaml"):
         output([provider.model_dump(mode="json")], output_format=output_format)
+
+
+@providers.command("delete")
+@click.argument("provider_id")
+@click.confirmation_option(prompt="Are you sure you want to delete this provider?")
+@click.pass_context
+@handle_api_errors
+def providers_delete(ctx: click.Context, provider_id: str) -> None:
+    """Delete an evaluation provider.
+
+    \b
+    Examples:
+      evalhub providers delete my-provider
+    """
+    client = get_client(ctx)
+    client.providers.delete(provider_id)
+    click.echo(f"Provider {provider_id} deleted.")
 
 
 @main.command("health")

--- a/src/evalhub/client/resources/providers.py
+++ b/src/evalhub/client/resources/providers.py
@@ -53,6 +53,24 @@ class AsyncProvidersResource:
         )
         return Provider(**response.json())
 
+    async def create(self, data: dict, *, tenant: str | None = None) -> Provider:
+        """Create a new evaluation provider.
+
+        Args:
+            data: Provider specification as a dict (name, title, description, runtime, benchmarks, ...)
+            tenant: Tenant override for this request (default: client-level tenant)
+
+        Returns:
+            Provider: The newly created provider
+
+        Raises:
+            httpx.HTTPError: If the request fails
+        """
+        response = await self._client._request_post(
+            "/evaluations/providers", json=data, tenant=tenant
+        )
+        return Provider(**response.json())
+
 
 class SyncProvidersResource:
     """Synchronous resource for provider operations."""
@@ -92,5 +110,23 @@ class SyncProvidersResource:
         """
         response = self._client._request_get(
             f"/evaluations/providers/{provider_id}", tenant=tenant
+        )
+        return Provider(**response.json())
+
+    def create(self, data: dict, *, tenant: str | None = None) -> Provider:
+        """Create a new evaluation provider.
+
+        Args:
+            data: Provider specification as a dict (name, title, description, runtime, benchmarks, ...)
+            tenant: Tenant override for this request (default: client-level tenant)
+
+        Returns:
+            Provider: The newly created provider
+
+        Raises:
+            httpx.HTTPError: If the request fails
+        """
+        response = self._client._request_post(
+            "/evaluations/providers", json=data, tenant=tenant
         )
         return Provider(**response.json())

--- a/src/evalhub/client/resources/providers.py
+++ b/src/evalhub/client/resources/providers.py
@@ -71,6 +71,20 @@ class AsyncProvidersResource:
         )
         return Provider(**response.json())
 
+    async def delete(self, provider_id: str, *, tenant: str | None = None) -> None:
+        """Delete an evaluation provider.
+
+        Args:
+            provider_id: The provider identifier
+            tenant: Tenant override for this request (default: client-level tenant)
+
+        Raises:
+            httpx.HTTPError: If the provider is not found or request fails
+        """
+        await self._client._request_delete(
+            f"/evaluations/providers/{provider_id}", tenant=tenant
+        )
+
 
 class SyncProvidersResource:
     """Synchronous resource for provider operations."""
@@ -130,3 +144,17 @@ class SyncProvidersResource:
             "/evaluations/providers", json=data, tenant=tenant
         )
         return Provider(**response.json())
+
+    def delete(self, provider_id: str, *, tenant: str | None = None) -> None:
+        """Delete an evaluation provider.
+
+        Args:
+            provider_id: The provider identifier
+            tenant: Tenant override for this request (default: client-level tenant)
+
+        Raises:
+            httpx.HTTPError: If the provider is not found or request fails
+        """
+        self._client._request_delete(
+            f"/evaluations/providers/{provider_id}", tenant=tenant
+        )

--- a/src/evalhub/models/__init__.py
+++ b/src/evalhub/models/__init__.py
@@ -38,6 +38,7 @@ from .api import (
     PassCriteria,
     PrimaryScore,
     Provider,
+    ProviderCreateRequest,
     ProviderList,
     QueueConfig,
     Resource,
@@ -67,6 +68,7 @@ __all__ = [
     "ExperimentConfig",
     # Provider & Benchmark models
     "Provider",
+    "ProviderCreateRequest",
     "ProviderList",
     "Benchmark",
     "BenchmarkConfig",

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -601,9 +601,6 @@ class Resource(BaseModel):
     updated_at: datetime | None = Field(
         default=None, description="Last update timestamp"
     )
-    read_only: bool | None = Field(
-        default=None, description="Whether the resource is read-only"
-    )
     owner: str | None = Field(default=None, description="Resource owner")
 
 

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -626,12 +626,13 @@ class Benchmark(BaseModel):
     """Benchmark information from EvalHub API."""
 
     id: str = Field(..., description="Unique benchmark identifier")
+    url: str | None = Field(default=None, description="Benchmark URL")
     name: str = Field(..., description="Human-readable benchmark name")
-    description: str = Field(..., description="Benchmark description")
+    description: str | None = Field(default=None, description="Benchmark description")
     category: str = Field(..., description="Benchmark category")
     metrics: list[str] = Field(default_factory=list, description="List of metrics")
-    num_few_shot: int | None = Field(None, description="Number of few-shot examples")
-    dataset_size: int | None = Field(None, description="Size of the evaluation dataset")
+    num_few_shot: int = Field(default=0, description="Number of few-shot examples")
+    dataset_size: int = Field(default=0, description="Size of the evaluation dataset")
     tags: list[str] = Field(default_factory=list, description="Tags for categorization")
     primary_score: PrimaryScore | None = Field(
         None, description="Primary score configuration"
@@ -653,8 +654,13 @@ class Provider(BaseModel):
     """
 
     resource: Resource = Field(..., description="Resource metadata")
-    name: str = Field(..., description="Provider display name")
-    description: str = Field(..., description="Provider description")
+    name: str = Field(..., description="Provider name")
+    title: str = Field(default="", description="Provider display title")
+    description: str | None = Field(default=None, description="Provider description")
+    tags: list[str] = Field(default_factory=list, description="Provider tags")
+    runtime: dict[str, Any] | None = Field(
+        default=None, description="Runtime configuration"
+    )
     benchmarks: list[Benchmark] = Field(
         default_factory=list, description="Benchmarks supported by this provider"
     )
@@ -671,6 +677,21 @@ class ProviderList(BaseModel):
     def handle_none_items(cls, v: list[Provider] | None) -> list[Provider]:
         """Convert None to empty list for compatibility with server responses."""
         return v if v is not None else []
+
+
+class ProviderCreateRequest(BaseModel):
+    """Request body for creating a new evaluation provider."""
+
+    name: str = Field(..., description="Provider name")
+    title: str = Field(default="", description="Provider display title")
+    description: str | None = Field(default=None, description="Provider description")
+    tags: list[str] = Field(default_factory=list, description="Provider tags")
+    runtime: dict[str, Any] | None = Field(
+        default=None, description="Runtime configuration"
+    )
+    benchmarks: list[Benchmark] = Field(
+        default_factory=list, description="Benchmarks provided by this provider"
+    )
 
 
 class BenchmarkReference(BaseModel):

--- a/tests/unit/test_cli_providers.py
+++ b/tests/unit/test_cli_providers.py
@@ -35,8 +35,8 @@ def _make_benchmark(
     description: str = "Massive Multitask Language Understanding",
     category: str = "knowledge",
     metrics: list[str] | None = None,
-    num_few_shot: int | None = None,
-    dataset_size: int | None = None,
+    num_few_shot: int = 0,
+    dataset_size: int = 0,
     primary_score: PrimaryScore | None = None,
     pass_criteria: PassCriteria | None = None,
 ) -> Benchmark:
@@ -257,12 +257,143 @@ class TestHealth:
         assert "unreachable" in result.output
 
 
+class TestProvidersCreate:
+    def test_create_from_yaml(
+        self,
+        runner: CliRunner,
+        config_file: Path,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        spec = {
+            "name": "my-provider",
+            "title": "MyProvider",
+            "description": "A custom provider",
+            "tags": ["custom", "byof"],
+            "runtime": {"local": {"command": "python main.py"}},
+            "benchmarks": [
+                {
+                    "id": "my-benchmark",
+                    "name": "My Benchmark",
+                    "description": "A custom benchmark",
+                    "category": "general",
+                    "metrics": ["accuracy"],
+                }
+            ],
+        }
+        spec_file = tmp_path / "provider.yaml"
+        spec_file.write_text(yaml.dump(spec))
+
+        created = _make_provider(id="my-provider", name="MyProvider")
+        mock_client.providers.create.return_value = created
+
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main, ["providers", "create", "--file", str(spec_file)]
+            )
+        assert result.exit_code == 0
+        assert "my-provider" in result.output
+        mock_client.providers.create.assert_called_once()
+        call_data = mock_client.providers.create.call_args[0][0]
+        assert call_data["name"] == "my-provider"
+        assert call_data["title"] == "MyProvider"
+        assert call_data["tags"] == ["custom", "byof"]
+        assert call_data["runtime"] == {"local": {"command": "python main.py"}}
+
+    def test_create_from_json(
+        self,
+        runner: CliRunner,
+        config_file: Path,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        spec = {
+            "name": "json-provider",
+            "title": "JSON Provider",
+            "benchmarks": [
+                {
+                    "id": "bench-1",
+                    "name": "Bench 1",
+                    "description": "A benchmark",
+                    "category": "general",
+                }
+            ],
+        }
+        spec_file = tmp_path / "provider.json"
+        spec_file.write_text(json.dumps(spec))
+
+        created = _make_provider(id="json-provider", name="JSON Provider")
+        mock_client.providers.create.return_value = created
+
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main, ["providers", "create", "--file", str(spec_file)]
+            )
+        assert result.exit_code == 0
+        assert "json-provider" in result.output
+
+    def test_create_json_output(
+        self,
+        runner: CliRunner,
+        config_file: Path,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        spec = {"name": "my-provider", "title": "MyProvider", "benchmarks": []}
+        spec_file = tmp_path / "provider.yaml"
+        spec_file.write_text(yaml.dump(spec))
+
+        created = _make_provider(id="my-provider", name="MyProvider")
+        mock_client.providers.create.return_value = created
+
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main,
+                ["providers", "create", "--file", str(spec_file), "--format", "json"],
+            )
+        assert result.exit_code == 0
+        assert "my-provider" in result.output
+        json_start = result.output.index("[")
+        parsed = json.loads(result.output[json_start:])
+        assert parsed[0]["name"] == "MyProvider"
+
+    def test_create_missing_file(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main,
+                ["providers", "create", "--file", "/nonexistent/path.yaml"],
+            )
+        assert result.exit_code != 0
+        mock_client.providers.create.assert_not_called()
+
+    def test_create_invalid_spec(
+        self,
+        runner: CliRunner,
+        config_file: Path,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        spec: dict = {"description": "Missing required fields", "benchmarks": []}
+        spec_file = tmp_path / "bad.yaml"
+        spec_file.write_text(yaml.dump(spec))
+
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main, ["providers", "create", "--file", str(spec_file)]
+            )
+        assert result.exit_code != 0
+        mock_client.providers.create.assert_not_called()
+
+
 class TestProvidersHelp:
     def test_providers_help(self, runner: CliRunner) -> None:
         result = runner.invoke(main, ["providers", "--help"])
         assert result.exit_code == 0
         assert "list" in result.output
         assert "describe" in result.output
+        assert "create" in result.output
 
     def test_providers_list_help(self, runner: CliRunner) -> None:
         result = runner.invoke(main, ["providers", "list", "--help"])

--- a/tests/unit/test_cli_providers.py
+++ b/tests/unit/test_cli_providers.py
@@ -387,6 +387,38 @@ class TestProvidersCreate:
         mock_client.providers.create.assert_not_called()
 
 
+class TestProvidersDelete:
+    def test_delete_confirmed(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.providers.delete.return_value = None
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main, ["providers", "delete", "my-provider"], input="y\n"
+            )
+        assert result.exit_code == 0
+        assert "deleted" in result.output
+        mock_client.providers.delete.assert_called_once_with("my-provider")
+
+    def test_delete_aborted(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            runner.invoke(main, ["providers", "delete", "my-provider"], input="n\n")
+        mock_client.providers.delete.assert_not_called()
+
+    def test_delete_yes_flag(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.providers.delete.return_value = None
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main, ["providers", "delete", "my-provider", "--yes"]
+            )
+        assert result.exit_code == 0
+        mock_client.providers.delete.assert_called_once_with("my-provider")
+
+
 class TestProvidersHelp:
     def test_providers_help(self, runner: CliRunner) -> None:
         result = runner.invoke(main, ["providers", "--help"])
@@ -394,6 +426,7 @@ class TestProvidersHelp:
         assert "list" in result.output
         assert "describe" in result.output
         assert "create" in result.output
+        assert "delete" in result.output
 
     def test_providers_list_help(self, runner: CliRunner) -> None:
         result = runner.invoke(main, ["providers", "list", "--help"])

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -70,8 +70,6 @@ def _make_provider(provider_id: str = "lm_eval") -> Provider:
                 description="Grade school math",
                 category="math",
                 metrics=["accuracy"],
-                num_few_shot=None,
-                dataset_size=None,
                 primary_score=None,
                 pass_criteria=None,
             )
@@ -86,8 +84,6 @@ def _make_benchmark(benchmark_id: str = "gsm8k") -> Benchmark:
         description="Grade school math",
         category="math",
         metrics=["accuracy"],
-        num_few_shot=None,
-        dataset_size=None,
         primary_score=None,
         pass_criteria=None,
     )


### PR DESCRIPTION
## What and why

Changes:
- providers create CLI command — reads a YAML/JSON spec file via --file, validates it with ProviderCreateRequest, and calls the API. Supports --format json/yaml output.                                                                                                                                       - providers delete CLI command — takes a provider_id argument, prompts for confirmation (skippable with --yes), and calls DELETE on the API.
- Client create() and delete() methods — added to both AsyncProvidersResource and SyncProvidersResource, hitting POST /evaluations/providers and DELETE   /evaluations/providers/{id}.
- ProviderCreateRequest model — new Pydantic model for validating provider spec input (name, title, description, tags, runtime, benchmarks).
- Model alignment with Go server structs:
  - Provider: added title, tags, runtime fields; made description optional (str | None)                                              
  - Benchmark: added url field; made description optional; changed num_few_shot/dataset_size from int | None to int with default 0
  - Resource: removed unused read_only field 
- Tests new unit tests covering create (YAML/JSON input, JSON output, missing file, invalid spec) and delete (confirmed, aborted, --yes flag), plus help output assertions.

Closes # https://redhat.atlassian.net/browse/RHOAIENG-63263

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

<img width="822" height="681" alt="Screenshot 2026-05-20 at 11 38 04 AM" src="https://github.com/user-attachments/assets/7148261f-52f9-48f1-ab9b-524008b9c8dd" />
<img width="861" height="285" alt="Screenshot 2026-05-20 at 11 41 40 AM" src="https://github.com/user-attachments/assets/63fd4be8-5ed5-4857-85e0-fa562075803e" />
<img width="1038" height="706" alt="Screenshot 2026-05-20 at 11 42 34 AM" src="https://github.com/user-attachments/assets/3de2a490-e887-4a0b-a347-501f04443ffc" />


## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to create evaluation providers from spec files (`providers create --file ...`) and delete providers (`providers delete ...`).
  * Added SDK methods to programmatically create and delete evaluation providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub-sdk/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->