### PR TITLE
feat: add experimental live collection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ Example `parameters["live_collection"]` shape:
 
 The helper does not require server/API changes. Redirects are not followed, and
 per-row request failures are recorded in the JSONL output instead of aborting
-the whole job.
+the whole job. When `max_retries` is set, failed row requests use capped
+exponential backoff between attempts.
 
 Because `endpoint_url`, `request_headers`, and `api_key_env` come from adapter
 parameters, use this helper only when the job submitter is trusted to choose the

--- a/README.md
+++ b/README.md
@@ -219,6 +219,65 @@ results = adapter.run_benchmark_job(adapter.job_spec, callbacks)
 - **Status updates**: Sent to sidecar if `sidecar_url` is provided, otherwise logged locally. Both `report_status` and `report_results` events always include `benchmark_index` (and `provider_id` when set) so the service can associate events with the correct benchmark in multi-benchmark jobs.
 - **OCI artifacts**: Created via SDK callbacks and pushed to the OCI registry through the sidecar-authenticated flow when mode is Kubernetes.
 
+### Experimental Live Response Collection
+
+Adapters that need to evaluate a live chatbot or RAG endpoint can opt into the
+experimental live collection helper during `JobPhase.LOADING_DATA`. The first
+collector reads questions from CSV, JSON, or JSONL, calls an OpenAI-compatible
+`/v1/chat/completions` endpoint, then writes `responses.jsonl` and
+`manifest.json` into an output directory for the adapter's evaluation framework
+to load.
+
+```python
+from evalhub.adapter import (
+    JobPhase,
+    JobStatus,
+    JobStatusUpdate,
+    LiveCollectionConfig,
+    MessageInfo,
+    collect_openai_chat_completions,
+)
+
+callbacks.report_status(JobStatusUpdate(
+    status=JobStatus.RUNNING,
+    phase=JobPhase.LOADING_DATA,
+    message=MessageInfo(
+        message="Collecting live endpoint responses",
+        message_code="live_collection",
+    ),
+))
+
+config = LiveCollectionConfig.from_parameters(adapter.job_spec.parameters)
+manifest = collect_openai_chat_completions(config)
+
+# Your framework can now load manifest.output_path, a JSONL file with one
+# row per question and either a response or an error field.
+```
+
+Example `parameters["live_collection"]` shape:
+
+```json
+{
+  "live_collection": {
+    "endpoint_type": "openai_chat_completions",
+    "endpoint_url": "https://example.com/v1/chat/completions",
+    "model": "my-chatbot",
+    "questions_path": "/data/questions.jsonl",
+    "output_dir": "/tmp/live_collection",
+    "api_key_env": "CHATBOT_API_KEY"
+  }
+}
+```
+
+The helper does not require server/API changes. Redirects are not followed, and
+per-row request failures are recorded in the JSONL output instead of aborting
+the whole job.
+
+Because `endpoint_url`, `request_headers`, and `api_key_env` come from adapter
+parameters, use this helper only when the job submitter is trusted to choose the
+endpoint and referenced secret. Hosted/server-side submission should add URL and
+secret-reference policy before promoting this shape into the API.
+
 ### 4. Containerise Your Adapter
 
 Create a Dockerfile for your adapter:

--- a/src/evalhub/adapter/__init__.py
+++ b/src/evalhub/adapter/__init__.py
@@ -76,6 +76,15 @@ from ..models.api import (
 from .auth import ModelCredentials, read_model_auth_key, resolve_model_credentials
 from .callbacks import DefaultCallbacks
 from .config import MlflowBackend, get_job_spec_path
+from .live_collection import (
+    LiveCollectionConfig,
+    LiveCollectionManifest,
+    LiveCollectionRecord,
+    LiveQuestion,
+    collect_live_responses_from_parameters,
+    collect_openai_chat_completions,
+    load_live_questions,
+)
 from .models import (
     CapabilityEvalEntry,
     EnvironmentCardMetadata,
@@ -127,6 +136,14 @@ __all__ = [
     "ModelCredentials",
     "read_model_auth_key",
     "resolve_model_credentials",
+    # Experimental live response collection
+    "LiveCollectionConfig",
+    "LiveCollectionManifest",
+    "LiveCollectionRecord",
+    "LiveQuestion",
+    "collect_live_responses_from_parameters",
+    "collect_openai_chat_completions",
+    "load_live_questions",
     # Common models (re-exported for convenience)
     "JobStatus",
     "ModelConfig",

--- a/src/evalhub/adapter/live_collection.py
+++ b/src/evalhub/adapter/live_collection.py
@@ -81,6 +81,7 @@ class LiveCollectionConfig(BaseModel):
     @field_validator("endpoint_url")
     @classmethod
     def _endpoint_url_must_be_http(cls, value: str) -> str:
+        """Require network endpoints to use explicit HTTP(S) schemes."""
         if not value.lower().startswith(("http://", "https://")):
             raise ValueError("endpoint_url must use http:// or https://")
         return value
@@ -233,6 +234,7 @@ def _load_csv_questions(
     question_column: str,
     id_column: str,
 ) -> list[LiveQuestion]:
+    """Parse CSV rows into live collection questions."""
     with path.open(newline="", encoding="utf-8") as csv_file:
         reader = csv.DictReader(csv_file)
         if reader.fieldnames is None or question_column not in reader.fieldnames:
@@ -266,6 +268,7 @@ def _load_jsonl_questions(
     question_column: str,
     id_column: str,
 ) -> list[LiveQuestion]:
+    """Parse newline-delimited JSON objects into live collection questions."""
     questions: list[LiveQuestion] = []
     with path.open(encoding="utf-8") as jsonl_file:
         for row_index, line in enumerate(jsonl_file, start=1):
@@ -290,6 +293,7 @@ def _load_json_questions(
     question_column: str,
     id_column: str,
 ) -> list[LiveQuestion]:
+    """Parse JSON list inputs into live collection questions."""
     raw_data = json.loads(path.read_text(encoding="utf-8"))
     if isinstance(raw_data, dict) and "questions" in raw_data:
         raw_data = raw_data["questions"]
@@ -319,6 +323,7 @@ def _question_from_mapping(
     id_column: str,
     row_index: int,
 ) -> LiveQuestion:
+    """Build a validated question from one structured input row."""
     raw_question = row.get(question_column)
     if not isinstance(raw_question, str) or not raw_question.strip():
         raise ValueError(f"Question row {row_index} must include '{question_column}'")
@@ -342,6 +347,7 @@ def _question_from_mapping(
 
 
 def _build_headers(config: LiveCollectionConfig) -> dict[str, str]:
+    """Build request headers, including optional bearer-token auth."""
     headers = dict(config.request_headers)
     if config.api_key_env:
         api_key = os.getenv(config.api_key_env)
@@ -357,6 +363,7 @@ def _collect_one_question(
     headers: Mapping[str, str],
     question: LiveQuestion,
 ) -> LiveCollectionRecord:
+    """Collect one endpoint response and return either content or row error."""
     last_error: str | None = None
     for _attempt in range(config.max_retries + 1):
         try:
@@ -401,6 +408,7 @@ def _chat_completion_body(
     config: LiveCollectionConfig,
     question: LiveQuestion,
 ) -> dict[str, Any]:
+    """Create an OpenAI-compatible chat-completions request body."""
     messages: list[dict[str, str]] = []
     if config.system_prompt:
         messages.append({"role": "system", "content": config.system_prompt})
@@ -415,6 +423,7 @@ def _chat_completion_body(
 
 
 def _extract_chat_content(raw_response: Mapping[str, Any]) -> str | None:
+    """Extract assistant text from a chat-completions response payload."""
     choices = raw_response.get("choices")
     if not isinstance(choices, list) or not choices:
         return None

--- a/src/evalhub/adapter/live_collection.py
+++ b/src/evalhub/adapter/live_collection.py
@@ -1,0 +1,424 @@
+"""Experimental helpers for collecting live endpoint responses in adapters."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class LiveCollectionConfig(BaseModel):
+    """Configuration for adapter-side live response collection.
+
+    The shape is intentionally small and can be passed through
+    ``JobSpec.parameters["live_collection"]`` while the server/API contract is
+    still being validated.
+    """
+
+    questions_path: Path = Field(
+        ..., description="CSV, JSON, or JSONL file containing input questions"
+    )
+    output_dir: Path = Field(
+        ..., description="Directory where responses.jsonl and manifest.json are written"
+    )
+    endpoint_url: str = Field(
+        ..., description="OpenAI-compatible /v1/chat/completions endpoint URL"
+    )
+    model: str = Field(..., description="Model name to send in each request")
+    endpoint_type: Literal["openai_chat_completions"] = Field(
+        default="openai_chat_completions",
+        description="Live endpoint collector implementation to use",
+    )
+    question_column: str = Field(
+        default="question", description="CSV/JSON field containing the prompt text"
+    )
+    id_column: str = Field(default="id", description="Optional question id field")
+    api_key_env: str | None = Field(
+        default=None,
+        description="Environment variable containing a bearer token for the endpoint",
+    )
+    request_headers: dict[str, str] = Field(
+        default_factory=dict, description="Additional headers sent with every request"
+    )
+    system_prompt: str | None = Field(
+        default=None, description="Optional system message sent before each question"
+    )
+    extra_body: dict[str, Any] = Field(
+        default_factory=dict, description="Additional JSON body fields for each request"
+    )
+    timeout_seconds: float = Field(
+        default=30.0, gt=0.0, description="Per-request timeout"
+    )
+    max_retries: int = Field(
+        default=0, ge=0, description="Number of retries after the initial request"
+    )
+
+    @classmethod
+    def from_parameters(cls, parameters: Mapping[str, Any]) -> LiveCollectionConfig:
+        """Load config from ``JobSpec.parameters["live_collection"]``."""
+        raw_config = parameters.get("live_collection")
+        if raw_config is None:
+            raise ValueError('JobSpec.parameters["live_collection"] is required')
+        return cls.model_validate(raw_config)
+
+    @field_validator("endpoint_url")
+    @classmethod
+    def _endpoint_url_must_be_http(cls, value: str) -> str:
+        if not value.lower().startswith(("http://", "https://")):
+            raise ValueError("endpoint_url must use http:// or https://")
+        return value
+
+
+class LiveQuestion(BaseModel):
+    """One question loaded from a CSV/JSON/JSONL input file."""
+
+    question: str
+    question_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class LiveCollectionRecord(BaseModel):
+    """One collected response row."""
+
+    question: str
+    question_id: str | None = None
+    response: str | None = None
+    raw_response: dict[str, Any] | None = None
+    error: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class LiveCollectionManifest(BaseModel):
+    """Summary of a live collection run."""
+
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    endpoint_type: str
+    endpoint_url: str
+    model: str
+    questions_path: Path
+    output_path: Path
+    total: int
+    completed: int
+    failed: int
+
+
+def load_live_questions(
+    path: Path | str,
+    *,
+    question_column: str = "question",
+    id_column: str = "id",
+) -> list[LiveQuestion]:
+    """Load live collection questions from CSV, JSON, or JSONL."""
+    question_path = Path(path)
+    if not question_path.exists():
+        raise FileNotFoundError(f"Question file not found: {question_path}")
+
+    suffix = question_path.suffix.lower()
+    if suffix == ".csv":
+        questions = _load_csv_questions(question_path, question_column, id_column)
+    elif suffix == ".jsonl":
+        questions = _load_jsonl_questions(question_path, question_column, id_column)
+    elif suffix == ".json":
+        questions = _load_json_questions(question_path, question_column, id_column)
+    else:
+        raise ValueError(
+            f"Unsupported question file type '{suffix}'. Use CSV, JSON, or JSONL."
+        )
+
+    if not questions:
+        raise ValueError(f"No questions found in {question_path}")
+    return questions
+
+
+def collect_openai_chat_completions(
+    config: LiveCollectionConfig,
+    *,
+    client: Any | None = None,
+) -> LiveCollectionManifest:
+    """Collect responses from an OpenAI-compatible chat-completions endpoint.
+
+    Adapters can call this during ``JobPhase.LOADING_DATA`` and pass the
+    returned ``responses.jsonl`` path into their evaluation framework loader.
+    Row-level request failures are recorded in the output JSONL instead of
+    aborting the whole collection run.
+    """
+    questions = load_live_questions(
+        config.questions_path,
+        question_column=config.question_column,
+        id_column=config.id_column,
+    )
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_path = config.output_dir / "responses.jsonl"
+    headers = _build_headers(config)
+    active_client = client
+    owns_client = active_client is None
+
+    if active_client is None:
+        try:
+            import httpx
+        except ImportError as exc:
+            raise RuntimeError(
+                "Live collection requires httpx. Install eval-hub-sdk[adapter] "
+                "or eval-hub-sdk[core]."
+            ) from exc
+
+        active_client = httpx.Client(
+            follow_redirects=False,
+            timeout=config.timeout_seconds,
+        )
+
+    completed = 0
+    failed = 0
+    try:
+        with output_path.open("w", encoding="utf-8") as output_file:
+            for question in questions:
+                record = _collect_one_question(config, active_client, headers, question)
+                if record.error:
+                    failed += 1
+                else:
+                    completed += 1
+                output_file.write(json.dumps(record.model_dump(mode="json")) + "\n")
+    finally:
+        if owns_client and hasattr(active_client, "close"):
+            active_client.close()
+
+    manifest = LiveCollectionManifest(
+        endpoint_type=config.endpoint_type,
+        endpoint_url=config.endpoint_url,
+        model=config.model,
+        questions_path=config.questions_path,
+        output_path=output_path,
+        total=len(questions),
+        completed=completed,
+        failed=failed,
+    )
+    manifest_path = config.output_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest.model_dump(mode="json"), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def collect_live_responses_from_parameters(
+    parameters: Mapping[str, Any],
+    *,
+    client: Any | None = None,
+) -> LiveCollectionManifest:
+    """Collect responses from ``JobSpec.parameters["live_collection"]`` config."""
+    config = LiveCollectionConfig.from_parameters(parameters)
+    return collect_openai_chat_completions(config, client=client)
+
+
+def _load_csv_questions(
+    path: Path,
+    question_column: str,
+    id_column: str,
+) -> list[LiveQuestion]:
+    with path.open(newline="", encoding="utf-8") as csv_file:
+        reader = csv.DictReader(csv_file)
+        if reader.fieldnames is None or question_column not in reader.fieldnames:
+            raise ValueError(f"CSV file must include a '{question_column}' column")
+
+        questions: list[LiveQuestion] = []
+        for row_index, row in enumerate(reader, start=1):
+            question = (row.get(question_column) or "").strip()
+            if not question:
+                continue
+            question_id = (row.get(id_column) or "").strip() or None
+            metadata = {
+                key: value
+                for key, value in row.items()
+                if key not in {question_column, id_column} and value not in (None, "")
+            }
+            if question_id is None:
+                question_id = str(row_index)
+            questions.append(
+                LiveQuestion(
+                    question=question,
+                    question_id=question_id,
+                    metadata=metadata,
+                )
+            )
+    return questions
+
+
+def _load_jsonl_questions(
+    path: Path,
+    question_column: str,
+    id_column: str,
+) -> list[LiveQuestion]:
+    questions: list[LiveQuestion] = []
+    with path.open(encoding="utf-8") as jsonl_file:
+        for row_index, line in enumerate(jsonl_file, start=1):
+            if not line.strip():
+                continue
+            raw_row = json.loads(line)
+            if not isinstance(raw_row, dict):
+                raise ValueError("Each JSONL line must be an object")
+            questions.append(
+                _question_from_mapping(
+                    cast(Mapping[str, Any], raw_row),
+                    question_column,
+                    id_column,
+                    row_index,
+                )
+            )
+    return questions
+
+
+def _load_json_questions(
+    path: Path,
+    question_column: str,
+    id_column: str,
+) -> list[LiveQuestion]:
+    raw_data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(raw_data, dict) and "questions" in raw_data:
+        raw_data = raw_data["questions"]
+    if not isinstance(raw_data, list):
+        raise ValueError(
+            "JSON question input must be a list or contain a questions list"
+        )
+
+    questions: list[LiveQuestion] = []
+    for row_index, raw_row in enumerate(raw_data, start=1):
+        if not isinstance(raw_row, dict):
+            raise ValueError("Each JSON question row must be an object")
+        questions.append(
+            _question_from_mapping(
+                cast(Mapping[str, Any], raw_row),
+                question_column,
+                id_column,
+                row_index,
+            )
+        )
+    return questions
+
+
+def _question_from_mapping(
+    row: Mapping[str, Any],
+    question_column: str,
+    id_column: str,
+    row_index: int,
+) -> LiveQuestion:
+    raw_question = row.get(question_column)
+    if not isinstance(raw_question, str) or not raw_question.strip():
+        raise ValueError(f"Question row {row_index} must include '{question_column}'")
+
+    raw_id = row.get(id_column)
+    question_id = str(raw_id) if raw_id not in (None, "") else str(row_index)
+
+    metadata: dict[str, Any] = {}
+    explicit_metadata = row.get("metadata")
+    if isinstance(explicit_metadata, dict):
+        metadata.update(cast(dict[str, Any], explicit_metadata))
+    for key, value in row.items():
+        if key not in {question_column, id_column, "metadata"}:
+            metadata[key] = value
+
+    return LiveQuestion(
+        question=raw_question.strip(),
+        question_id=question_id,
+        metadata=metadata,
+    )
+
+
+def _build_headers(config: LiveCollectionConfig) -> dict[str, str]:
+    headers = dict(config.request_headers)
+    if config.api_key_env:
+        api_key = os.getenv(config.api_key_env)
+        if not api_key:
+            raise ValueError(f"Environment variable {config.api_key_env} is not set")
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _collect_one_question(
+    config: LiveCollectionConfig,
+    client: Any,
+    headers: Mapping[str, str],
+    question: LiveQuestion,
+) -> LiveCollectionRecord:
+    last_error: str | None = None
+    for _attempt in range(config.max_retries + 1):
+        try:
+            response = client.post(
+                config.endpoint_url,
+                json=_chat_completion_body(config, question),
+                headers=dict(headers),
+                timeout=config.timeout_seconds,
+            )
+            status_code = getattr(response, "status_code", None)
+            if isinstance(status_code, int) and 300 <= status_code < 400:
+                raise ValueError(f"Redirect response not allowed: HTTP {status_code}")
+            response.raise_for_status()
+            raw_response = response.json()
+            if not isinstance(raw_response, dict):
+                raise ValueError("Chat completion response must be a JSON object")
+            return LiveCollectionRecord(
+                question=question.question,
+                question_id=question.question_id,
+                response=_extract_chat_content(cast(dict[str, Any], raw_response)),
+                raw_response=cast(dict[str, Any], raw_response),
+                metadata=question.metadata,
+            )
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+
+    return LiveCollectionRecord(
+        question=question.question,
+        question_id=question.question_id,
+        error=last_error,
+        metadata=question.metadata,
+    )
+
+
+def _chat_completion_body(
+    config: LiveCollectionConfig,
+    question: LiveQuestion,
+) -> dict[str, Any]:
+    messages: list[dict[str, str]] = []
+    if config.system_prompt:
+        messages.append({"role": "system", "content": config.system_prompt})
+    messages.append({"role": "user", "content": question.question})
+
+    body: dict[str, Any] = {
+        "model": config.model,
+        "messages": messages,
+    }
+    body.update(config.extra_body)
+    return body
+
+
+def _extract_chat_content(raw_response: Mapping[str, Any]) -> str | None:
+    choices = raw_response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return None
+
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        return None
+
+    message = first_choice.get("message")
+    if not isinstance(message, dict):
+        return None
+
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "".join(parts) if parts else None
+    return None

--- a/src/evalhub/adapter/live_collection.py
+++ b/src/evalhub/adapter/live_collection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import json
 import os
+import time
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
@@ -57,6 +58,16 @@ class LiveCollectionConfig(BaseModel):
     )
     max_retries: int = Field(
         default=0, ge=0, description="Number of retries after the initial request"
+    )
+    retry_backoff_seconds: float = Field(
+        default=0.25,
+        ge=0.0,
+        description="Base delay before retrying failed row requests",
+    )
+    max_retry_backoff_seconds: float = Field(
+        default=5.0,
+        ge=0.0,
+        description="Maximum delay before retrying failed row requests",
     )
 
     @classmethod
@@ -371,6 +382,12 @@ def _collect_one_question(
             )
         except Exception as exc:
             last_error = f"{type(exc).__name__}: {exc}"
+            if _attempt < config.max_retries and config.retry_backoff_seconds > 0:
+                delay = min(
+                    config.retry_backoff_seconds * (2**_attempt),
+                    config.max_retry_backoff_seconds,
+                )
+                time.sleep(delay)
 
     return LiveCollectionRecord(
         question=question.question,

--- a/src/evalhub/adapter/live_collection.py
+++ b/src/evalhub/adapter/live_collection.py
@@ -277,14 +277,14 @@ def _load_jsonl_questions(
             raw_row = json.loads(line)
             if not isinstance(raw_row, dict):
                 raise ValueError("Each JSONL line must be an object")
-            questions.append(
-                _question_from_mapping(
-                    cast(Mapping[str, Any], raw_row),
-                    question_column,
-                    id_column,
-                    row_index,
-                )
+            question = _question_from_mapping(
+                cast(Mapping[str, Any], raw_row),
+                question_column,
+                id_column,
+                row_index,
             )
+            if question is not None:
+                questions.append(question)
     return questions
 
 
@@ -306,14 +306,14 @@ def _load_json_questions(
     for row_index, raw_row in enumerate(raw_data, start=1):
         if not isinstance(raw_row, dict):
             raise ValueError("Each JSON question row must be an object")
-        questions.append(
-            _question_from_mapping(
-                cast(Mapping[str, Any], raw_row),
-                question_column,
-                id_column,
-                row_index,
-            )
+        question = _question_from_mapping(
+            cast(Mapping[str, Any], raw_row),
+            question_column,
+            id_column,
+            row_index,
         )
+        if question is not None:
+            questions.append(question)
     return questions
 
 
@@ -322,14 +322,22 @@ def _question_from_mapping(
     question_column: str,
     id_column: str,
     row_index: int,
-) -> LiveQuestion:
+) -> LiveQuestion | None:
     """Build a validated question from one structured input row."""
     raw_question = row.get(question_column)
-    if not isinstance(raw_question, str) or not raw_question.strip():
+    if raw_question is None:
+        raise ValueError(f"Question row {row_index} must include '{question_column}'")
+    if not isinstance(raw_question, str):
         raise ValueError(f"Question row {row_index} must include '{question_column}'")
 
+    question_text = raw_question.strip()
+    if not question_text:
+        return None
+
     raw_id = row.get(id_column)
-    question_id = str(raw_id) if raw_id not in (None, "") else str(row_index)
+    question_id = str(raw_id).strip() if raw_id is not None else ""
+    if not question_id:
+        question_id = str(row_index)
 
     metadata: dict[str, Any] = {}
     explicit_metadata = row.get("metadata")
@@ -340,7 +348,7 @@ def _question_from_mapping(
             metadata[key] = value
 
     return LiveQuestion(
-        question=raw_question.strip(),
+        question=question_text,
         question_id=question_id,
         metadata=metadata,
     )
@@ -414,11 +422,9 @@ def _chat_completion_body(
         messages.append({"role": "system", "content": config.system_prompt})
     messages.append({"role": "user", "content": question.question})
 
-    body: dict[str, Any] = {
-        "model": config.model,
-        "messages": messages,
-    }
-    body.update(config.extra_body)
+    body: dict[str, Any] = dict(config.extra_body)
+    body["model"] = config.model
+    body["messages"] = messages
     return body
 
 

--- a/tests/unit/test_live_collection.py
+++ b/tests/unit/test_live_collection.py
@@ -176,6 +176,7 @@ def test_collect_openai_chat_completions_records_redirect_errors(
 
 def test_collect_openai_chat_completions_retries_row_errors(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     questions_path = tmp_path / "questions.json"
     questions_path.write_text(
@@ -188,6 +189,7 @@ def test_collect_openai_chat_completions_retries_row_errors(
         endpoint_url="https://example.test/v1/chat/completions",
         model="test-model",
         max_retries=1,
+        retry_backoff_seconds=0.5,
     )
     client = StubClient(
         [
@@ -195,12 +197,15 @@ def test_collect_openai_chat_completions_retries_row_errors(
             StubResponse({"choices": [{"message": {"content": "recovered"}}]}),
         ]
     )
+    sleeps: list[float] = []
+    monkeypatch.setattr("evalhub.adapter.live_collection.time.sleep", sleeps.append)
 
     manifest = collect_openai_chat_completions(config, client=client)
 
     assert manifest.completed == 1
     assert manifest.failed == 0
     assert len(client.calls) == 2
+    assert sleeps == [0.5]
 
 
 def test_collect_openai_chat_completions_requires_configured_auth_env(

--- a/tests/unit/test_live_collection.py
+++ b/tests/unit/test_live_collection.py
@@ -1,0 +1,255 @@
+"""Tests for adapter-side live response collection helpers."""
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import pytest
+from evalhub.adapter import (
+    LiveCollectionConfig,
+    collect_live_responses_from_parameters,
+    collect_openai_chat_completions,
+    load_live_questions,
+)
+
+
+class StubResponse:
+    def __init__(
+        self,
+        payload: dict[str, Any] | None = None,
+        *,
+        status_code: int = 200,
+    ) -> None:
+        self.payload = payload or {"choices": [{"message": {"content": "stub answer"}}]}
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 300:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+class StubClient:
+    def __init__(self, responses: list[StubResponse]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    def post(
+        self,
+        url: str,
+        *,
+        json: Mapping[str, Any],
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> StubResponse:
+        self.calls.append(
+            {
+                "url": url,
+                "json": dict(json),
+                "headers": dict(headers),
+                "timeout": timeout,
+            }
+        )
+        return self.responses.pop(0)
+
+
+def test_load_live_questions_from_csv(tmp_path: Path) -> None:
+    questions_path = tmp_path / "questions.csv"
+    questions_path.write_text(
+        "id,question,topic\nq1,What is EvalHub?,sdk\n",
+        encoding="utf-8",
+    )
+
+    questions = load_live_questions(questions_path)
+
+    assert len(questions) == 1
+    assert questions[0].question_id == "q1"
+    assert questions[0].question == "What is EvalHub?"
+    assert questions[0].metadata == {"topic": "sdk"}
+
+
+def test_load_live_questions_from_jsonl(tmp_path: Path) -> None:
+    questions_path = tmp_path / "questions.jsonl"
+    questions_path.write_text(
+        json.dumps(
+            {
+                "id": "row-1",
+                "question": "Summarize the release.",
+                "metadata": {"source": "golden"},
+                "category": "summary",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    questions = load_live_questions(questions_path)
+
+    assert questions[0].question_id == "row-1"
+    assert questions[0].metadata == {
+        "source": "golden",
+        "category": "summary",
+    }
+
+
+def test_collect_openai_chat_completions_writes_jsonl_and_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    questions_path = tmp_path / "questions.csv"
+    questions_path.write_text(
+        "id,question\nq1,What is EvalHub?\nq2,What is BYOF?\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+    monkeypatch.setenv("CHAT_API_KEY", "secret-token")
+    client = StubClient(
+        [
+            StubResponse({"choices": [{"message": {"content": "answer 1"}}]}),
+            StubResponse({"choices": [{"message": {"content": "answer 2"}}]}),
+        ]
+    )
+    config = LiveCollectionConfig(
+        questions_path=questions_path,
+        output_dir=output_dir,
+        endpoint_url="https://example.test/v1/chat/completions",
+        model="test-model",
+        api_key_env="CHAT_API_KEY",
+        system_prompt="Answer briefly.",
+        extra_body={"temperature": 0},
+    )
+
+    manifest = collect_openai_chat_completions(config, client=client)
+
+    assert manifest.total == 2
+    assert manifest.completed == 2
+    assert manifest.failed == 0
+    assert client.calls[0]["headers"]["Authorization"] == "Bearer secret-token"
+    assert client.calls[0]["json"]["model"] == "test-model"
+    assert client.calls[0]["json"]["temperature"] == 0
+    assert client.calls[0]["json"]["messages"] == [
+        {"role": "system", "content": "Answer briefly."},
+        {"role": "user", "content": "What is EvalHub?"},
+    ]
+
+    rows = [
+        json.loads(line)
+        for line in (output_dir / "responses.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert rows[0]["question_id"] == "q1"
+    assert rows[0]["response"] == "answer 1"
+    assert rows[0]["error"] is None
+
+    manifest_data = json.loads((output_dir / "manifest.json").read_text())
+    assert manifest_data["completed"] == 2
+    assert manifest_data["output_path"].endswith("responses.jsonl")
+
+
+def test_collect_openai_chat_completions_records_redirect_errors(
+    tmp_path: Path,
+) -> None:
+    questions_path = tmp_path / "questions.json"
+    questions_path.write_text(
+        json.dumps([{"question": "Will this redirect?"}]),
+        encoding="utf-8",
+    )
+    config = LiveCollectionConfig(
+        questions_path=questions_path,
+        output_dir=tmp_path / "out",
+        endpoint_url="https://example.test/v1/chat/completions",
+        model="test-model",
+    )
+    client = StubClient([StubResponse(status_code=302)])
+
+    manifest = collect_openai_chat_completions(config, client=client)
+
+    assert manifest.completed == 0
+    assert manifest.failed == 1
+    row = json.loads((tmp_path / "out" / "responses.jsonl").read_text())
+    assert "HTTP 302" in row["error"]
+
+
+def test_collect_openai_chat_completions_retries_row_errors(
+    tmp_path: Path,
+) -> None:
+    questions_path = tmp_path / "questions.json"
+    questions_path.write_text(
+        json.dumps([{"question": "Retry this?"}]),
+        encoding="utf-8",
+    )
+    config = LiveCollectionConfig(
+        questions_path=questions_path,
+        output_dir=tmp_path / "out",
+        endpoint_url="https://example.test/v1/chat/completions",
+        model="test-model",
+        max_retries=1,
+    )
+    client = StubClient(
+        [
+            StubResponse(status_code=500),
+            StubResponse({"choices": [{"message": {"content": "recovered"}}]}),
+        ]
+    )
+
+    manifest = collect_openai_chat_completions(config, client=client)
+
+    assert manifest.completed == 1
+    assert manifest.failed == 0
+    assert len(client.calls) == 2
+
+
+def test_collect_openai_chat_completions_requires_configured_auth_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    questions_path = tmp_path / "questions.csv"
+    questions_path.write_text("question\nHello?\n", encoding="utf-8")
+    monkeypatch.delenv("MISSING_CHAT_KEY", raising=False)
+    config = LiveCollectionConfig(
+        questions_path=questions_path,
+        output_dir=tmp_path / "out",
+        endpoint_url="https://example.test/v1/chat/completions",
+        model="test-model",
+        api_key_env="MISSING_CHAT_KEY",
+    )
+
+    with pytest.raises(ValueError, match="MISSING_CHAT_KEY"):
+        collect_openai_chat_completions(config, client=StubClient([]))
+
+
+def test_live_collection_config_rejects_non_http_endpoint(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="endpoint_url"):
+        LiveCollectionConfig(
+            questions_path=tmp_path / "questions.csv",
+            output_dir=tmp_path / "out",
+            endpoint_url="file:///tmp/socket",
+            model="test-model",
+        )
+
+
+def test_collect_live_responses_from_parameters(tmp_path: Path) -> None:
+    questions_path = tmp_path / "questions.csv"
+    questions_path.write_text("question\nHello?\n", encoding="utf-8")
+    client = StubClient(
+        [StubResponse({"choices": [{"message": {"content": "hello"}}]})]
+    )
+
+    manifest = collect_live_responses_from_parameters(
+        {
+            "live_collection": {
+                "questions_path": questions_path,
+                "output_dir": tmp_path / "out",
+                "endpoint_url": "https://example.test/v1/chat/completions",
+                "model": "test-model",
+            }
+        },
+        client=client,
+    )
+
+    assert manifest.total == 1
+    assert manifest.completed == 1

--- a/tests/unit/test_live_collection.py
+++ b/tests/unit/test_live_collection.py
@@ -15,6 +15,8 @@ from evalhub.adapter import (
 
 
 class StubResponse:
+    """Minimal HTTP response stub for live collection tests."""
+
     def __init__(
         self,
         payload: dict[str, Any] | None = None,
@@ -25,15 +27,20 @@ class StubResponse:
         self.status_code = status_code
 
     def raise_for_status(self) -> None:
+        """Raise when the configured status code represents an error."""
         if self.status_code >= 300:
             raise RuntimeError(f"HTTP {self.status_code}")
 
     def json(self) -> dict[str, Any]:
+        """Return the configured JSON payload."""
         return self.payload
 
 
 class StubClient:
+    """Minimal HTTP client stub that records outgoing POST calls."""
+
     def __init__(self, responses: list[StubResponse]) -> None:
+        """Store queued responses returned by subsequent POST calls."""
         self.responses = responses
         self.calls: list[dict[str, Any]] = []
 
@@ -45,6 +52,7 @@ class StubClient:
         headers: Mapping[str, str],
         timeout: float,
     ) -> StubResponse:
+        """Record one POST call and return the next queued response."""
         self.calls.append(
             {
                 "url": url,
@@ -57,6 +65,7 @@ class StubClient:
 
 
 def test_load_live_questions_from_csv(tmp_path: Path) -> None:
+    """Load one CSV question and preserve non-key columns as metadata."""
     questions_path = tmp_path / "questions.csv"
     questions_path.write_text(
         "id,question,topic\nq1,What is EvalHub?,sdk\n",
@@ -72,6 +81,7 @@ def test_load_live_questions_from_csv(tmp_path: Path) -> None:
 
 
 def test_load_live_questions_from_jsonl(tmp_path: Path) -> None:
+    """Load JSONL questions and merge explicit plus row-level metadata."""
     questions_path = tmp_path / "questions.jsonl"
     questions_path.write_text(
         json.dumps(
@@ -96,6 +106,7 @@ def test_load_live_questions_from_jsonl(tmp_path: Path) -> None:
 
 
 def test_load_live_questions_skips_blank_json_and_normalizes_ids(tmp_path: Path) -> None:
+    """Skip blank JSON questions and trim IDs for retained rows."""
     questions_path = tmp_path / "questions.json"
     questions_path.write_text(
         json.dumps(
@@ -115,6 +126,7 @@ def test_load_live_questions_skips_blank_json_and_normalizes_ids(tmp_path: Path)
 
 
 def test_load_live_questions_skips_blank_jsonl_rows(tmp_path: Path) -> None:
+    """Skip blank JSONL questions without aborting the whole load."""
     questions_path = tmp_path / "questions.jsonl"
     questions_path.write_text(
         json.dumps({"id": "", "question": "   "})
@@ -135,6 +147,7 @@ def test_collect_openai_chat_completions_writes_jsonl_and_manifest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Write response rows, manifest data, auth headers, and request payloads."""
     questions_path = tmp_path / "questions.csv"
     questions_path.write_text(
         "id,question\nq1,What is EvalHub?\nq2,What is BYOF?\n",
@@ -189,6 +202,7 @@ def test_collect_openai_chat_completions_writes_jsonl_and_manifest(
 def test_collect_openai_chat_completions_preserves_canonical_request_fields(
     tmp_path: Path,
 ) -> None:
+    """Keep model and messages canonical when extra_body contains overrides."""
     questions_path = tmp_path / "questions.csv"
     questions_path.write_text("question\nWhat is EvalHub?\n", encoding="utf-8")
     client = StubClient([StubResponse()])
@@ -217,6 +231,7 @@ def test_collect_openai_chat_completions_preserves_canonical_request_fields(
 def test_collect_openai_chat_completions_records_redirect_errors(
     tmp_path: Path,
 ) -> None:
+    """Record redirect responses as row errors instead of following them."""
     questions_path = tmp_path / "questions.json"
     questions_path.write_text(
         json.dumps([{"question": "Will this redirect?"}]),
@@ -242,6 +257,7 @@ def test_collect_openai_chat_completions_retries_row_errors(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Retry transient row failures and keep backoff timing observable."""
     questions_path = tmp_path / "questions.json"
     questions_path.write_text(
         json.dumps([{"question": "Retry this?"}]),
@@ -276,6 +292,7 @@ def test_collect_openai_chat_completions_requires_configured_auth_env(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Reject authenticated collection when the configured env var is missing."""
     questions_path = tmp_path / "questions.csv"
     questions_path.write_text("question\nHello?\n", encoding="utf-8")
     monkeypatch.delenv("MISSING_CHAT_KEY", raising=False)
@@ -292,6 +309,7 @@ def test_collect_openai_chat_completions_requires_configured_auth_env(
 
 
 def test_live_collection_config_rejects_non_http_endpoint(tmp_path: Path) -> None:
+    """Require endpoint URLs to use HTTP or HTTPS."""
     with pytest.raises(ValueError, match="endpoint_url"):
         LiveCollectionConfig(
             questions_path=tmp_path / "questions.csv",
@@ -302,6 +320,7 @@ def test_live_collection_config_rejects_non_http_endpoint(tmp_path: Path) -> Non
 
 
 def test_collect_live_responses_from_parameters(tmp_path: Path) -> None:
+    """Build config from adapter parameters and collect one response."""
     questions_path = tmp_path / "questions.csv"
     questions_path.write_text("question\nHello?\n", encoding="utf-8")
     client = StubClient(

--- a/tests/unit/test_live_collection.py
+++ b/tests/unit/test_live_collection.py
@@ -95,6 +95,42 @@ def test_load_live_questions_from_jsonl(tmp_path: Path) -> None:
     }
 
 
+def test_load_live_questions_skips_blank_json_and_normalizes_ids(tmp_path: Path) -> None:
+    questions_path = tmp_path / "questions.json"
+    questions_path.write_text(
+        json.dumps(
+            [
+                {"id": "  ", "question": "   "},
+                {"id": "  row-2  ", "question": "  Summarize this.  "},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    questions = load_live_questions(questions_path)
+
+    assert len(questions) == 1
+    assert questions[0].question_id == "row-2"
+    assert questions[0].question == "Summarize this."
+
+
+def test_load_live_questions_skips_blank_jsonl_rows(tmp_path: Path) -> None:
+    questions_path = tmp_path / "questions.jsonl"
+    questions_path.write_text(
+        json.dumps({"id": "", "question": "   "})
+        + "\n"
+        + json.dumps({"id": "row-2", "question": "Keep this one"})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    questions = load_live_questions(questions_path)
+
+    assert len(questions) == 1
+    assert questions[0].question_id == "row-2"
+    assert questions[0].question == "Keep this one"
+
+
 def test_collect_openai_chat_completions_writes_jsonl_and_manifest(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -148,6 +184,34 @@ def test_collect_openai_chat_completions_writes_jsonl_and_manifest(
     manifest_data = json.loads((output_dir / "manifest.json").read_text())
     assert manifest_data["completed"] == 2
     assert manifest_data["output_path"].endswith("responses.jsonl")
+
+
+def test_collect_openai_chat_completions_preserves_canonical_request_fields(
+    tmp_path: Path,
+) -> None:
+    questions_path = tmp_path / "questions.csv"
+    questions_path.write_text("question\nWhat is EvalHub?\n", encoding="utf-8")
+    client = StubClient([StubResponse()])
+    config = LiveCollectionConfig(
+        questions_path=questions_path,
+        output_dir=tmp_path / "out",
+        endpoint_url="https://example.test/v1/chat/completions",
+        model="test-model",
+        extra_body={
+            "model": "wrong-model",
+            "messages": [{"role": "user", "content": "wrong prompt"}],
+            "temperature": 0,
+        },
+    )
+
+    manifest = collect_openai_chat_completions(config, client=client)
+
+    assert manifest.completed == 1
+    assert client.calls[0]["json"]["model"] == "test-model"
+    assert client.calls[0]["json"]["messages"] == [
+        {"role": "user", "content": "What is EvalHub?"},
+    ]
+    assert client.calls[0]["json"]["temperature"] == 0
 
 
 def test_collect_openai_chat_completions_records_redirect_errors(


### PR DESCRIPTION
## What and why

Closes #135

Adds an experimental adapter-side live response collection helper that adapters can call during `JobPhase.LOADING_DATA` while the longer-term API shape is still being decided.

The helper:

- reads questions from CSV, JSON, or JSONL inputs
- calls an OpenAI-compatible `/v1/chat/completions` endpoint
- writes `responses.jsonl` plus `manifest.json` for evaluation framework loaders
- records per-row request failures instead of aborting the whole collection run
- keeps `httpx` optional via lazy import and supports dependency injection for tests
- documents the trusted-submitter boundary for endpoint URLs, request headers, and `api_key_env`

## Type

- [x] feat
- [ ] fix
- [x] docs
- [ ] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

Commands run:

```powershell
uv run ruff check src/evalhub/adapter/live_collection.py src/evalhub/adapter/__init__.py tests/unit/test_live_collection.py
uv run mypy src/evalhub/adapter/live_collection.py tests/unit/test_live_collection.py
uv run pytest tests/unit/test_live_collection.py -q
uv run pytest tests/unit/test_adapter_models.py tests/unit/test_live_collection.py -q
```

I also ran the full unit suite after `uv sync --extra cli --extra mcp --group dev`; it reached `492 passed` with 2 failures in `tests/unit/test_cli_config.py` that assert POSIX owner-only permission bits on Windows.

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental live response collection adapter to capture chatbot/RAG responses during data-loading jobs; produces per-item response records and a manifest summary.

* **Documentation**
  * Added README section with usage examples, configuration schema, behavior notes (no redirect following, per-row failure recording, capped retry backoff), and output file descriptions (responses.jsonl, manifest.json).

* **Public API**
  * Exposed live-collection helpers and models as part of the adapter package.

* **Tests**
  * Added unit tests for input formats, retry/error handling, outputs, and config validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->