### PR TITLE
refactor: SDK reports MLFlow integration errors on events API

### DIFF
--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -13,15 +13,22 @@ from .config import EvalHubMode, MlflowBackend
 from .mlflow import MlflowArtifact
 from .models import (
     EnvironmentCardMetadata,
+    ErrorInfo,
     JobCallbacks,
     JobResults,
     JobSpec,
     JobStatusUpdate,
+    MessageInfo,
     OCIArtifactResult,
     OCIArtifactSpec,
 )
 from .oci import DEFAULT_OCI_PROXY_HOST, OCIArtifactPersister
 from .oci.persister import OCIArtifactContext
+
+_MLFLOW_SAVE_FAILED = ErrorInfo(
+    message="Failed to save evaluation results to MLflow.",
+    message_code="mlflow_save_failed",
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +66,13 @@ class _MlflowOps:
       ``mlflow-skinny`` to be installed.
     """
 
-    def __init__(self, backend: MlflowBackend = MlflowBackend.ODH) -> None:
+    def __init__(
+        self,
+        backend: MlflowBackend = MlflowBackend.ODH,
+        callbacks: DefaultCallbacks | None = None,
+    ) -> None:
         self._backend = backend
+        self._callbacks = callbacks
 
     def save(
         self,
@@ -77,7 +89,18 @@ class _MlflowOps:
                 return self._save_upstream(results, job_spec, artifacts)
             return self._save_odh(results, job_spec, artifacts)
         except Exception as e:
-            logger.error("Failed to save to MLflow: %s", e)
+            logger.error("Failed to save to MLflow: %s", e, exc_info=True)
+            if self._callbacks is not None:
+                self._callbacks.report_status(
+                    JobStatusUpdate(
+                        status=JobStatus.FAILED,
+                        error=_MLFLOW_SAVE_FAILED,
+                        message=MessageInfo(
+                            message="Evaluation failed",
+                            message_code="evaluation_failed",
+                        ),
+                    )
+                )
             raise RuntimeError(f"MLflow save failed: {e}") from e
 
     # ------------------------------------------------------------------
@@ -374,8 +397,8 @@ class DefaultCallbacks(JobCallbacks):
         else:
             self._ca_bundle = self._resolve_ca_bundle(ca_bundle_path)
 
-        # MLflow integration (single-method API)
-        self.mlflow = _MlflowOps(backend=mlflow_backend)
+        # MLflow integration (single-method API via callbacks.mlflow.save)
+        self.mlflow = _MlflowOps(backend=mlflow_backend, callbacks=self)
 
         # Try to import httpx for sidecar communication
         self._httpx_available = False

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -157,6 +157,7 @@ def test_mlflow_save_returns_run_id_from_upstream_path() -> None:
     assert rid == "run-upstream"
     m.assert_called_once()
 
+@pytest.mark.unit
 def test_mlflow_save_posts_failed_event_on_mlflow_error() -> None:
     mock_http = MagicMock()
     resp = MagicMock()

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -157,6 +157,7 @@ def test_mlflow_save_returns_run_id_from_upstream_path() -> None:
     assert rid == "run-upstream"
     m.assert_called_once()
 
+
 @pytest.mark.unit
 def test_mlflow_save_posts_failed_event_on_mlflow_error() -> None:
     mock_http = MagicMock()
@@ -191,6 +192,7 @@ def test_mlflow_save_posts_failed_event_on_mlflow_error() -> None:
     assert body["error_message"]["message_code"] == "mlflow_save_failed"
     assert "mlflow offline" not in body["error_message"]["message"]
     assert "warning_message" not in body
+
 
 def test_build_run_name_format() -> None:
     from evalhub.adapter.callbacks import _MlflowOps

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
 from evalhub.adapter.callbacks import DefaultCallbacks
-from evalhub.adapter.models.job import JobResults
-from evalhub.models.api import EvaluationResult
+from evalhub.adapter.models.job import (
+    JobResults,
+    JobSpec,
+)
+from evalhub.models.api import EvaluationResult, JobStatus, ModelConfig
 
 
 def _results(mlflow_run_id: str | None = None) -> JobResults:
@@ -23,6 +27,19 @@ def _results(mlflow_run_id: str | None = None) -> JobResults:
         duration_seconds=1.0,
         completed_at=datetime.now(UTC),
         mlflow_run_id=mlflow_run_id,
+    )
+
+
+def _job_spec(experiment_name: str = "exp") -> JobSpec:
+    return JobSpec(
+        id="job-1",
+        provider_id="lm_evaluation_harness",
+        benchmark_id="arc_easy",
+        benchmark_index=0,
+        model=ModelConfig(url="http://localhost/v1", name="m"),
+        parameters={},
+        callback_url="http://evalhub:8080",
+        experiment_name=experiment_name,
     )
 
 
@@ -139,3 +156,38 @@ def test_mlflow_save_returns_run_id_from_upstream_path() -> None:
         rid = ops.save(results, spec)
     assert rid == "run-upstream"
     m.assert_called_once()
+
+
+def test_mlflow_save_posts_failed_event_on_mlflow_error() -> None:
+    mock_http = MagicMock()
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    mock_http.post.return_value = resp
+
+    with patch.object(DefaultCallbacks, "_create_http_client", return_value=mock_http):
+        callbacks = DefaultCallbacks(
+            job_id="job-1",
+            benchmark_id="arc_easy",
+            benchmark_index=0,
+            sidecar_url="http://evalhub:8080",
+            insecure=True,
+        )
+
+    with patch.object(
+        callbacks.mlflow,
+        "_save_odh",
+        side_effect=RuntimeError("mlflow offline"),
+    ):
+        with pytest.raises(RuntimeError, match="MLflow save failed: mlflow offline"):
+            callbacks.mlflow.save(_results(), _job_spec())
+
+    body = mock_http.post.call_args.kwargs["json"]["benchmark_status_event"]
+    assert body["state"] == JobStatus.FAILED.value
+    assert body["status"] == JobStatus.FAILED.value
+    assert (
+        body["error_message"]["message"]
+        == "Failed to save evaluation results to MLflow."
+    )
+    assert body["error_message"]["message_code"] == "mlflow_save_failed"
+    assert "mlflow offline" not in body["error_message"]["message"]
+    assert "warning_message" not in body


### PR DESCRIPTION
## What and why

MLFLow integration errors in the runtime pod while saving evaluation results were earlier not caught/reported. This PR has the change to call evalhub `/events` API to mark the job as failed.

Closes https://redhat.atlassian.net/browse/RHOAIENG-64709

## Type

- [ ] feat
- [X] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [X] Tested manually

### Manual test details
- mlflow service was scaled down to 0 replicas after an evaluation job with experiment was submitted and accepted by EH service. The job was configured with `num_examples: 100` to allow enough time for mlflow instances to terminate before adapter attempted to upload results to mlflow. With this approach, the error was reported by runtime (SDK) back to EH service on `/events` and was surfaced in job status API response to the end user.

<details>
<summary>Job status API response</summary>

```
{
    "resource": {
      "id": "eb9c681f-f9c0-43a0-9b5e-e85b279c77ac",
      "tenant": "sagar",
      "created_at": "2026-06-02T08:59:25.953123Z",
      "updated_at": "2026-06-02T08:59:45.052611Z",
      "owner": "nbs",
      "mlflow_experiment_id": "35"
    },
    "status": {
      "state": "failed",
      "message": {
        "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: Failed to save evaluation results to MLflow.\n",
        "message_code": "evaluation_job_updated"
      },
      "benchmarks": [
        {
          "provider_id": "lm_evaluation_harness",
          "id": "arc_easy",
          "benchmark_index": 0,
          "status": "failed",
          "error_message": {
            "message": "Failed to save evaluation results to MLflow.",
            "message_code": "mlflow_save_failed"
          }
        }
      ]
    },
    "results": {
      "benchmarks": [
        {
          "id": "arc_easy",
          "provider_id": "lm_evaluation_harness",
          "benchmark_index": 0
        }
      ],
      "mlflow_experiment_url": "https://mlflow.opendatahub.svc.cluster.local:8443/mlflow/api/2.0/mlflow/experiments"
    },
    "name": "gpt2-arc-easy-experiment-test",
    "model": {
      "url": "http://vllm-route-dataplane.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v1",
      "name": "gpt2"
    },
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "parameters": {
          "num_examples": 5,
          "tokenizer": "google/flan-t5-small"
        }
      }
    ],
    "experiment": {
      "name": "lm-eval-mlflow-test"
    }
  }
```
</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for evaluation failures. MLflow save errors are now properly tracked and reported as job status updates with detailed failure information, providing better visibility into evaluation job issues.

* **Tests**
  * Added unit tests to verify error propagation and status update behavior during evaluation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->