### PR TITLE
fix(adapter): align JobStatusUpdate and event payloads with server BenchmarkStatusEvent

### DIFF
--- a/examples/simple_adapter/simple_adapter.py
+++ b/examples/simple_adapter/simple_adapter.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import Any
 
 from evalhub.adapter import (
-    ErrorInfo,
     EvaluationResult,
     FrameworkAdapter,
     JobCallbacks,
@@ -191,7 +190,7 @@ class ExampleAdapter(FrameworkAdapter):
                     message=_status_message(
                         "Evaluation failed", code="evaluation_failed"
                     ),
-                    error=ErrorInfo(
+                    error_message=MessageInfo(
                         message=str(e),
                         message_code="evaluation_failed",
                     ),

--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -13,7 +13,6 @@ from .config import EvalHubMode, MlflowBackend
 from .mlflow import MlflowArtifact
 from .models import (
     EnvironmentCardMetadata,
-    ErrorInfo,
     JobCallbacks,
     JobResults,
     JobSpec,
@@ -25,7 +24,7 @@ from .models import (
 from .oci import DEFAULT_OCI_PROXY_HOST, OCIArtifactPersister
 from .oci.persister import OCIArtifactContext
 
-_MLFLOW_SAVE_FAILED = ErrorInfo(
+_MLFLOW_SAVE_FAILED = MessageInfo(
     message="Failed to save evaluation results to MLflow.",
     message_code="mlflow_save_failed",
 )
@@ -98,7 +97,7 @@ class _MlflowOps:
                 self._callbacks.report_status(
                     JobStatusUpdate(
                         status=JobStatus.FAILED,
-                        error=_MLFLOW_SAVE_FAILED,
+                        error_message=_MLFLOW_SAVE_FAILED,
                         message=MessageInfo(
                             message="Evaluation failed",
                             message_code="evaluation_failed",
@@ -564,6 +563,15 @@ class DefaultCallbacks(JobCallbacks):
             timeout=30.0,
         )
 
+    def _build_base_status_event(self, status: str) -> dict[str, Any]:
+        """Build the common BenchmarkStatusEvent fields required by the server."""
+        return {
+            "provider_id": self.provider_id or "",
+            "id": self.benchmark_id,
+            "benchmark_index": self.benchmark_index,
+            "status": status,
+        }
+
     def report_status(self, update: JobStatusUpdate) -> None:
         """Report status update to evalhub or log it.
 
@@ -575,22 +583,17 @@ class DefaultCallbacks(JobCallbacks):
             try:
                 url = f"{self.sidecar_url}{self._events_path_template.format(job_id=self.job_id)}"
 
-                # Transform to eval-hub API format
-                status_event = {
-                    "id": self.benchmark_id,
-                    "benchmark_index": self.benchmark_index,
-                    "state": update.status.value,
-                    "status": update.status.value,
-                    "message": update.message.model_dump(mode="json"),
-                }
+                status_event = self._build_base_status_event(update.status.value)
 
-                # Include error details for failed updates
-                if update.error:
-                    status_event["error_message"] = update.error.model_dump(mode="json")
+                if update.resolved_error:
+                    status_event["error_message"] = update.resolved_error.model_dump(
+                        mode="json"
+                    )
 
-                # Include provider_id if available
-                if self.provider_id:
-                    status_event["provider_id"] = self.provider_id
+                if update.warning_message:
+                    status_event["warning_message"] = update.warning_message.model_dump(
+                        mode="json"
+                    )
 
                 data = {"benchmark_status_event": status_event}
                 logger.debug("Events report_status body: %s", data)
@@ -682,24 +685,9 @@ class DefaultCallbacks(JobCallbacks):
                 for result in results.results:
                     metrics[result.metric_name] = result.metric_value
 
-                # Build status event with results
-                status_event = {
-                    "id": self.benchmark_id,
-                    "benchmark_index": self.benchmark_index,
-                    "state": JobStatus.COMPLETED.value,
-                    "status": JobStatus.COMPLETED.value,
-                    "message": {
-                        "message": "Evaluation completed successfully",
-                        "message_code": "evaluation_completed",
-                    },
-                    "metrics": metrics,
-                    "completed_at": results.completed_at.isoformat(),
-                    "duration_seconds": int(results.duration_seconds),
-                }
-
-                # Include provider_id if available
-                if self.provider_id:
-                    status_event["provider_id"] = self.provider_id
+                status_event = self._build_base_status_event(JobStatus.COMPLETED.value)
+                status_event["metrics"] = metrics
+                status_event["completed_at"] = results.completed_at.isoformat()
 
                 if results.mlflow_run_id:
                     status_event["mlflow_run_id"] = results.mlflow_run_id

--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import json
+import warnings
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any, Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from ...models.api import EvaluationResult, JobStatus, ModelConfig, OCICoordinates
 from .cards import EnvironmentCardMetadata, EvalCardMetadata
@@ -174,10 +175,14 @@ class JobStatusUpdate(BaseModel):
     """Status update sent to service via callback."""
 
     status: JobStatus = Field(..., description="Current job status")
+    # Not part of the server BenchmarkStatusEvent schema; used only for
+    # local fallback logging when no sidecar is available or the POST fails.
     phase: JobPhase | None = Field(default=None, description="Current execution phase")
     progress: float | None = Field(
         default=None, description="Progress percentage (0.0 to 1.0)"
     )
+    # Not part of the server BenchmarkStatusEvent schema; kept for backward
+    # compatibility with adapters that read it locally (e.g. logging).
     message: MessageInfo = Field(
         default_factory=lambda: MessageInfo(
             message="Status update",
@@ -192,15 +197,52 @@ class JobStatusUpdate(BaseModel):
     completed_steps: int | None = Field(
         default=None, description="Number of completed steps"
     )
+    # Deprecated: use error_message instead. Kept for backward compatibility;
+    # if both are set, error_message takes precedence. Marked for deletion in a future release.
     error: ErrorInfo | None = Field(
-        default=None, description="Error information if failed"
+        default=None,
+        description="Deprecated: use error_message instead. Marked for deletion in a future release.",
+        deprecated=True,
     )
+    error_message: MessageInfo | None = Field(
+        default=None, description="Error information (sent as error_message)"
+    )
+    warning_message: MessageInfo | None = Field(
+        default=None, description="Warning information (sent as warning_message)"
+    )
+    # Not part of the server BenchmarkStatusEvent schema; not sent to the
+    # server and not used in local logging. Marked for deletion in a future release.
     error_details: dict[str, Any] | None = Field(
-        default=None, description="Detailed error information"
+        default=None,
+        description="Deprecated: not sent to server. Marked for deletion in a future release.",
+        deprecated=True,
     )
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(UTC), description="Update timestamp"
     )
+
+    @model_validator(mode="after")
+    def _warn_deprecated_fields(self) -> Self:
+        if self.error is not None:
+            warnings.warn(
+                "JobStatusUpdate.error is deprecated and will be removed in a"
+                " future release, use error_message instead",
+                DeprecationWarning,
+                stacklevel=4,
+            )
+        if self.error_details is not None:
+            warnings.warn(
+                "JobStatusUpdate.error_details is deprecated and will be"
+                " removed in a future release",
+                DeprecationWarning,
+                stacklevel=4,
+            )
+        return self
+
+    @property
+    def resolved_error(self) -> MessageInfo | ErrorInfo | None:
+        """Return error_message if set, falling back to deprecated error field."""
+        return self.error_message or self.error
 
 
 class OCIArtifactSpec(BaseModel):

--- a/tests/unit/test_adapter_models.py
+++ b/tests/unit/test_adapter_models.py
@@ -254,6 +254,119 @@ class TestJobStatusUpdate:
         assert update.error_details is not None
         assert update.error_details["retry_count"] == 3
 
+    def test_status_update_with_error_message(self) -> None:
+        """Test status update with new error_message field."""
+        update = JobStatusUpdate(
+            status=JobStatus.FAILED,
+            error_message=MessageInfo(
+                message="Model server unreachable",
+                message_code="model_server_unreachable",
+            ),
+        )
+
+        assert update.error_message is not None
+        assert update.error_message.message == "Model server unreachable"
+        assert update.error_message.message_code == "model_server_unreachable"
+        assert update.error is None
+
+    def test_status_update_with_warning_message(self) -> None:
+        """Test status update with warning_message field."""
+        update = JobStatusUpdate(
+            status=JobStatus.RUNNING,
+            warning_message=MessageInfo(
+                message="Slow model response",
+                message_code="slow_response",
+            ),
+        )
+
+        assert update.warning_message is not None
+        assert update.warning_message.message == "Slow model response"
+        assert update.warning_message.message_code == "slow_response"
+
+    def test_resolved_error_prefers_error_message_over_error(self) -> None:
+        """Test that resolved_error returns error_message when both are set."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            update = JobStatusUpdate(
+                status=JobStatus.FAILED,
+                error_message=MessageInfo(
+                    message="New error",
+                    message_code="new_error",
+                ),
+                error=ErrorInfo(
+                    message="Old error",
+                    message_code="old_error",
+                ),
+            )
+
+        assert update.resolved_error is not None
+        assert update.resolved_error.message == "New error"
+
+    def test_resolved_error_falls_back_to_deprecated_error(self) -> None:
+        """Test that resolved_error falls back to error when error_message is not set."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            update = JobStatusUpdate(
+                status=JobStatus.FAILED,
+                error=ErrorInfo(
+                    message="Legacy error",
+                    message_code="legacy_error",
+                ),
+            )
+
+        assert update.resolved_error is not None
+        assert update.resolved_error.message == "Legacy error"
+
+    def test_resolved_error_returns_none_when_no_error(self) -> None:
+        """Test that resolved_error returns None when neither field is set."""
+        update = JobStatusUpdate(status=JobStatus.RUNNING)
+        assert update.resolved_error is None
+
+    def test_deprecated_error_field_emits_warning(self) -> None:
+        """Test that using the deprecated error field emits a DeprecationWarning."""
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            JobStatusUpdate(
+                status=JobStatus.FAILED,
+                error=ErrorInfo(
+                    message="test",
+                    message_code="test",
+                ),
+            )
+
+        deprecation_warnings = [
+            x
+            for x in w
+            if issubclass(x.category, DeprecationWarning)
+            and "error is deprecated" in str(x.message)
+        ]
+        assert len(deprecation_warnings) == 1
+
+    def test_deprecated_error_details_field_emits_warning(self) -> None:
+        """Test that using the deprecated error_details field emits a DeprecationWarning."""
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            JobStatusUpdate(
+                status=JobStatus.FAILED,
+                error_details={"exception_type": "ValueError"},
+            )
+
+        deprecation_warnings = [
+            x
+            for x in w
+            if issubclass(x.category, DeprecationWarning)
+            and "error_details is deprecated" in str(x.message)
+        ]
+        assert len(deprecation_warnings) == 1
+
     def test_that_timestamp_is_automatically_set(self) -> None:
         """Test that timestamp is automatically set."""
         update = JobStatusUpdate(status=JobStatus.RUNNING)

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -43,7 +43,10 @@ def _job_spec(experiment_name: str = "exp") -> JobSpec:
     )
 
 
-def test_report_results_sends_mlflow_run_id_when_set_on_job_results() -> None:
+def _make_callbacks(
+    provider_id: str | None = "lm_evaluation_harness",
+) -> tuple[DefaultCallbacks, MagicMock]:
+    """Create a DefaultCallbacks with a mocked HTTP client."""
     mock_http = MagicMock()
     resp = MagicMock()
     resp.raise_for_status = MagicMock()
@@ -53,11 +56,16 @@ def test_report_results_sends_mlflow_run_id_when_set_on_job_results() -> None:
         callbacks = DefaultCallbacks(
             job_id="job-1",
             benchmark_id="arc_easy",
-            provider_id="lm_evaluation_harness",
+            provider_id=provider_id,
             benchmark_index=0,
             sidecar_url="http://evalhub:8080",
             insecure=True,
         )
+    return callbacks, mock_http
+
+
+def test_report_results_sends_mlflow_run_id_when_set_on_job_results() -> None:
+    callbacks, mock_http = _make_callbacks()
 
     callbacks.report_results(_results(mlflow_run_id="mlflow-run-abc"))
 
@@ -67,19 +75,7 @@ def test_report_results_sends_mlflow_run_id_when_set_on_job_results() -> None:
 
 
 def test_report_results_omits_mlflow_run_id_when_not_set() -> None:
-    mock_http = MagicMock()
-    resp = MagicMock()
-    resp.raise_for_status = MagicMock()
-    mock_http.post.return_value = resp
-
-    with patch.object(DefaultCallbacks, "_create_http_client", return_value=mock_http):
-        callbacks = DefaultCallbacks(
-            job_id="job-1",
-            benchmark_id="arc_easy",
-            benchmark_index=0,
-            sidecar_url="http://evalhub:8080",
-            insecure=True,
-        )
+    callbacks, mock_http = _make_callbacks()
 
     callbacks.report_results(_results())
 
@@ -160,19 +156,7 @@ def test_mlflow_save_returns_run_id_from_upstream_path() -> None:
 
 @pytest.mark.unit
 def test_mlflow_save_posts_failed_event_on_mlflow_error() -> None:
-    mock_http = MagicMock()
-    resp = MagicMock()
-    resp.raise_for_status = MagicMock()
-    mock_http.post.return_value = resp
-
-    with patch.object(DefaultCallbacks, "_create_http_client", return_value=mock_http):
-        callbacks = DefaultCallbacks(
-            job_id="job-1",
-            benchmark_id="arc_easy",
-            benchmark_index=0,
-            sidecar_url="http://evalhub:8080",
-            insecure=True,
-        )
+    callbacks, mock_http = _make_callbacks()
 
     with patch.object(
         callbacks.mlflow,
@@ -183,7 +167,6 @@ def test_mlflow_save_posts_failed_event_on_mlflow_error() -> None:
             callbacks.mlflow.save(_results(), _job_spec())
 
     body = mock_http.post.call_args.kwargs["json"]["benchmark_status_event"]
-    assert body["state"] == JobStatus.FAILED.value
     assert body["status"] == JobStatus.FAILED.value
     assert (
         body["error_message"]["message"]
@@ -256,3 +239,103 @@ def test_build_params_metrics_base_params_and_metrics() -> None:
     assert metric_dict["acc"] == 0.9
     assert metric_dict["overall_score"] == 0.85
     assert "f1" not in metric_dict
+
+
+# ---------------------------------------------------------------------------
+# report_status payload tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_status_sends_error_message() -> None:
+    from evalhub.adapter.models.job import JobStatusUpdate, MessageInfo
+    from evalhub.models.api import JobStatus
+
+    callbacks, mock_http = _make_callbacks()
+    callbacks.report_status(
+        JobStatusUpdate(
+            status=JobStatus.FAILED,
+            error_message=MessageInfo(
+                message="boom",
+                message_code="kaboom",
+            ),
+        )
+    )
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert event["error_message"] == {"message": "boom", "message_code": "kaboom"}
+
+
+def test_report_status_sends_warning_message() -> None:
+    from evalhub.adapter.models.job import JobStatusUpdate, MessageInfo
+    from evalhub.models.api import JobStatus
+
+    callbacks, mock_http = _make_callbacks()
+    callbacks.report_status(
+        JobStatusUpdate(
+            status=JobStatus.RUNNING,
+            warning_message=MessageInfo(
+                message="slow",
+                message_code="slow_response",
+            ),
+        )
+    )
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert event["warning_message"] == {
+        "message": "slow",
+        "message_code": "slow_response",
+    }
+
+
+def test_report_status_always_includes_provider_id() -> None:
+    from evalhub.adapter.models.job import JobStatusUpdate
+    from evalhub.models.api import JobStatus
+
+    callbacks, mock_http = _make_callbacks(provider_id=None)
+    callbacks.report_status(JobStatusUpdate(status=JobStatus.RUNNING))
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert "provider_id" in event
+    assert event["provider_id"] == ""
+
+
+def test_report_status_does_not_send_state_or_message() -> None:
+    from evalhub.adapter.models.job import JobStatusUpdate
+    from evalhub.models.api import JobStatus
+
+    callbacks, mock_http = _make_callbacks()
+    callbacks.report_status(JobStatusUpdate(status=JobStatus.RUNNING))
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert "state" not in event
+    assert "message" not in event
+
+
+# ---------------------------------------------------------------------------
+# report_results payload tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_results_does_not_send_state_message_or_duration() -> None:
+    callbacks, mock_http = _make_callbacks()
+    callbacks.report_results(_results())
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert "state" not in event
+    assert "message" not in event
+    assert "duration_seconds" not in event
+
+
+def test_report_results_always_includes_provider_id() -> None:
+    callbacks, mock_http = _make_callbacks(provider_id=None)
+    callbacks.report_results(_results())
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert "provider_id" in event
+    assert event["provider_id"] == ""


### PR DESCRIPTION

The SDK was sending fields not in the server schema (state, message, duration_seconds) and conditionally omitting the required provider_id. This aligns report_status and report_results payloads with the server's BenchmarkStatusEvent struct, adds error_message and warning_message fields matching the server schema, and deprecates error and error_details with runtime DeprecationWarnings.

## What and why

Changes:
```
## Summary

Align the SDK's JobStatusUpdate model and event payloads (report_status, report_results)
with the server's BenchmarkStatusEvent schema. Previously the SDK sent fields not in the
server schema (state, message, duration_seconds) and conditionally omitted the required
provider_id field.

## What changed

### Schema alignment (callbacks.py)
- Removed "state", "message", and "duration_seconds" from payloads — not in server BenchmarkStatusEvent struct
- Made provider_id always present in payloads — server validates it as required
- Extracted _build_base_status_event() helper to avoid duplicating the common 4-field dict in report_status and report_results

### New fields on JobStatusUpdate (models/job.py)
- Added error_message (MessageInfo) — maps directly to server's error_message field
- Added warning_message (MessageInfo) — maps directly to server's warning_message field
- Added resolved_error property — returns error_message if set, falls back to deprecated error field

### Deprecations (models/job.py)
- error field: deprecated in favor of error_message, emits DeprecationWarning at runtime, marked for deletion
- error_details field: not in server schema and unused in callbacks, marked for deletion with runtime warning
- Both fields retain backward compatibility — existing adapters using error=ErrorInfo(...) continue to work

### Documentation comments (models/job.py)
- phase: not in server schema, used only for local fallback logging
- message: not in server schema, kept for backward compatibility with adapters that read it locally
- error_details: not in server schema, not sent, not used in logging

### Internal migration (callbacks.py)
- Changed _MLFLOW_SAVE_FAILED from ErrorInfo to MessageInfo
- Changed error= to error_message= at the mlflow failure report_status call site
- Removed unused ErrorInfo import

### Example (examples/simple_adapter/simple_adapter.py)
- Changed error=ErrorInfo(...) to error_message=MessageInfo(...) in the error handling path
- Removed unused ErrorInfo import

### Tests
- 7 new model tests: error_message, warning_message, resolved_error precedence/fallback/none, deprecation warnings
- 6 new callback tests: payload shape for report_status and report_results (error_message, warning_message, provider_id presence, absence of state/message/duration_seconds)
- Refactored existing callback tests to use shared _make_callbacks() helper
```
Closes # https://redhat.atlassian.net/browse/RHOAIENG-64651

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [x] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually


<img width="1116" height="449" alt="Screenshot 2026-06-03 at 12 00 54 PM" src="https://github.com/user-attachments/assets/daa44d80-165c-44a9-9c86-75f76914554c" />
<img width="751" height="196" alt="Screenshot 2026-06-03 at 12 00 00 PM" src="https://github.com/user-attachments/assets/7e039e97-cc13-4a5e-93fa-369312dba079" />
<img width="1173" height="915" alt="Screenshot 2026-06-03 at 12 17 36 PM" src="https://github.com/user-attachments/assets/907c1de5-3986-46e2-a1bd-97a183ebf75e" />

### Deprecation warnign message in logs
<img width="644" height="190" alt="Screenshot 2026-06-03 at 11 57 13 AM" src="https://github.com/user-attachments/assets/957302ce-6124-4e92-99a2-19dda65c806f" />
<img width="1219" height="272" alt="Screenshot 2026-06-03 at 11 56 39 AM" src="https://github.com/user-attachments/assets/a912c555-5934-4e60-b963-c986203d41d2" />


## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Job status updates now include dedicated `error_message` and `warning_message` fields for clearer error and warning reporting.
  * Refactored error reporting in backup storage integration.

* **Deprecation**
  * Legacy error field is deprecated in favor of the new `error_message` field.

* **Tests**
  * Added comprehensive test coverage for new error/warning fields and backward compatibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->