### PR TITLE
Add experimental live endpoint collection helper

### DIFF
--- a/src/evalhub/adapter/__init__.py
+++ b/src/evalhub/adapter/__init__.py
@@ -76,6 +76,14 @@ from ..models.api import (
 from .auth import ModelCredentials, read_model_auth_key, resolve_model_credentials
 from .callbacks import DefaultCallbacks
 from .config import MlflowBackend, get_job_spec_path
+from .live_collection import (
+    LiveCollectionConfig,
+    LiveCollectionSummary,
+    LiveEndpointConfig,
+    load_input_rows,
+    load_live_collection_config,
+    run_live_collection,
+)
 from .models import (
     CapabilityEvalEntry,
     EnvironmentCardMetadata,
@@ -127,6 +135,13 @@ __all__ = [
     "ModelCredentials",
     "read_model_auth_key",
     "resolve_model_credentials",
+    # Experimental live endpoint collection
+    "LiveEndpointConfig",
+    "LiveCollectionConfig",
+    "LiveCollectionSummary",
+    "load_input_rows",
+    "load_live_collection_config",
+    "run_live_collection",
     # Common models (re-exported for convenience)
     "JobStatus",
     "ModelConfig",

--- a/src/evalhub/adapter/live_collection.py
+++ b/src/evalhub/adapter/live_collection.py
@@ -1,0 +1,324 @@
+"""Experimental live endpoint collection helpers for adapters.
+
+This module is intentionally adapter-side only.  It lets an adapter validate a
+small ``parameters["live_collection"]`` contract, collect model responses during
+``JobPhase.LOADING_DATA``, and write a normalized JSONL dataset for its existing
+benchmark loader.
+
+Trust boundary: this helper assumes the adapter operator controls the endpoint
+configuration. Hosted runtimes that accept this config from untrusted users
+should add their own egress policy or endpoint allowlist before enabling it.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import tempfile
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class LiveEndpointConfig(BaseModel):
+    """Configuration for a live endpoint used during data collection."""
+
+    type: Literal["openai_chat_completions"] = Field(
+        default="openai_chat_completions",
+        description="Endpoint protocol supported by the collector.",
+    )
+    base_url: str = Field(
+        ..., description="Base URL for an OpenAI-compatible API, excluding the route."
+    )
+    model: str = Field(..., description="Model name sent to the endpoint.")
+    api_key_env: str | None = Field(
+        default=None,
+        description="Environment variable containing the endpoint bearer token.",
+    )
+    timeout_seconds: float = Field(default=30.0, gt=0)
+    max_retries: int = Field(default=2, ge=0)
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, value: str) -> str:
+        parsed = urlparse(value)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError("base_url must use http or https")
+        if not parsed.netloc:
+            raise ValueError("base_url must include a host")
+        return value.rstrip("/")
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("model cannot be empty")
+        return cleaned
+
+    @field_validator("api_key_env")
+    @classmethod
+    def validate_api_key_env(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("api_key_env cannot be empty")
+        return cleaned
+
+    @model_validator(mode="after")
+    def require_https_for_api_keys(self) -> LiveEndpointConfig:
+        if self.api_key_env and urlparse(self.base_url).scheme != "https":
+            raise ValueError("api_key_env requires an https base_url")
+        return self
+
+    @property
+    def chat_completions_url(self) -> str:
+        """Return the OpenAI-compatible chat completions route."""
+        return f"{self.base_url}/chat/completions"
+
+    @property
+    def api_key(self) -> str | None:
+        """Read the bearer token from the configured environment variable."""
+        if not self.api_key_env:
+            return None
+        return os.getenv(self.api_key_env)
+
+
+class LiveCollectionConfig(BaseModel):
+    """Experimental adapter parameter contract for live response collection."""
+
+    input_path: Path = Field(..., description="CSV or JSONL file with questions.")
+    output_path: Path = Field(..., description="JSONL file to write collected rows.")
+    question_field: str = Field(default="question")
+    id_field: str | None = Field(default=None)
+    endpoint: LiveEndpointConfig
+
+    @field_validator("question_field")
+    @classmethod
+    def validate_question_field(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("question_field cannot be empty")
+        return cleaned
+
+    @field_validator("id_field")
+    @classmethod
+    def validate_id_field(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("id_field cannot be empty")
+        return cleaned
+
+    @property
+    def manifest_path(self) -> Path:
+        """Return the sidecar manifest path for ``output_path``."""
+        return self.output_path.with_suffix(f"{self.output_path.suffix}.manifest.json")
+
+
+class LiveCollectionSummary(BaseModel):
+    """Summary returned after a collection run."""
+
+    rows_total: int
+    rows_succeeded: int
+    rows_failed: int
+    output_path: Path
+    manifest_path: Path
+
+
+def load_live_collection_config(parameters: dict[str, Any]) -> LiveCollectionConfig:
+    """Load ``parameters["live_collection"]`` into a typed config model."""
+    raw_config = parameters.get("live_collection")
+    if raw_config is None:
+        raise ValueError('Missing parameters["live_collection"]')
+    if not isinstance(raw_config, dict):
+        raise ValueError('parameters["live_collection"] must be an object')
+    return LiveCollectionConfig(**raw_config)
+
+
+def run_live_collection(config: LiveCollectionConfig) -> LiveCollectionSummary:
+    """Collect live endpoint responses and write output JSONL plus a manifest."""
+    rows = load_input_rows(config.input_path)
+    collected = list(collect_live_responses(rows, config))
+    write_jsonl(config.output_path, collected)
+
+    rows_failed = sum(1 for row in collected if row["error"] is not None)
+    summary = LiveCollectionSummary(
+        rows_total=len(collected),
+        rows_succeeded=len(collected) - rows_failed,
+        rows_failed=rows_failed,
+        output_path=config.output_path,
+        manifest_path=config.manifest_path,
+    )
+    write_manifest(config.manifest_path, config, summary)
+    return summary
+
+
+def load_input_rows(path: Path) -> list[dict[str, Any]]:
+    """Load CSV or JSONL input rows."""
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        with path.open(newline="", encoding="utf-8") as handle:
+            return list(csv.DictReader(handle))
+    if suffix == ".jsonl":
+        rows: list[dict[str, Any]] = []
+        with path.open(encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                value = json.loads(stripped)
+                if not isinstance(value, dict):
+                    raise ValueError(f"JSONL row {line_number} is not an object")
+                rows.append(value)
+        return rows
+    raise ValueError(f"Unsupported input format: {path.suffix}")
+
+
+def collect_live_responses(
+    rows: Iterable[dict[str, Any]],
+    config: LiveCollectionConfig,
+) -> Iterable[dict[str, Any]]:
+    """Yield source rows with collected response fields attached."""
+    for index, row in enumerate(rows):
+        output = dict(row)
+        output["response"] = None
+        output["response_metadata"] = {"source_index": index}
+        if config.id_field and config.id_field in row:
+            output["response_metadata"]["source_id"] = row[config.id_field]
+        output["error"] = None
+
+        question = str(row.get(config.question_field, "")).strip()
+        if not question:
+            output["error"] = {
+                "type": "missing_question",
+                "message": f"Missing or empty question field: {config.question_field}",
+            }
+            yield output
+            continue
+
+        try:
+            response = call_openai_chat_completion(config.endpoint, question)
+        except Exception as exc:  # noqa: BLE001 - preserve per-row failures.
+            output["error"] = {
+                "type": exc.__class__.__name__,
+                "message": str(exc),
+            }
+        else:
+            output["response"] = response["text"]
+            output["response_metadata"].update(response["metadata"])
+            if response["text"] is None:
+                output["error"] = {
+                    "type": "empty_response_content",
+                    "message": "Endpoint returned no message content",
+                }
+        yield output
+
+
+def call_openai_chat_completion(
+    endpoint: LiveEndpointConfig,
+    question: str,
+) -> dict[str, Any]:
+    """Call one OpenAI-compatible chat completions endpoint."""
+    try:
+        import httpx
+    except ImportError as exc:
+        raise RuntimeError(
+            "live endpoint collection requires httpx; install eval-hub-sdk[core]"
+        ) from exc
+
+    payload = {
+        "model": endpoint.model,
+        "messages": [{"role": "user", "content": question}],
+    }
+    headers = {"content-type": "application/json"}
+    if endpoint.api_key:
+        headers["authorization"] = f"Bearer {endpoint.api_key}"
+
+    last_error: Exception | None = None
+    for attempt in range(endpoint.max_retries + 1):
+        try:
+            response = httpx.post(
+                endpoint.chat_completions_url,
+                json=payload,
+                headers=headers,
+                timeout=endpoint.timeout_seconds,
+                follow_redirects=False,
+            )
+            response.raise_for_status()
+            body = response.json()
+            choice = body["choices"][0]
+            message = choice["message"]
+            return {
+                "text": message.get("content"),
+                "metadata": {
+                    "status_code": response.status_code,
+                    "finish_reason": choice.get("finish_reason"),
+                    "usage": body.get("usage"),
+                },
+            }
+        except httpx.HTTPStatusError as exc:
+            last_error = exc
+            if exc.response.status_code < 500 or attempt >= endpoint.max_retries:
+                raise
+        except (httpx.RequestError, TimeoutError) as exc:
+            last_error = exc
+            if attempt >= endpoint.max_retries:
+                raise
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise ValueError("Unexpected chat completions response shape") from exc
+
+        time.sleep(min(2**attempt, 8))
+
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("chat completion failed without an exception")
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    """Atomically write JSONL rows."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            delete=False,
+        ) as handle:
+            temp_path = Path(handle.name)
+            for row in rows:
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+        temp_path.replace(path)
+    except Exception:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+        raise
+
+
+def write_manifest(
+    path: Path,
+    config: LiveCollectionConfig,
+    summary: LiveCollectionSummary,
+) -> None:
+    """Write a small manifest next to the collected dataset."""
+    manifest = {
+        "experimental": True,
+        "endpoint_type": config.endpoint.type,
+        "input_path": str(config.input_path),
+        "output_path": str(summary.output_path),
+        "question_field": config.question_field,
+        "id_field": config.id_field,
+        "rows_total": summary.rows_total,
+        "rows_succeeded": summary.rows_succeeded,
+        "rows_failed": summary.rows_failed,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")

--- a/src/evalhub/adapter/live_collection.py
+++ b/src/evalhub/adapter/live_collection.py
@@ -87,7 +87,12 @@ class LiveEndpointConfig(BaseModel):
         """Read the bearer token from the configured environment variable."""
         if not self.api_key_env:
             return None
-        return os.getenv(self.api_key_env)
+        value = os.getenv(self.api_key_env)
+        if value is None or not value.strip():
+            raise ValueError(
+                f"Environment variable {self.api_key_env!r} is required and must be non-empty"
+            )
+        return value.strip()
 
 
 class LiveCollectionConfig(BaseModel):
@@ -117,6 +122,14 @@ class LiveCollectionConfig(BaseModel):
             raise ValueError("id_field cannot be empty")
         return cleaned
 
+    @model_validator(mode="after")
+    def validate_paths_are_distinct(self) -> LiveCollectionConfig:
+        if self.input_path.resolve(strict=False) == self.output_path.resolve(
+            strict=False
+        ):
+            raise ValueError("input_path and output_path must be different")
+        return self
+
     @property
     def manifest_path(self) -> Path:
         """Return the sidecar manifest path for ``output_path``."""
@@ -145,6 +158,7 @@ def load_live_collection_config(parameters: dict[str, Any]) -> LiveCollectionCon
 
 def run_live_collection(config: LiveCollectionConfig) -> LiveCollectionSummary:
     """Collect live endpoint responses and write output JSONL plus a manifest."""
+    _ = config.endpoint.api_key
     rows = load_input_rows(config.input_path)
     collected = list(collect_live_responses(rows, config))
     write_jsonl(config.output_path, collected)
@@ -195,7 +209,8 @@ def collect_live_responses(
             output["response_metadata"]["source_id"] = row[config.id_field]
         output["error"] = None
 
-        question = str(row.get(config.question_field, "")).strip()
+        question_value = row.get(config.question_field)
+        question = question_value.strip() if isinstance(question_value, str) else ""
         if not question:
             output["error"] = {
                 "type": "missing_question",
@@ -239,8 +254,9 @@ def call_openai_chat_completion(
         "messages": [{"role": "user", "content": question}],
     }
     headers = {"content-type": "application/json"}
-    if endpoint.api_key:
-        headers["authorization"] = f"Bearer {endpoint.api_key}"
+    api_key = endpoint.api_key
+    if api_key:
+        headers["authorization"] = f"Bearer {api_key}"
 
     last_error: Exception | None = None
     for attempt in range(endpoint.max_retries + 1):

--- a/tests/unit/test_live_collection.py
+++ b/tests/unit/test_live_collection.py
@@ -16,6 +16,8 @@ from evalhub.adapter import (
     run_live_collection,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _response(status_code: int, payload: dict[str, Any]) -> httpx.Response:
     return httpx.Response(
@@ -76,6 +78,43 @@ def test_endpoint_config_requires_https_when_api_key_is_used() -> None:
             base_url="http://endpoint.example/v1",
             model="chatbot",
             api_key_env="CHATBOT_API_KEY",
+        )
+
+
+def test_endpoint_config_fails_fast_when_api_key_env_is_missing_or_blank(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint = LiveEndpointConfig(
+        base_url="https://endpoint.example/v1",
+        model="chatbot",
+        api_key_env="CHATBOT_API_KEY",
+    )
+
+    monkeypatch.delenv("CHATBOT_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="required and must be non-empty"):
+        _ = endpoint.api_key
+
+    monkeypatch.setenv("CHATBOT_API_KEY", "   ")
+    with pytest.raises(ValueError, match="required and must be non-empty"):
+        _ = endpoint.api_key
+
+    monkeypatch.setenv("CHATBOT_API_KEY", " secret-token ")
+    assert endpoint.api_key == "secret-token"
+
+
+def test_live_collection_config_rejects_same_input_and_output_path(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "questions.jsonl"
+
+    with pytest.raises(ValueError, match="input_path and output_path"):
+        LiveCollectionConfig(
+            input_path=path,
+            output_path=path,
+            endpoint=LiveEndpointConfig(
+                base_url="https://endpoint.example/v1",
+                model="chatbot",
+            ),
         )
 
 
@@ -164,6 +203,80 @@ def test_run_live_collection_writes_jsonl_and_manifest(
     assert manifest["rows_failed"] == 1
     assert summary.rows_total == 2
     assert summary.rows_succeeded == 1
+    assert summary.rows_failed == 1
+
+
+def test_run_live_collection_fails_before_request_when_api_key_env_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "questions.jsonl"
+    output_path = tmp_path / "responses.jsonl"
+    input_path.write_text(json.dumps({"question": "hello"}) + "\n", encoding="utf-8")
+    monkeypatch.delenv("CHATBOT_API_KEY", raising=False)
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(*args: Any, **kwargs: Any) -> httpx.Response:
+        _ = args
+        calls.append(kwargs)
+        return _response(200, {"choices": [{"message": {"content": "ignored"}}]})
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    with pytest.raises(ValueError, match="required and must be non-empty"):
+        run_live_collection(
+            LiveCollectionConfig(
+                input_path=input_path,
+                output_path=output_path,
+                endpoint=LiveEndpointConfig(
+                    base_url="https://endpoint.example/v1",
+                    model="chatbot",
+                    api_key_env="CHATBOT_API_KEY",
+                    max_retries=0,
+                ),
+            )
+        )
+
+    assert calls == []
+    assert not output_path.exists()
+
+
+def test_run_live_collection_rejects_non_string_questions_without_calling_endpoint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "questions.jsonl"
+    output_path = tmp_path / "responses.jsonl"
+    input_path.write_text(json.dumps({"question": 123}) + "\n", encoding="utf-8")
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(*args: Any, **kwargs: Any) -> httpx.Response:
+        _ = args
+        calls.append(kwargs)
+        return _response(
+            200,
+            {"choices": [{"message": {"content": "should not be called"}}]},
+        )
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    summary = run_live_collection(
+        LiveCollectionConfig(
+            input_path=input_path,
+            output_path=output_path,
+            endpoint=LiveEndpointConfig(
+                base_url="https://endpoint.example/v1",
+                model="chatbot",
+            ),
+        )
+    )
+
+    row = json.loads(output_path.read_text(encoding="utf-8"))
+    assert row["response"] is None
+    assert row["error"]["type"] == "missing_question"
+    assert calls == []
     assert summary.rows_failed == 1
 
 

--- a/tests/unit/test_live_collection.py
+++ b/tests/unit/test_live_collection.py
@@ -1,0 +1,265 @@
+"""Unit tests for experimental live endpoint collection helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from evalhub.adapter import (
+    LiveCollectionConfig,
+    LiveEndpointConfig,
+    load_input_rows,
+    load_live_collection_config,
+    run_live_collection,
+)
+
+
+def _response(status_code: int, payload: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=payload,
+        request=httpx.Request("POST", "https://endpoint.example/v1/chat/completions"),
+    )
+
+
+def test_load_live_collection_config_from_parameters(tmp_path: Path) -> None:
+    input_path = tmp_path / "questions.jsonl"
+    output_path = tmp_path / "responses.jsonl"
+
+    config = load_live_collection_config(
+        {
+            "live_collection": {
+                "input_path": str(input_path),
+                "output_path": str(output_path),
+                "question_field": "prompt",
+                "id_field": "case_id",
+                "endpoint": {
+                    "base_url": "https://endpoint.example/v1/",
+                    "model": "chatbot",
+                    "api_key_env": "CHATBOT_API_KEY",
+                    "timeout_seconds": 5,
+                    "max_retries": 0,
+                },
+            }
+        }
+    )
+
+    assert config.input_path == input_path
+    assert config.output_path == output_path
+    assert config.question_field == "prompt"
+    assert config.id_field == "case_id"
+    assert config.endpoint.base_url == "https://endpoint.example/v1"
+    assert config.endpoint.chat_completions_url == (
+        "https://endpoint.example/v1/chat/completions"
+    )
+
+
+def test_load_live_collection_config_requires_object() -> None:
+    with pytest.raises(ValueError, match='parameters\\["live_collection"\\]'):
+        load_live_collection_config({})
+
+    with pytest.raises(ValueError, match="must be an object"):
+        load_live_collection_config({"live_collection": "not-an-object"})
+
+
+def test_endpoint_config_rejects_non_http_urls() -> None:
+    with pytest.raises(ValueError, match="http or https"):
+        LiveEndpointConfig(base_url="file:///tmp/model", model="chatbot")
+
+
+def test_endpoint_config_requires_https_when_api_key_is_used() -> None:
+    with pytest.raises(ValueError, match="requires an https base_url"):
+        LiveEndpointConfig(
+            base_url="http://endpoint.example/v1",
+            model="chatbot",
+            api_key_env="CHATBOT_API_KEY",
+        )
+
+
+def test_load_input_rows_supports_csv_and_jsonl(tmp_path: Path) -> None:
+    csv_path = tmp_path / "questions.csv"
+    csv_path.write_text("id,question\n1,hello\n", encoding="utf-8")
+    assert load_input_rows(csv_path) == [{"id": "1", "question": "hello"}]
+
+    jsonl_path = tmp_path / "questions.jsonl"
+    jsonl_path.write_text(
+        json.dumps({"id": "2", "question": "hi"}) + "\n\n",
+        encoding="utf-8",
+    )
+    assert load_input_rows(jsonl_path) == [{"id": "2", "question": "hi"}]
+
+
+def test_load_input_rows_rejects_non_object_jsonl(tmp_path: Path) -> None:
+    path = tmp_path / "bad.jsonl"
+    path.write_text("[1, 2, 3]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="row 1 is not an object"):
+        load_input_rows(path)
+
+
+def test_run_live_collection_writes_jsonl_and_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "questions.csv"
+    output_path = tmp_path / "responses.jsonl"
+    input_path.write_text("id,question\nrow-1,What is up?\nrow-2,\n", encoding="utf-8")
+    monkeypatch.setenv("CHATBOT_API_KEY", "secret-token")
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(*args: Any, **kwargs: Any) -> httpx.Response:
+        _ = args
+        calls.append(kwargs)
+        return _response(
+            200,
+            {
+                "choices": [
+                    {
+                        "message": {"content": "collected answer"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"total_tokens": 7},
+            },
+        )
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    summary = run_live_collection(
+        LiveCollectionConfig(
+            input_path=input_path,
+            output_path=output_path,
+            id_field="id",
+            endpoint=LiveEndpointConfig(
+                base_url="https://endpoint.example/v1",
+                model="chatbot",
+                api_key_env="CHATBOT_API_KEY",
+                max_retries=0,
+            ),
+        )
+    )
+
+    rows = [
+        json.loads(line)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert rows[0]["response"] == "collected answer"
+    assert rows[0]["response_metadata"]["source_index"] == 0
+    assert rows[0]["response_metadata"]["source_id"] == "row-1"
+    assert rows[0]["response_metadata"]["usage"] == {"total_tokens": 7}
+    assert rows[0]["error"] is None
+    assert rows[1]["error"]["type"] == "missing_question"
+    assert len(calls) == 1
+    assert calls[0]["headers"]["authorization"] == "Bearer secret-token"
+    assert calls[0]["follow_redirects"] is False
+
+    manifest = json.loads(summary.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["experimental"] is True
+    assert manifest["rows_total"] == 2
+    assert manifest["rows_succeeded"] == 1
+    assert manifest["rows_failed"] == 1
+    assert summary.rows_total == 2
+    assert summary.rows_succeeded == 1
+    assert summary.rows_failed == 1
+
+
+def test_run_live_collection_retries_transient_http_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "questions.jsonl"
+    output_path = tmp_path / "responses.jsonl"
+    input_path.write_text(json.dumps({"question": "retry?"}) + "\n", encoding="utf-8")
+    monkeypatch.setattr("evalhub.adapter.live_collection.time.sleep", lambda _: None)
+
+    responses = [
+        _response(500, {"error": "temporarily unavailable"}),
+        _response(
+            200,
+            {
+                "choices": [
+                    {
+                        "message": {"content": "after retry"},
+                        "finish_reason": "stop",
+                    }
+                ]
+            },
+        ),
+    ]
+
+    def fake_post(*args: Any, **kwargs: Any) -> httpx.Response:
+        _ = args, kwargs
+        return responses.pop(0)
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    summary = run_live_collection(
+        LiveCollectionConfig(
+            input_path=input_path,
+            output_path=output_path,
+            endpoint=LiveEndpointConfig(
+                base_url="https://endpoint.example/v1",
+                model="chatbot",
+                max_retries=1,
+            ),
+        )
+    )
+
+    row = json.loads(output_path.read_text(encoding="utf-8"))
+    assert row["response"] == "after retry"
+    assert row["error"] is None
+    assert summary.rows_succeeded == 1
+    assert responses == []
+
+
+def test_redirect_response_becomes_row_error_without_following_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_path = tmp_path / "questions.jsonl"
+    output_path = tmp_path / "responses.jsonl"
+    input_path.write_text(
+        json.dumps({"question": "redirect?"}) + "\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("CHATBOT_API_KEY", "secret-token")
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(*args: Any, **kwargs: Any) -> httpx.Response:
+        _ = args
+        calls.append(kwargs)
+        return httpx.Response(
+            307,
+            headers={"location": "https://other.example/v1/chat/completions"},
+            request=httpx.Request(
+                "POST",
+                "https://endpoint.example/v1/chat/completions",
+            ),
+        )
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    summary = run_live_collection(
+        LiveCollectionConfig(
+            input_path=input_path,
+            output_path=output_path,
+            endpoint=LiveEndpointConfig(
+                base_url="https://endpoint.example/v1",
+                model="chatbot",
+                api_key_env="CHATBOT_API_KEY",
+                max_retries=0,
+            ),
+        )
+    )
+
+    row = json.loads(output_path.read_text(encoding="utf-8"))
+    assert row["response"] is None
+    assert row["error"]["type"] == "HTTPStatusError"
+    assert len(calls) == 1
+    assert calls[0]["headers"]["authorization"] == "Bearer secret-token"
+    assert calls[0]["follow_redirects"] is False
+    assert summary.rows_failed == 1


### PR DESCRIPTION
## What and why

Refs eval-hub/eval-hub-sdk#135.

This adds an experimental adapter-side live endpoint collection helper for the SDK-helper-first path discussed in the issue. It lets adapters collect model responses during loading by reading CSV/JSONL question rows, calling an OpenAI-compatible `/chat/completions` endpoint, and writing normalized JSONL rows plus a small manifest.

The helper preserves source fields and adds `response`, `response_metadata`, and `error` fields. Per-row endpoint failures are captured in the output, while configuration hazards fail early.

Security/trust-boundary choices:

- `api_key_env` requires an `https://` base URL
- bearer tokens are read from environment variables, not job JSON
- missing or blank API key environment variables fail before any request is sent
- redirects are not followed, so auth headers are not forwarded to redirect targets
- input and output paths cannot point to the same file
- this is intentionally adapter/operator-controlled config; hosted runtimes that accept this config from untrusted users should add their own egress policy or endpoint allowlist before enabling it

## Type

feat

## Testing

- `uv run ruff format src/evalhub/adapter/live_collection.py tests/unit/test_live_collection.py`
- `uv run ruff check src/evalhub/adapter/live_collection.py tests/unit/test_live_collection.py`
- `uv run pytest tests/unit/test_live_collection.py -q` (13 passed)
- `uv run mypy --config-file=pyproject.toml src/evalhub/adapter/live_collection.py tests/unit/test_live_collection.py`
- `git diff --check`
- Claude Code CLI blocker-only review of the follow-up diff: no blockers

## Breaking changes

None. The helper is new experimental adapter SDK surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental live endpoint collection functionality to gather responses from OpenAI-compatible chat completions endpoints
  * Supports configuration loading and batch processing of input data (CSV/JSONL formats)
  * Automatically collects responses, metadata, and error details with retry support and manifest generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
