### PR TITLE
feat: generated mlflow run name

### DIFF
--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -62,6 +62,10 @@ class _MlflowOps:
     def __init__(self, backend: MlflowBackend = MlflowBackend.ODH) -> None:
         self._backend = backend
 
+    @staticmethod
+    def _build_run_name(job_spec: JobSpec) -> str:
+        return f"{job_spec.id}_{job_spec.benchmark_index}"
+
     def save(
         self,
         results: JobResults,
@@ -87,11 +91,13 @@ class _MlflowOps:
     @staticmethod
     def _build_params_metrics(
         results: JobResults,
+        job_spec: JobSpec,
     ) -> tuple[list, list]:
         from .mlflow import Metric, Param, sanitize_metric_key_for_api
 
         params = [
             Param("benchmark_id", results.benchmark_id),
+            Param("provider_id", job_spec.provider_id),
             Param("model_name", results.model_name),
             Param("num_examples_evaluated", str(results.num_examples_evaluated)),
             Param("duration_seconds", str(results.duration_seconds)),
@@ -162,7 +168,7 @@ class _MlflowOps:
     ) -> str:
         from .mlflow import MlflowClient
 
-        params, metrics = self._build_params_metrics(results)
+        params, metrics = self._build_params_metrics(results, job_spec)
         run_tags: dict[str, str] = {
             tag["key"]: tag["value"] for tag in (job_spec.tags or [])
         }
@@ -173,7 +179,9 @@ class _MlflowOps:
                 job_spec.experiment_name or ""
             )
             with client.start_run(
-                experiment_id, run_name=job_spec.id, tags=run_tags
+                experiment_id,
+                run_name=self._build_run_name(job_spec),
+                tags=run_tags,
             ) as rid:
                 run_id = rid
                 client.log_batch(run_id, metrics=metrics, params=params)
@@ -212,14 +220,16 @@ class _MlflowOps:
                 "Install it with: pip install mlflow-skinny"
             ) from exc
 
-        params, metrics = self._build_params_metrics(results)
+        params, metrics = self._build_params_metrics(results, job_spec)
         run_tags: dict[str, str] = {
             tag["key"]: tag["value"] for tag in (job_spec.tags or [])
         }
 
         mlflow.set_experiment(job_spec.experiment_name)
         run_id = ""
-        with mlflow.start_run(run_name=job_spec.id, tags=run_tags) as active_run:
+        with mlflow.start_run(
+            run_name=self._build_run_name(job_spec), tags=run_tags
+        ) as active_run:
             run_id = str(active_run.info.run_id)
             mlflow.log_params({p.key: p.value for p in params})
             mlflow.log_metrics({m.key: m.value for m in metrics})

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -139,3 +139,67 @@ def test_mlflow_save_returns_run_id_from_upstream_path() -> None:
         rid = ops.save(results, spec)
     assert rid == "run-upstream"
     m.assert_called_once()
+
+
+def test_build_run_name_format() -> None:
+    from evalhub.adapter.callbacks import _MlflowOps
+    from evalhub.adapter.models.job import JobSpec
+    from evalhub.models.api import ModelConfig
+
+    spec = JobSpec(
+        id="job-42",
+        provider_id="p",
+        benchmark_id="mmlu",
+        benchmark_index=3,
+        model=ModelConfig(url="http://localhost/v1", name="m"),
+        parameters={},
+        callback_url="http://localhost/",
+    )
+    assert _MlflowOps._build_run_name(spec) == "job-42_3"
+
+
+def test_build_params_metrics_base_params_and_metrics() -> None:
+    from evalhub.adapter.callbacks import _MlflowOps
+    from evalhub.adapter.models.job import JobResults, JobSpec
+    from evalhub.models.api import EvaluationResult, ModelConfig
+
+    spec = JobSpec(
+        id="j1",
+        provider_id="lm_evaluation_harness",
+        benchmark_id="mmlu",
+        benchmark_index=0,
+        model=ModelConfig(url="http://localhost/v1", name="m"),
+        parameters={},
+        callback_url="http://localhost/",
+    )
+    results = JobResults(
+        id="j1",
+        benchmark_id="mmlu",
+        benchmark_index=0,
+        model_name="gpt-4",
+        results=[
+            EvaluationResult(metric_name="acc", metric_value=0.9, metric_type="float"),
+            EvaluationResult(
+                metric_name="f1", metric_value="N/A", metric_type="string"
+            ),
+        ],
+        num_examples_evaluated=100,
+        duration_seconds=42.5,
+        overall_score=0.85,
+        completed_at=datetime.now(UTC),
+    )
+    params, metrics = _MlflowOps._build_params_metrics(results, spec)
+    param_dict = {p.key: p.value for p in params}
+
+    assert param_dict == {
+        "benchmark_id": "mmlu",
+        "provider_id": "lm_evaluation_harness",
+        "model_name": "gpt-4",
+        "num_examples_evaluated": "100",
+        "duration_seconds": "42.5",
+    }
+
+    metric_dict = {m.key: m.value for m in metrics}
+    assert metric_dict["acc"] == 0.9
+    assert metric_dict["overall_score"] == 0.85
+    assert "f1" not in metric_dict


### PR DESCRIPTION


## What and why

- Generate run_name as job-id_benchmark-index for MLflow runs
- and add provider_id as an MLflow parameter

Closes # https://redhat.atlassian.net/browse/RHOAIENG-58270

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

<img width="1424" height="304" alt="Screenshot 2026-05-28 at 2 16 49 PM" src="https://github.com/user-attachments/assets/61870b84-14b5-495e-9d6e-c3e9c6a331ee" />
<img width="857" height="662" alt="Screenshot 2026-05-28 at 2 17 14 PM" src="https://github.com/user-attachments/assets/def172d2-cd06-4a80-8d76-78c450d740cb" />


## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced MLflow integration with improved run identification and expanded parameter tracking across backend implementations.

* **Tests**
  * Added unit tests to validate MLflow configuration and parameter handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eval-hub/eval-hub-sdk/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->