### PR TITLE
feat(sdk): add agent metadata to Provider and Benchmark models

### DIFF
--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -974,6 +974,12 @@ def providers_list(ctx: click.Context, output_format: str) -> None:
     """
     client = get_client(ctx)
     items = client.providers.list()
+    if output_format in ("json", "yaml"):
+        output(
+            [p.model_dump(mode="json") for p in items],
+            output_format=output_format,
+        )
+        return
     rows = [
         {
             "id": p.resource.id,

--- a/src/evalhub/client/resources/providers.py
+++ b/src/evalhub/client/resources/providers.py
@@ -16,10 +16,18 @@ class AsyncProvidersResource:
     def __init__(self, client: BaseAsyncClient):
         self._client = client
 
-    async def list(self, *, tenant: str | None = None) -> list[Provider]:
+    async def list(
+        self,
+        *,
+        target_type: str | None = None,
+        evaluates: str | None = None,
+        tenant: str | None = None,
+    ) -> list[Provider]:
         """List all registered providers.
 
         Args:
+            target_type: Filter by agent target type (e.g. "model", "agent", "inference_server")
+            evaluates: Filter to providers whose agent evaluates this capability
             tenant: Tenant override for this request (default: client-level tenant)
 
         Returns:
@@ -33,7 +41,12 @@ class AsyncProvidersResource:
         )
         data = response.json()
         provider_list = ProviderList(**data)
-        return provider_list.items
+        items = provider_list.items
+        if target_type:
+            items = [p for p in items if p.agent and p.agent.target_type == target_type]
+        if evaluates:
+            items = [p for p in items if p.agent and evaluates in p.agent.evaluates]
+        return items
 
     async def get(self, provider_id: str, *, tenant: str | None = None) -> Provider:
         """Get information about a specific provider.
@@ -92,10 +105,18 @@ class SyncProvidersResource:
     def __init__(self, client: BaseSyncClient):
         self._client = client
 
-    def list(self, *, tenant: str | None = None) -> list[Provider]:
+    def list(
+        self,
+        *,
+        target_type: str | None = None,
+        evaluates: str | None = None,
+        tenant: str | None = None,
+    ) -> list[Provider]:
         """List all registered providers.
 
         Args:
+            target_type: Filter by agent target type (e.g. "model", "agent", "inference_server")
+            evaluates: Filter to providers whose agent evaluates this capability
             tenant: Tenant override for this request (default: client-level tenant)
 
         Returns:
@@ -107,7 +128,12 @@ class SyncProvidersResource:
         response = self._client._request_get("/evaluations/providers", tenant=tenant)
         data = response.json()
         provider_list = ProviderList(**data)
-        return provider_list.items
+        items = provider_list.items
+        if target_type:
+            items = [p for p in items if p.agent and p.agent.target_type == target_type]
+        if evaluates:
+            items = [p for p in items if p.agent and evaluates in p.agent.evaluates]
+        return items
 
     def get(self, provider_id: str, *, tenant: str | None = None) -> Provider:
         """Get information about a specific provider.

--- a/src/evalhub/models/__init__.py
+++ b/src/evalhub/models/__init__.py
@@ -1,7 +1,9 @@
 """EvalHub SDK Models - Standard request/response models for framework adapters."""
 
 from .api import (
+    AgentMetadata,
     Benchmark,
+    BenchmarkAgentMetadata,
     BenchmarkConfig,
     BenchmarkInfo,
     BenchmarkReference,
@@ -43,6 +45,7 @@ from .api import (
     QueueConfig,
     Resource,
     S3TestDataRef,
+    ScoreRange,
     TestDataRef,
 )
 
@@ -67,6 +70,9 @@ __all__ = [
     "ExperimentTag",
     "ExperimentConfig",
     # Provider & Benchmark models
+    "AgentMetadata",
+    "BenchmarkAgentMetadata",
+    "ScoreRange",
     "Provider",
     "ProviderCreateRequest",
     "ProviderList",

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -619,6 +619,32 @@ class PassCriteria(BaseModel):
     threshold: float = Field(..., description="Threshold value for passing")
 
 
+class ScoreRange(BaseModel):
+    """A score band with semantic meaning."""
+
+    range: str = Field(..., description="Score range (e.g. '0-50')")
+    meaning: str = Field(..., description="Human-readable meaning of this band")
+
+
+class BenchmarkAgentMetadata(BaseModel):
+    """Agent-consumption metadata at the benchmark level."""
+
+    result_interpretation: str | None = Field(default=None)
+    score_ranges: list[ScoreRange] = Field(default_factory=list)
+
+
+class AgentMetadata(BaseModel):
+    """Agent-consumption metadata at the provider level."""
+
+    evaluates: list[str] = Field(default_factory=list)
+    recommended_when: list[str] = Field(default_factory=list)
+    target_type: str | None = Field(default=None)
+    summary: str | None = Field(default=None)
+    complements: list[str] = Field(default_factory=list)
+    hints: list[str] = Field(default_factory=list)
+    result_interpretation: list[str] = Field(default_factory=list)
+
+
 class Benchmark(BaseModel):
     """Benchmark information from EvalHub API."""
 
@@ -635,6 +661,7 @@ class Benchmark(BaseModel):
         None, description="Primary score configuration"
     )
     pass_criteria: PassCriteria | None = Field(None, description="Pass/fail criteria")
+    agent: BenchmarkAgentMetadata | None = Field(default=None)
 
 
 class BenchmarksList(BaseModel):
@@ -661,6 +688,7 @@ class Provider(BaseModel):
     benchmarks: list[Benchmark] = Field(
         default_factory=list, description="Benchmarks supported by this provider"
     )
+    agent: AgentMetadata | None = Field(default=None)
 
 
 class ProviderList(BaseModel):

--- a/tests/unit/test_cli_providers.py
+++ b/tests/unit/test_cli_providers.py
@@ -12,7 +12,14 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from evalhub.cli.main import main
-from evalhub.models.api import Benchmark, PassCriteria, PrimaryScore, Provider, Resource
+from evalhub.models.api import (
+    AgentMetadata,
+    Benchmark,
+    PassCriteria,
+    PrimaryScore,
+    Provider,
+    Resource,
+)
 
 
 def _make_provider(
@@ -20,12 +27,14 @@ def _make_provider(
     name: str = "LM Evaluation Harness",
     description: str = "Language model evaluation framework",
     benchmarks: list | None = None,
+    agent: AgentMetadata | None = None,
 ) -> Provider:
     return Provider(
         resource=Resource(id=id),
         name=name,
         description=description,
         benchmarks=benchmarks or [],
+        agent=agent,
     )
 
 
@@ -103,7 +112,8 @@ class TestProvidersList:
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         assert len(parsed) == 1
-        assert parsed[0]["id"] == "lm_eval"
+        assert parsed[0]["resource"]["id"] == "lm_eval"
+        assert "agent" in parsed[0]
 
     def test_list_yaml_format(
         self, runner: CliRunner, config_file: Path, mock_client: MagicMock
@@ -115,7 +125,31 @@ class TestProvidersList:
             result = runner.invoke(main, ["providers", "list", "--format", "yaml"])
         assert result.exit_code == 0
         parsed = yaml.safe_load(result.output)
-        assert parsed[0]["id"] == "garak"
+        assert parsed[0]["resource"]["id"] == "garak"
+        assert "agent" in parsed[0]
+
+    def test_list_json_includes_agent_metadata(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        agent = AgentMetadata(
+            evaluates=["reasoning", "knowledge"],
+            recommended_when=["general LLM evaluation"],
+            target_type="llm",
+            summary="Broad benchmark suite",
+            complements=["garak"],
+            hints=["use with mmlu for knowledge tasks"],
+            result_interpretation=["higher is better"],
+        )
+        mock_client.providers.list.return_value = [
+            _make_provider(id="lm_eval", name="LM Eval", agent=agent),
+        ]
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(main, ["providers", "list", "--format", "json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed[0]["agent"]["target_type"] == "llm"
+        assert parsed[0]["agent"]["summary"] == "Broad benchmark suite"
+        assert parsed[0]["agent"]["evaluates"] == ["reasoning", "knowledge"]
 
     def test_list_csv_format(
         self, runner: CliRunner, config_file: Path, mock_client: MagicMock

--- a/tests/unit/test_evalhub_client.py
+++ b/tests/unit/test_evalhub_client.py
@@ -28,6 +28,9 @@ from evalhub.client.base import (
     BaseSyncClient,
 )
 from evalhub.models.api import (
+    AgentMetadata,
+    Benchmark,
+    BenchmarkAgentMetadata,
     BenchmarkConfig,
     CollectionRef,
     EvaluationExports,
@@ -38,6 +41,9 @@ from evalhub.models.api import (
     ModelConfig,
     OCIConnectionConfig,
     OCICoordinates,
+    Provider,
+    Resource,
+    ScoreRange,
 )
 
 # Environment variable to enable real server testing
@@ -461,3 +467,161 @@ class TestEvalHubClient:
             with patch.object(client, "_request", return_value=mock_response):
                 health = await client.health()
                 assert health["status"] == "healthy"
+
+
+class TestAgentMetadataModels:
+    """Unit tests for agent-discoverability model round-trips."""
+
+    def test_provider_agent_metadata_round_trip(self) -> None:
+        data: dict[str, Any] = {
+            "resource": {"id": "test"},
+            "name": "Test Provider",
+            "agent": {
+                "evaluates": ["data-ingestion", "metrics-reporting"],
+                "recommended_when": ["User wants to validate the pipeline"],
+                "target_type": "model",
+                "summary": "Validate the EvalHub pipeline",
+                "complements": [],
+                "hints": ["Requires JSON data mounted at /data"],
+                "result_interpretation": ["row_count: number of records"],
+            },
+        }
+        provider = Provider(**data)
+        assert provider.agent is not None
+        assert provider.agent.target_type == "model"
+        assert provider.agent.evaluates == ["data-ingestion", "metrics-reporting"]
+        assert provider.agent.hints == ["Requires JSON data mounted at /data"]
+        assert provider.agent.result_interpretation == ["row_count: number of records"]
+
+    def test_provider_without_agent_defaults_to_none(self) -> None:
+        provider = Provider(resource=Resource(id="p"), name="P")
+        assert provider.agent is None
+
+    def test_benchmark_agent_metadata_round_trip(self) -> None:
+        data: dict[str, Any] = {
+            "id": "datafile",
+            "name": "Datafile",
+            "category": "general",
+            "agent": {
+                "result_interpretation": "row_count shows records read",
+                "score_ranges": [
+                    {"range": "0-50", "meaning": "Low data volume"},
+                    {"range": "51-100", "meaning": "Expected range"},
+                ],
+            },
+        }
+        benchmark = Benchmark(**data)
+        assert benchmark.agent is not None
+        assert benchmark.agent.result_interpretation == "row_count shows records read"
+        assert len(benchmark.agent.score_ranges) == 2
+        assert benchmark.agent.score_ranges[0].range == "0-50"
+        assert benchmark.agent.score_ranges[0].meaning == "Low data volume"
+        assert benchmark.agent.score_ranges[1].range == "51-100"
+
+    def test_benchmark_without_agent_defaults_to_none(self) -> None:
+        benchmark = Benchmark(
+            id="b", name="B", category="general", primary_score=None, pass_criteria=None
+        )
+        assert benchmark.agent is None
+
+    def test_score_range_model(self) -> None:
+        sr = ScoreRange(range="0-100", meaning="full scale")
+        assert sr.range == "0-100"
+        assert sr.meaning == "full scale"
+
+    def test_benchmark_agent_metadata_empty_score_ranges(self) -> None:
+        bam = BenchmarkAgentMetadata(result_interpretation="some text")
+        assert bam.score_ranges == []
+
+    def test_agent_metadata_defaults(self) -> None:
+        am = AgentMetadata()
+        assert am.evaluates == []
+        assert am.recommended_when == []
+        assert am.target_type is None
+        assert am.summary is None
+        assert am.complements == []
+        assert am.hints == []
+        assert am.result_interpretation == []
+
+
+class TestProvidersListFiltering:
+    """Unit tests for client-side filtering in providers.list()."""
+
+    def _make_providers_response(self) -> dict:
+        return {
+            "total_count": 3,
+            "items": [
+                {
+                    "resource": {"id": "test"},
+                    "name": "Test",
+                    "agent": {
+                        "target_type": "model",
+                        "evaluates": ["data-ingestion", "metrics-reporting"],
+                    },
+                },
+                {
+                    "resource": {"id": "garak"},
+                    "name": "Garak",
+                    "agent": {
+                        "target_type": "agent",
+                        "evaluates": ["safety"],
+                    },
+                },
+                {
+                    "resource": {"id": "ragas"},
+                    "name": "RAGAS",
+                },
+            ],
+        }
+
+    def test_list_no_filter_returns_all(self) -> None:
+        with SyncEvalHubClient() as client:
+            mock_resp = Mock()
+            mock_resp.json.return_value = self._make_providers_response()
+            with patch.object(client, "_request_get", return_value=mock_resp):
+                result = client.providers.list()
+        assert len(result) == 3
+
+    def test_list_filter_by_target_type_model(self) -> None:
+        with SyncEvalHubClient() as client:
+            mock_resp = Mock()
+            mock_resp.json.return_value = self._make_providers_response()
+            with patch.object(client, "_request_get", return_value=mock_resp):
+                result = client.providers.list(target_type="model")
+        assert len(result) == 1
+        assert result[0].resource.id == "test"
+
+    def test_list_filter_by_target_type_agent(self) -> None:
+        with SyncEvalHubClient() as client:
+            mock_resp = Mock()
+            mock_resp.json.return_value = self._make_providers_response()
+            with patch.object(client, "_request_get", return_value=mock_resp):
+                result = client.providers.list(target_type="agent")
+        assert len(result) == 1
+        assert result[0].resource.id == "garak"
+
+    def test_list_filter_by_evaluates(self) -> None:
+        with SyncEvalHubClient() as client:
+            mock_resp = Mock()
+            mock_resp.json.return_value = self._make_providers_response()
+            with patch.object(client, "_request_get", return_value=mock_resp):
+                result = client.providers.list(evaluates="data-ingestion")
+        assert len(result) == 1
+        assert result[0].resource.id == "test"
+
+    def test_list_filter_by_evaluates_no_match(self) -> None:
+        with SyncEvalHubClient() as client:
+            mock_resp = Mock()
+            mock_resp.json.return_value = self._make_providers_response()
+            with patch.object(client, "_request_get", return_value=mock_resp):
+                result = client.providers.list(evaluates="hallucination")
+        assert result == []
+
+    def test_list_filter_excludes_providers_without_agent(self) -> None:
+        with SyncEvalHubClient() as client:
+            mock_resp = Mock()
+            mock_resp.json.return_value = self._make_providers_response()
+            with patch.object(client, "_request_get", return_value=mock_resp):
+                result = client.providers.list(target_type="model")
+        ids = [p.resource.id for p in result]
+        assert "ragas" not in ids


### PR DESCRIPTION
## What and why

Adds agent-discoverability metadata (`AgentMetadata`, `BenchmarkAgentMetadata`, `ScoreRange`) to the `Provider` and `Benchmark` models, so AI agents and tooling can reason about which providers to use for a given task.

The `providers list` CLI command now includes the full provider payload (including `agent`) when `--format json` or `--format yaml` is used. Table and CSV output are unchanged.

The `providers.list()` client method gains optional `target_type` and `evaluates` filters for client-side filtering on agent metadata.

Closes [RHOAIENG-60131](https://redhat.atlassian.net/browse/RHOAIENG-60131)

## Type

- [x] feat

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

`evalhub providers list --format json` and `--format yaml` now emit the full provider object (matching `providers describe` output) instead of the previous flat summary dict. Callers that parsed `.[].id` must update to `.[].resource.id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* `providers list` command now supports JSON and YAML structured output formats for programmatic integration
* Provider resources can be filtered by target type and evaluation capabilities through optional parameters
* Providers and benchmarks now include enriched agent metadata describing evaluation targets, capabilities, and result interpretation guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->