### PR TITLE
feat: remove ca_cert_path and auth_headers as the sidecar handles auth

### DIFF
--- a/src/evalhub/adapter/auth.py
+++ b/src/evalhub/adapter/auth.py
@@ -26,51 +26,24 @@ def read_model_auth_key(key_name: str) -> str | None:
 
 @dataclass
 class ModelCredentials:
-    """Resolved model credentials from environment."""
+    """Resolved model credentials from the pod environment.
+
+    api_key holds the ref token (e.g. 'api-key:ref') that the sidecar
+    proxy resolves to the real credential. CA cert and SA token injection
+    are handled transparently by the sidecar — not the adapter.
+    """
 
     api_key: str | None = field(default=None, repr=False)
-    ca_cert_path: str | None = None
-    _service_account_token: str | None = field(default=None, repr=False)
-
-    @property
-    def auth_headers(self) -> dict[str, str]:
-        """Auth headers derived from the ServiceAccount token only.
-
-        The API key is intentionally excluded and must be consumed separately
-        by the adapter.
-        """
-        if self._service_account_token:
-            return {"Authorization": f"Bearer {self._service_account_token}"}
-        return {}
 
 
 def resolve_model_credentials() -> ModelCredentials:
     """Resolve model authentication from the pod environment.
 
-    Reads credentials from the mounted model auth secret path.
+    Reads the api-key ref token from the mounted model auth secret.
+    CA cert and SA token injection are handled by the sidecar proxy.
     """
     creds = ModelCredentials()
-
     api_key = read_model_auth_key("api-key")
     if api_key:
         creds.api_key = api_key
-
-    if not creds.api_key:
-        sa_token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        path = Path(sa_token_path)
-        if path.is_file():
-            try:
-                sa_token = path.read_text(encoding="utf-8").strip()
-            except (OSError, UnicodeDecodeError, ValueError) as exc:
-                logger.warning(
-                    "Failed to read service account token file", exc_info=exc
-                )
-            else:
-                if sa_token:
-                    creds._service_account_token = sa_token
-
-    ca_cert = read_model_auth_key("ca_cert")
-    if ca_cert:
-        creds.ca_cert_path = str(_MODEL_AUTH_DIR / "ca_cert")
-
     return creds


### PR DESCRIPTION
With the sidecar always routing all model traffic, the adapter always talks to `localhost:8080` over plain HTTP. Two fields on `ModelCredentials` are no longer meaningful:

- `ca_cert_path` — no TLS between adapter and sidecar; the sidecar handles TLS to the model endpoint using `ca_cert` from its own secret mount
- `auth_headers()` / `_service_account_token` — the SA token file is not mounted on the adapter filesystem; the sidecar injects the SA token automatically when no `Authorization` header is present

Remove both fields and simplify `resolve_model_credentials()` to only read the `api-key` ref token.
## What and why

<!-- What does this PR do and why? Link to related issues. -->
https://redhat.atlassian.net/browse/RHOAIENG-70469
Closes #

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

I have tested the below scenarios and all are completed successfully.
- API key only -  adapter sets `OPENAI_API_KEY` from ref token, sidecar resolves to real key 
- API key + ca_cert + hf-token - evaluation completed; sidecar handled TLS with ca_cert 
- SA token + ca_cert  - evaluation completed; sidecar injected SA token and handled TLS with ca_cert 
- 
## Breaking changes

<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified model authentication handling to rely on a single API key.
  * Removed automatic certificate and service-account token handling from the app, with those details now managed by the proxy layer.
  * Reduced credential-related complexity for more predictable authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->