### PR TITLE
feat(cli): add TLS config keys to evalhub config set 

### DIFF
--- a/src/evalhub/cli/client.py
+++ b/src/evalhub/cli/client.py
@@ -36,6 +36,7 @@ def create_client(
     tenant = prof.get("tenant")
     insecure = cfg.parse_bool(prof.get("insecure"))
     timeout = float(prof.get("timeout", 30.0))
+    ca_bundle_path = prof.get("ca_bundle_path")
 
     return SyncEvalHubClient(
         base_url=resolved_url,
@@ -43,6 +44,7 @@ def create_client(
         tenant=tenant,
         insecure=insecure,
         timeout=timeout,
+        ca_bundle_path=ca_bundle_path,
     )
 
 

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -31,6 +31,9 @@ OPTIONAL_KEYS = (
     "provider",
     "insecure",
     "timeout",
+    "tls_cert_file",
+    "tls_key_file",
+    "ca_bundle_path",
     "mcp_transport",
     "mcp_host",
     "mcp_port",
@@ -165,7 +168,7 @@ def build_mcp_config(
         port = int(profile.get("mcp_port", 3001))
     except (TypeError, ValueError):
         port = 3001
-    return {
+    mcp_cfg: dict[str, Any] = {
         "base_url": profile.get("base_url", "http://localhost:8080"),
         "token": profile.get("token", ""),
         "tenant": profile.get("tenant", ""),
@@ -174,3 +177,8 @@ def build_mcp_config(
         "host": profile.get("mcp_host", "localhost"),
         "port": port,
     }
+    for key in ("tls_cert_file", "tls_key_file"):
+        val = profile.get(key)
+        if val:
+            mcp_cfg[key] = val
+    return mcp_cfg

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -1162,7 +1162,18 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
 
     \b
     Known keys: base_url, token, tenant, provider, insecure, timeout,
+    tls_cert_file, tls_key_file, ca_bundle_path,
     mcp_transport, mcp_host, mcp_port.
+
+    \b
+    TLS (local server — used by 'evalhub mcp start'):
+      tls_cert_file  — path to TLS certificate
+      tls_key_file   — path to TLS private key
+
+    \b
+    TLS (remote cluster):
+      ca_bundle_path — CA bundle to verify the remote EvalHub server
+      insecure       — skip TLS verification (true/false)
 
     \b
     mcp_transport values:
@@ -1179,6 +1190,9 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
       evalhub config set token my-api-token
       evalhub config set tenant my-tenant
       evalhub config set insecure true
+      evalhub config set tls_cert_file /path/to/server.crt
+      evalhub config set tls_key_file /path/to/server.key
+      evalhub config set ca_bundle_path /path/to/ca-bundle.crt
       evalhub config set mcp_transport http
       evalhub --profile prod config set base_url https://evalhub.example.com
     """

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -1166,14 +1166,17 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
     mcp_transport, mcp_host, mcp_port.
 
     \b
-    TLS (local server — used by 'evalhub mcp start'):
-      tls_cert_file  — path to TLS certificate
-      tls_key_file   — path to TLS private key
+    TLS (local MCP server — used by 'evalhub mcp start'):
+      tls_cert_file  — path to PEM-encoded TLS certificate
+      tls_key_file   — path to PEM-encoded TLS private key
 
     \b
-    TLS (remote cluster):
-      ca_bundle_path — CA bundle to verify the remote EvalHub server
-      insecure       — skip TLS verification (true/false)
+    TLS (remote EvalHub server verification):
+      ca_bundle_path — CA bundle (.pem) to verify the remote server
+      insecure       — skip TLS verification (true/false, default: false)
+    When insecure is true, ca_bundle_path is ignored.
+    When insecure is false or unset, ca_bundle_path is used if provided,
+    otherwise system CA certificates are used.
 
     \b
     mcp_transport values:
@@ -1192,7 +1195,7 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
       evalhub config set insecure true
       evalhub config set tls_cert_file /path/to/server.crt
       evalhub config set tls_key_file /path/to/server.key
-      evalhub config set ca_bundle_path /path/to/ca-bundle.crt
+      evalhub config set ca_bundle_path /path/to/ca-bundle.pem
       evalhub config set mcp_transport http
       evalhub --profile prod config set base_url https://evalhub.example.com
     """

--- a/src/evalhub/cli/mcp_cmd.py
+++ b/src/evalhub/cli/mcp_cmd.py
@@ -6,6 +6,7 @@ import json
 import os
 import shutil
 import signal
+import ssl
 import subprocess
 import sys
 import time
@@ -91,6 +92,21 @@ def _generate_config(
     return ["--config", str(CONFIG_FILE)], mcp_config
 
 
+def _tls_enabled(mcp_config: dict[str, Any]) -> bool:
+    return bool(mcp_config.get("tls_cert_file") and mcp_config.get("tls_key_file"))
+
+
+def _scheme(mcp_config: dict[str, Any]) -> str:
+    return "https" if _tls_enabled(mcp_config) else "http"
+
+
+def _insecure_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
 _JSONRPC_VERSION = "2.0"
 
 
@@ -117,8 +133,9 @@ def _mcp_post(
     req = urllib.request.Request(
         url, data=json.dumps(body).encode(), headers=headers, method="POST"
     )
+    ssl_ctx = _insecure_ssl_context() if url.startswith("https://") else None
     try:
-        with urllib.request.urlopen(req, timeout=3) as resp:
+        with urllib.request.urlopen(req, timeout=3, context=ssl_ctx) as resp:
             sid = resp.headers.get("Mcp-Session-Id") or session_id
             raw = resp.read().decode()
     except (OSError, ValueError):
@@ -154,10 +171,10 @@ def _read_version_resource(url: str, session_id: str | None) -> dict[str, Any]:
 
 
 def _fetch_server_info(
-    host: str = "localhost", port: int = 3001
+    host: str = "localhost", port: int = 3001, *, scheme: str = "http"
 ) -> dict[str, Any] | None:
     """Perform an MCP handshake and return serverInfo + version resource data."""
-    url = f"http://{host}:{port}/mcp"
+    url = f"{scheme}://{host}:{port}/mcp"
 
     result, sid = _mcp_post(
         url,
@@ -261,9 +278,10 @@ def mcp_start(ctx: click.Context) -> None:
         raise click.ClickException(msg)
 
     PID_FILE.write_text(str(proc.pid))
+    scheme = _scheme(mcp_config)
     click.echo(f"MCP server started (PID {proc.pid}).")
     click.echo(f"  Transport: {mcp_config['transport']}")
-    click.echo(f"  URL:       http://{mcp_config['host']}:{mcp_config['port']}")
+    click.echo(f"  URL:       {scheme}://{mcp_config['host']}:{mcp_config['port']}")
     click.echo(f"  Logs:      {LOG_FILE}")
 
 
@@ -303,7 +321,8 @@ def mcp_status() -> None:
     mcp_cfg = cfg.load_config(CONFIG_FILE)
     host = str(mcp_cfg.get("host", "localhost"))
     port = int(mcp_cfg.get("port", 3001))
-    info = _fetch_server_info(host, port)
+    scheme = _scheme(mcp_cfg)
+    info = _fetch_server_info(host, port, scheme=scheme)
     if info:
         name = info.get("name", "unknown")
         version = info.get("version", "unknown")
@@ -312,5 +331,5 @@ def mcp_status() -> None:
         click.echo(f"  Version: {version}")
         if git_hash:
             click.echo(f"  Commit:  {git_hash}")
-    click.echo(f"  URL:     http://{host}:{port}")
+    click.echo(f"  URL:     {scheme}://{host}:{port}")
     click.echo(f"  Logs:    {LOG_FILE}")

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -443,13 +443,22 @@ class TestConfigMasking:
         assert "longtoken123" not in result.output
 
 
-class TestMcpConfigKeys:
-    def test_mcp_keys_in_optional_keys(self) -> None:
-        for key in ("mcp_transport", "mcp_host", "mcp_port"):
+class TestOptionalConfigKeys:
+    _EXPECTED = (
+        "mcp_transport",
+        "mcp_host",
+        "mcp_port",
+        "tls_cert_file",
+        "tls_key_file",
+        "ca_bundle_path",
+    )
+
+    def test_in_optional_keys(self) -> None:
+        for key in self._EXPECTED:
             assert key in OPTIONAL_KEYS
 
-    def test_mcp_keys_in_known_keys(self) -> None:
-        for key in ("mcp_transport", "mcp_host", "mcp_port"):
+    def test_in_known_keys(self) -> None:
+        for key in self._EXPECTED:
             assert key in KNOWN_KEYS
 
 
@@ -499,6 +508,28 @@ class TestBuildMcpConfig:
     def test_invalid_port_falls_back_to_default(self) -> None:
         result = build_mcp_config({"mcp_port": "not-a-number"})
         assert result["port"] == 3001
+
+    def test_tls_fields_forwarded_when_set(self) -> None:
+        profile = {
+            "base_url": "https://evalhub.example.com",
+            "token": "t",
+            "tenant": "ns",
+            "tls_cert_file": "/path/to/server.crt",
+            "tls_key_file": "/path/to/server.key",
+        }
+        result = build_mcp_config(profile)
+        assert result["tls_cert_file"] == "/path/to/server.crt"
+        assert result["tls_key_file"] == "/path/to/server.key"
+
+    def test_tls_fields_omitted_when_not_set(self) -> None:
+        result = build_mcp_config({})
+        assert "tls_cert_file" not in result
+        assert "tls_key_file" not in result
+
+    def test_ca_bundle_path_not_in_mcp_config(self) -> None:
+        profile = {"ca_bundle_path": "/path/to/ca-bundle.crt"}
+        result = build_mcp_config(profile)
+        assert "ca_bundle_path" not in result
 
 
 class TestParseBool:


### PR DESCRIPTION
## What and why
Introduces evalhub configs: tls_cert_file and tls_key_file
- This is used to start SSL enabled MCP localhost server with `evalhub mcp start`
- This will also be used to start SSL enabled Evalhub Control plane localhost server `evalhub server start` `TODO`
And `ca_bundle_path`
- if the existing config `insecure=false` then users can provide ca_bundle here, to talk to remote control plane of Evalhub

```
Profile: gbn
  base_url: https://evalhub-evalhub-test.apps.rosa.gbn-dev.vqoo.p3.openshiftapps.com
  token: sha***5g
  tenant: dataplane
  tls_cert_file: /Users/gnaulak/workspace/worktrees/local-blog/server.crt
  tls_key_file: /Users/gnaulak/workspace/worktrees/local-blog/server.key
  ca_bundle_path: /Users/gnaulak/workspace/worktrees/local-blog/ca_bundle.pem
```

### evalhub config set --help now shows these new config keys
```bash
╰─➤  evalhub config set --help
Usage: evalhub config set [OPTIONS] KEY VALUE

  Set a configuration value in the active profile.

  Known keys: base_url, token, tenant, provider, insecure, timeout,
  tls_cert_file, tls_key_file, ca_bundle_path,
  mcp_transport, mcp_host, mcp_port.

  TLS (local MCP server — used by 'evalhub mcp start'):
    tls_cert_file  — path to PEM-encoded TLS certificate
    tls_key_file   — path to PEM-encoded TLS private key

  TLS (remote EvalHub server verification):
    ca_bundle_path — CA bundle (.pem) to verify the remote server
    insecure       — skip TLS verification (true/false, default: false)
  When insecure is true, ca_bundle_path is ignored.
  When insecure is false or unset, ca_bundle_path is used if provided,
  otherwise system CA certificates are used.

  mcp_transport values:
    stdio    — default for 'evalhub mcp run'
    http     — Streamable HTTP, default for 'evalhub mcp start'
    http-sse — legacy HTTP+SSE
  When mcp_transport is not set, each command uses its own default.
  mcp_host default: localhost
  mcp_port default: 3001

  Examples:
    evalhub config set base_url http://localhost:8080
    evalhub config set token my-api-token
    evalhub config set tenant my-tenant
    evalhub config set insecure true
    evalhub config set tls_cert_file /path/to/server.crt
    evalhub config set tls_key_file /path/to/server.key
    evalhub config set ca_bundle_path /path/to/ca-bundle.pem
    evalhub config set mcp_transport http
    evalhub --profile prod config set base_url https://evalhub.example.com

Options:
  -h, --help  Show this message and exit.
```

Closes # https://redhat.atlassian.net/browse/RHOAIENG-71224

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

### when tls* configs are set
<img width="979" height="565" alt="Screenshot 2026-06-24 at 2 16 06 PM" src="https://github.com/user-attachments/assets/db867591-dc3b-47e5-9c05-6dca431ddcc5" />


### when tls* configs are not set
<img width="772" height="513" alt="Screenshot 2026-06-24 at 2 18 25 PM" src="https://github.com/user-attachments/assets/aadfc058-baea-4268-8175-8a1dc70e1ad1" />

### ca_bundle_path verification
<img width="1129" height="520" alt="Screenshot 2026-06-24 at 2 11 18 PM" src="https://github.com/user-attachments/assets/ac653efc-af37-407a-934e-a2d06c89fb83" />


## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TLS/HTTPS support for MCP connections, including secure server URLs and certificate handling.
  * Expanded configuration options to include TLS certificate, key, and CA bundle settings.
  * Updated CLI help and examples to document the new TLS-related configuration values.

* **Bug Fixes**
  * Client connections now respect the configured CA bundle when connecting to EvalHub services.
  * Status and startup output now show the correct protocol for secure MCP endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->