### PR TITLE
feat(models): add JobPhase to client-side models and CLI display

### DIFF
--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -6,13 +6,18 @@ import json
 import warnings
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
-from enum import Enum
 from pathlib import Path
 from typing import Any, Self
 
 from pydantic import BaseModel, Field, model_validator
 
-from ...models.api import EvaluationResult, JobStatus, ModelConfig, OCICoordinates
+from ...models.api import (
+    EvaluationResult,
+    JobPhase,
+    JobStatus,
+    ModelConfig,
+    OCICoordinates,
+)
 from .cards import EnvironmentCardMetadata, EvalCardMetadata
 
 
@@ -34,17 +39,6 @@ class ErrorInfo(BaseModel):
 
     message: str = Field(..., description="Error message")
     message_code: str = Field(..., description="Error code identifier")
-
-
-class JobPhase(str, Enum):
-    """Job execution phases."""
-
-    INITIALIZING = "initializing"
-    LOADING_DATA = "loading_data"
-    RUNNING_EVALUATION = "running_evaluation"
-    POST_PROCESSING = "post_processing"
-    PERSISTING_ARTIFACTS = "persisting_artifacts"
-    COMPLETED = "completed"
 
 
 class JobSpec(BaseModel):

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -578,10 +578,10 @@ def _watch_job(client: Any, job_id: str, poll_interval: float) -> None:
         benchmarks_status = ""
         if job.status and job.status.benchmarks:
             done = sum(1 for b in job.status.benchmarks if b.state in terminal)
-            phases = [
-                b.phase.value for b in job.status.benchmarks if b.phase is not None
-            ]
-            phase_info = f" phase={phases[0]}" if len(phases) == 1 else ""
+            phases = {b.phase for b in job.status.benchmarks if b.phase}
+            phase_info = (
+                f" phase={next(iter(phases)).value}" if len(phases) == 1 else ""
+            )
             benchmarks_status = (
                 f" [{done}/{len(job.status.benchmarks)} benchmarks{phase_info}]"
             )

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -578,7 +578,13 @@ def _watch_job(client: Any, job_id: str, poll_interval: float) -> None:
         benchmarks_status = ""
         if job.status and job.status.benchmarks:
             done = sum(1 for b in job.status.benchmarks if b.state in terminal)
-            benchmarks_status = f" [{done}/{len(job.status.benchmarks)} benchmarks]"
+            phases = [
+                b.phase.value for b in job.status.benchmarks if b.phase is not None
+            ]
+            phase_info = f" phase={phases[0]}" if len(phases) == 1 else ""
+            benchmarks_status = (
+                f" [{done}/{len(job.status.benchmarks)} benchmarks{phase_info}]"
+            )
         click.echo(
             f"\r{job.id}: {job.effective_state.value}{benchmarks_status}", nl=False
         )
@@ -604,6 +610,8 @@ def _print_job_detail(job: Any) -> None:
         click.echo(f"\nBenchmarks ({len(job.status.benchmarks)}):")
         for b in job.status.benchmarks:
             line = f"  {b.id} ({b.provider_id}): {b.state.value}"
+            if b.phase:
+                line += f" [{b.phase.value}]"
             if b.error_message:
                 line += f" - {b.error_message.message}"
             click.echo(line)

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 import sys
 import time
 from datetime import UTC, datetime, timedelta
@@ -577,17 +578,15 @@ def _watch_job(client: Any, job_id: str, poll_interval: float) -> None:
         job = client.jobs.get(job_id)
         benchmarks_status = ""
         if job.status and job.status.benchmarks:
-            done = sum(1 for b in job.status.benchmarks if b.state in terminal)
-            phases = {b.phase for b in job.status.benchmarks if b.phase}
-            phase_info = (
-                f" phase={next(iter(phases)).value}" if len(phases) == 1 else ""
-            )
-            benchmarks_status = (
-                f" [{done}/{len(job.status.benchmarks)} benchmarks{phase_info}]"
-            )
-        click.echo(
-            f"\r{job.id}: {job.effective_state.value}{benchmarks_status}", nl=False
-        )
+            benchmarks = job.status.benchmarks
+            done = sum(1 for b in benchmarks if b.state in terminal)
+            phase_info = ""
+            if len(benchmarks) == 1 and benchmarks[0].phase:
+                phase_info = f" phase={benchmarks[0].phase.value}"
+            benchmarks_status = f" [{done}/{len(benchmarks)} benchmarks{phase_info}]"
+        line = f"{job.id}: {job.effective_state.value}{benchmarks_status}"
+        cols = shutil.get_terminal_size().columns
+        click.echo(f"\r{line:<{cols}}", nl=False)
         sys.stdout.flush()
         if job.effective_state in terminal:
             click.echo()

--- a/src/evalhub/models/__init__.py
+++ b/src/evalhub/models/__init__.py
@@ -31,6 +31,7 @@ from .api import (
     FrameworkInfo,
     HealthResponse,
     # Status and metadata
+    JobPhase,
     JobsList,
     JobStatus,
     JobSubmissionRequest,
@@ -51,6 +52,7 @@ from .api import (
 
 __all__ = [
     # Job & Evaluation models
+    "JobPhase",
     "JobStatus",
     "EvaluationExports",
     "EvaluationExportsOCI",

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -36,6 +36,21 @@ class EvaluationStatus(str, Enum):
     CANCELLED = "cancelled"
 
 
+class JobPhase(str, Enum):
+    """Job execution phases.
+
+    Represents the granular execution phase within a running benchmark job.
+    Sent by adapters via status events and surfaced in server responses.
+    """
+
+    INITIALIZING = "initializing"
+    LOADING_DATA = "loading_data"
+    RUNNING_EVALUATION = "running_evaluation"
+    POST_PROCESSING = "post_processing"
+    PERSISTING_ARTIFACTS = "persisting_artifacts"
+    COMPLETED = "completed"
+
+
 class ErrorInfo(BaseModel):
     """Error information with message and code.
 
@@ -180,6 +195,9 @@ class BenchmarkStatus(BaseModel):
     provider_id: str = Field(..., description="Provider identifier")
     benchmark_index: int | None = Field(default=None, description="Benchmark index")
     status: JobStatus = Field(..., description="Benchmark status")
+    phase: JobPhase | None = Field(
+        default=None, description="Current execution phase of the benchmark job"
+    )
     error_message: MessageInfo | None = Field(default=None, description="Error message")
     started_at: datetime | None = Field(
         default=None, description="When benchmark started"

--- a/tests/unit/test_cli_eval.py
+++ b/tests/unit/test_cli_eval.py
@@ -688,6 +688,27 @@ class TestEvalStatus:
         assert "running" in result.output
         assert "llama3" in result.output
 
+    def test_single_job_detail_with_phase(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        from evalhub.models.api import JobPhase
+
+        mock_client.jobs.get.return_value = _make_job(
+            state=JobStatus.RUNNING,
+            benchmark_statuses=[
+                BenchmarkStatus(
+                    id="mmlu",
+                    provider_id="lm_eval",
+                    status=JobStatus.RUNNING,
+                    phase=JobPhase.RUNNING_EVALUATION,
+                ),
+            ],
+        )
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(main, ["eval", "status", "eval-123"])
+        assert result.exit_code == 0
+        assert "running_evaluation" in result.output
+
     def test_single_job_json(
         self, runner: CliRunner, config_file: Path, mock_client: MagicMock
     ) -> None:

--- a/tests/unit/test_models_api.py
+++ b/tests/unit/test_models_api.py
@@ -1100,3 +1100,97 @@ class TestQueueConfig:
         )
         assert req.queue is None
         assert "queue" not in req.model_dump(exclude_none=True)
+
+
+class TestBenchmarkStatusPhase:
+    """Test cases for JobPhase support on BenchmarkStatus."""
+
+    def test_benchmark_status_without_phase(self) -> None:
+        """BenchmarkStatus should default phase to None for backward compat."""
+        from evalhub.models.api import BenchmarkStatus
+
+        status = BenchmarkStatus(
+            id="mmlu",
+            provider_id="lm_eval",
+            status=JobStatus.RUNNING,
+        )
+        assert status.phase is None
+
+    def test_benchmark_status_with_phase(self) -> None:
+        """BenchmarkStatus should accept and expose a JobPhase value."""
+        from evalhub.models.api import BenchmarkStatus, JobPhase
+
+        status = BenchmarkStatus(
+            id="mmlu",
+            provider_id="lm_eval",
+            status=JobStatus.RUNNING,
+            phase=JobPhase.RUNNING_EVALUATION,
+        )
+        assert status.phase == JobPhase.RUNNING_EVALUATION
+        assert status.phase.value == "running_evaluation"
+
+    def test_benchmark_status_phase_from_json(self) -> None:
+        """BenchmarkStatus should deserialize phase from raw JSON (server response)."""
+        from evalhub.models.api import BenchmarkStatus, JobPhase
+
+        data: dict[str, Any] = {
+            "id": "mmlu",
+            "provider_id": "lm_eval",
+            "status": "running",
+            "phase": "loading_data",
+        }
+        status = BenchmarkStatus(**data)
+        assert status.phase == JobPhase.LOADING_DATA
+
+    def test_benchmark_status_phase_serializes(self) -> None:
+        """BenchmarkStatus should serialize phase in model_dump output."""
+        from evalhub.models.api import BenchmarkStatus, JobPhase
+
+        status = BenchmarkStatus(
+            id="mmlu",
+            provider_id="lm_eval",
+            status=JobStatus.RUNNING,
+            phase=JobPhase.POST_PROCESSING,
+        )
+        data = status.model_dump(mode="json")
+        assert data["phase"] == "post_processing"
+
+    def test_benchmark_status_phase_excluded_when_none(self) -> None:
+        """Phase should be absent from exclude_none dumps when unset."""
+        from evalhub.models.api import BenchmarkStatus
+
+        status = BenchmarkStatus(
+            id="mmlu",
+            provider_id="lm_eval",
+            status=JobStatus.RUNNING,
+        )
+        data = status.model_dump(exclude_none=True)
+        assert "phase" not in data
+
+    def test_job_phase_enum_values(self) -> None:
+        """Verify all expected JobPhase values exist in the common models."""
+        from evalhub.models.api import JobPhase
+
+        expected = {
+            "initializing",
+            "loading_data",
+            "running_evaluation",
+            "post_processing",
+            "persisting_artifacts",
+            "completed",
+        }
+        actual = {p.value for p in JobPhase}
+        assert actual == expected
+
+    def test_job_phase_importable_from_models_package(self) -> None:
+        """JobPhase should be importable from evalhub.models."""
+        from evalhub.models import JobPhase
+
+        assert JobPhase.RUNNING_EVALUATION.value == "running_evaluation"
+
+    def test_adapter_job_phase_is_same_as_common(self) -> None:
+        """Adapter JobPhase should be the same class as the common models JobPhase."""
+        from evalhub.adapter.models import JobPhase as AdapterJobPhase
+        from evalhub.models import JobPhase as CommonJobPhase
+
+        assert AdapterJobPhase is CommonJobPhase

--- a/tests/unit/test_models_api.py
+++ b/tests/unit/test_models_api.py
@@ -1127,7 +1127,6 @@ class TestBenchmarkStatusPhase:
             phase=JobPhase.RUNNING_EVALUATION,
         )
         assert status.phase == JobPhase.RUNNING_EVALUATION
-        assert status.phase.value == "running_evaluation"
 
     def test_benchmark_status_phase_from_json(self) -> None:
         """BenchmarkStatus should deserialize phase from raw JSON (server response)."""


### PR DESCRIPTION
## What and why

JobPhase are now part of sdk-client core (already delivered https://github.com/eval-hub/eval-hub-sdk/pull/138). The server supports updating phase of job with /events endpoint https://github.com/eval-hub/eval-hub/pull/664 . 
We now are addressing CLI support for it.

Closes # https://redhat.atlassian.net/browse/RHOAIENG-67571

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

`evalhub eval status $JOB_ID`

Example:
```
╰─➤  evalhub eval status $JOB_ID
Job:     7510e942-fab1-4b56-934f-f439da1bf406
Name:    byof-job1
State:   running
Model:   llama3.2:3b-instruct-q4_K_M (http://localhost:11434/v1)
Created: 2026-06-19 06:11:24+00:00

Benchmarks (1):
  my-benchmark (e16e7c7a-9920-4295-89bf-f86570f9315f): running [persisting_artifacts]

Message: Evaluation job is running
```

Example 2:
```
╰─➤  evalhub eval status $JOB_ID --format json
[
  {
    "resource": {
      "id": "7510e942-fab1-4b56-934f-f439da1bf406",
      "tenant": null,
      "created_at": "2026-06-19T06:11:24Z",
      "updated_at": "2026-06-19T06:12:44Z",
      "mlflow_experiment_id": null,
      "message": null
    },
    "status": {
      "state": "running",
      "message": {
        "message": "Evaluation job is running",
        "message_code": "evaluation_job_updated"
      },
      "benchmarks": [
        {
          "id": "my-benchmark",
          "provider_id": "e16e7c7a-9920-4295-89bf-f86570f9315f",
          "benchmark_index": 0,
          "status": "running",
          "phase": "persisting_artifacts",
          "error_message": null,
          "started_at": null,
          "completed_at": null
        }
      ]
    },
    "results": {
      "benchmarks": [],
      "mlflow_experiment_url": null
    },
    "name": "byof-job1",
    "description": null,
    "tags": [],
    "model": {
      "url": "http://localhost:11434/v1",
      "name": "llama3.2:3b-instruct-q4_K_M",
      "auth": null
    },
    "benchmarks": [
      {
        "id": "my-benchmark",
        "provider_id": "e16e7c7a-9920-4295-89bf-f86570f9315f",
        "parameters": {
          "num_examples": 10,
          "num_few_shot": 0
        },
        "test_data_ref": null
      }
    ],
    "collection": null,
    "experiment": null,
    "exports": null,
    "queue": null
  }
]
```


For multiple benchmarks. it will look like:
```
(local-blog) ╭─gnaulak@gnaulak-mac ~/workspace/worktrees/local-blog  ‹main*›
╰─➤  evalhub eval status $JOB_ID
Job:     04d773db-f15a-4bc1-afe1-bc4b86b42960
Name:    byof-job1
State:   running
Model:   llama3.2:3b-instruct-q4_K_M (http://localhost:11434/v1)
Created: 2026-06-19 08:53:01+00:00

Benchmarks (3):
  my-benchmark-1 (7a8b25fc-3373-4f31-9a0a-caaf02f5c48b): running [initializing]
  my-benchmark-2 (7a8b25fc-3373-4f31-9a0a-caaf02f5c48b): running [initializing]
  my-benchmark-3 (7a8b25fc-3373-4f31-9a0a-caaf02f5c48b): running [initializing]

Message: Evaluation job is running
```

With "--watch" mode, the phase will be presented only if there is a `single` benchmark
```
╰─➤  evalhub eval status $JOB_ID --watch
eb92a593-e387-4b7c-9af4-bfea693eb727: running [0/1 benchmarks phase=initializing]
```
```
╰─➤  evalhub eval status $JOB_ID --watch
eb92a593-e387-4b7c-9af4-bfea693eb727: running [0/1 benchmarks phase=loading_data]
```
and so on

If there are multiple .. it does not show the phases. This is by designed. (We could add all the phases against the benchmarks as comma separated values, however, it could potentially be a long list). To be revisited in a fresh PR on this.

With `--watch` for multiple benchmark
```
(local-blog) ╭─gnaulak@gnaulak-mac ~/workspace/worktrees/local-blog  ‹main*›
╰─➤  evalhub eval status $JOB_ID --watch
04d773db-f15a-4bc1-afe1-bc4b86b42960: running [0/3 benchmarks]
```

## Breaking changes

No

**JobPhase already available from: `from evalhub.adapter import JobPhase` (if there are adapter written by end user importing `from evalhub.adapter.models.jobs` Which they should not but could, then , it could potentially break) . Crossed checked contrib adapters, lm-eval-harness and garak on ODH. All are good there