### PR TITLE
feat(cli): add server subcommand for eval-hub-server lifecycle management

### DIFF
--- a/src/evalhub/adapter/auth.py
+++ b/src/evalhub/adapter/auth.py
@@ -42,8 +42,4 @@ def resolve_model_credentials() -> ModelCredentials:
     Reads the api-key ref token from the mounted model auth secret.
     CA cert and SA token injection are handled by the sidecar proxy.
     """
-    creds = ModelCredentials()
-    api_key = read_model_auth_key("api-key")
-    if api_key:
-        creds.api_key = api_key
-    return creds
+    return ModelCredentials(api_key=read_model_auth_key("api-key"))

--- a/src/evalhub/adapter/mlflow.py
+++ b/src/evalhub/adapter/mlflow.py
@@ -354,15 +354,12 @@ class MlflowClient:
                 return None
             raise
         exp = data.get("experiment", {})
-        tags: dict[str, str] = {}
-        for t in exp.get("tags", []):
-            tags[t["key"]] = t["value"]
         return Experiment(
             experiment_id=exp.get("experiment_id", ""),
             name=exp.get("name", ""),
             artifact_location=exp.get("artifact_location", ""),
             lifecycle_stage=exp.get("lifecycle_stage", ""),
-            tags=tags,
+            tags=_kv_list_to_dict(exp.get("tags")),
         )
 
     def get_or_create_experiment(self, name: str) -> str:

--- a/src/evalhub/cli/_process.py
+++ b/src/evalhub/cli/_process.py
@@ -1,0 +1,93 @@
+"""Shared process lifecycle helpers for CLI daemon commands."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import click
+
+GRACEFUL_SIGNAL: signal.Signals = (
+    signal.CTRL_BREAK_EVENT if sys.platform == "win32" else signal.SIGTERM  # type: ignore[attr-defined]
+)
+FORCE_SIGNAL: signal.Signals = (
+    signal.SIGTERM if sys.platform == "win32" else signal.SIGKILL
+)
+
+
+def is_process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def read_pid(pid_file: Path) -> int | None:
+    if not pid_file.exists():
+        return None
+    try:
+        pid = int(pid_file.read_text().strip())
+    except (ValueError, OSError):
+        return None
+    return pid
+
+
+def live_pid(pid_file: Path) -> int | None:
+    pid = read_pid(pid_file)
+    if pid is not None and not is_process_alive(pid):
+        pid_file.unlink(missing_ok=True)
+        return None
+    return pid
+
+
+def find_binary(name: str, env_var: str) -> str:
+    env = os.environ.get(env_var)
+    if env:
+        return env
+    found = shutil.which(name)
+    if found:
+        return found
+    raise click.ClickException(
+        f"Could not find the '{name}' binary.\n"
+        f"Install it and ensure it is on your PATH, or set {env_var}."
+    )
+
+
+def graceful_stop(pid: int, pid_file: Path, timeout: float, label: str) -> None:
+    os.kill(pid, GRACEFUL_SIGNAL)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not is_process_alive(pid):
+            pid_file.unlink(missing_ok=True)
+            click.echo(f"{label} stopped.")
+            return
+        time.sleep(0.2)
+    os.kill(pid, FORCE_SIGNAL)
+    pid_file.unlink(missing_ok=True)
+    click.echo(f"{label} force-killed.")
+
+
+def spawn_background(
+    cmd: list[str], state_dir: Path, log_file: Path
+) -> subprocess.Popen[bytes]:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    log_fh = log_file.open("w")
+    creationflags = 0
+    if sys.platform == "win32":
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+    try:
+        return subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            creationflags=creationflags,
+        )
+    finally:
+        log_fh.close()

--- a/src/evalhub/cli/_process.py
+++ b/src/evalhub/cli/_process.py
@@ -12,6 +12,10 @@ from pathlib import Path
 
 import click
 
+# ---------------------------------------------------------------------------
+# Signals
+# ---------------------------------------------------------------------------
+
 GRACEFUL_SIGNAL: signal.Signals = (
     signal.CTRL_BREAK_EVENT if sys.platform == "win32" else signal.SIGTERM  # type: ignore[attr-defined]
 )
@@ -91,3 +95,38 @@ def spawn_background(
         )
     finally:
         log_fh.close()
+
+
+# ---------------------------------------------------------------------------
+# High-level daemon lifecycle helpers
+# ---------------------------------------------------------------------------
+
+
+def run_foreground(cmd: list[str], ctx: click.Context) -> None:
+    """Run *cmd* in the foreground, forwarding stdio and exit code."""
+    result = subprocess.run(
+        cmd,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+    ctx.exit(result.returncode)
+
+
+def require_not_running(pid_file: Path, label: str, stop_hint: str) -> None:
+    """Raise if a daemon tracked by *pid_file* is already alive."""
+    pid = live_pid(pid_file)
+    if pid is not None:
+        raise click.ClickException(
+            f"{label} is already running (PID {pid}). "
+            f"Stop it first with: {stop_hint}"
+        )
+
+
+def stop_daemon(pid_file: Path, timeout: float, label: str) -> None:
+    """Stop a daemon tracked by *pid_file*, or report that it is not running."""
+    pid = live_pid(pid_file)
+    if pid is None:
+        click.echo(f"{label} is not running.")
+        return
+    graceful_stop(pid, pid_file, timeout, label)

--- a/src/evalhub/cli/_process.py
+++ b/src/evalhub/cli/_process.py
@@ -39,7 +39,7 @@ def read_pid(pid_file: Path) -> int | None:
         pid = int(pid_file.read_text().strip())
     except (ValueError, OSError):
         return None
-    return pid
+    return pid if pid > 0 else None
 
 
 def live_pid(pid_file: Path) -> int | None:
@@ -53,6 +53,10 @@ def live_pid(pid_file: Path) -> int | None:
 def find_binary(name: str, env_var: str) -> str:
     env = os.environ.get(env_var)
     if env:
+        if not Path(env).is_file():
+            raise click.ClickException(
+                f"{env_var} is set to '{env}' but that file does not exist."
+            )
         return env
     found = shutil.which(name)
     if found:

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -22,6 +22,7 @@ import stat
 from pathlib import Path
 from typing import Any
 
+import click
 import yaml
 
 DEFAULT_CONFIG_DIR = Path.home() / ".config" / "evalhub"
@@ -162,8 +163,6 @@ def validate_config_file(path: Path) -> None:
 
     Raises ``click.ClickException`` on any validation failure.
     """
-    import click  # deferred to avoid circular import at module level
-
     if not path.is_file():
         raise click.ClickException(f"File not found: {path}")
     try:

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -186,6 +186,7 @@ def store_file_key(key: str, src: Path, profile_name: str) -> str:
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / "config.yaml"
     shutil.copy2(str(src), str(dest))
+    dest.chmod(stat.S_IRUSR | stat.S_IWUSR)
     return str(dest)
 
 

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -17,6 +17,7 @@ Config is stored at ~/.config/evalhub/config.yaml with structure:
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 from pathlib import Path
 from typing import Any
@@ -34,9 +35,11 @@ OPTIONAL_KEYS = (
     "mcp_transport",
     "mcp_host",
     "mcp_port",
+    "server_config_file",
 )
 KNOWN_KEYS = set(REQUIRED_KEYS) | set(OPTIONAL_KEYS)
 SENSITIVE_KEYS = frozenset({"token"})
+FILE_KEYS = frozenset({"server_config_file"})
 
 DEFAULT_PROFILE = "default"
 
@@ -142,6 +145,62 @@ def missing_required_keys(
 def is_known_key(key: str) -> bool:
     """Check whether a key is a recognised config key."""
     return key in KNOWN_KEYS
+
+
+def is_file_key(key: str) -> bool:
+    """Check whether a key references an external file."""
+    return key in FILE_KEYS
+
+
+_FILE_KEY_STORE_DIRS: dict[str, Path] = {
+    "server_config_file": DEFAULT_CONFIG_DIR / "server",
+}
+
+
+def validate_config_file(path: Path) -> None:
+    """Validate that *path* exists and contains a YAML mapping.
+
+    Raises ``click.ClickException`` on any validation failure.
+    """
+    import click  # deferred to avoid circular import at module level
+
+    if not path.is_file():
+        raise click.ClickException(f"File not found: {path}")
+    try:
+        with path.open() as f:
+            parsed = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        raise click.ClickException(f"Invalid YAML: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise click.ClickException(
+            f"Config file must contain a YAML mapping, got {type(parsed).__name__}"
+        )
+
+
+def store_file_key(key: str, src: Path, profile_name: str) -> str:
+    """Copy *src* into the profile-specific storage dir for *key*.
+
+    Returns the absolute path of the stored copy.
+    """
+    base = _FILE_KEY_STORE_DIRS[key]
+    dest_dir = base / profile_name
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / "config.yaml"
+    shutil.copy2(str(src), str(dest))
+    return str(dest)
+
+
+def remove_file_key(key: str, profile_name: str) -> None:
+    """Delete the stored file for *key* and clean up the directory if empty."""
+    base = _FILE_KEY_STORE_DIRS[key]
+    dest_dir = base / profile_name
+    dest = dest_dir / "config.yaml"
+    if dest.exists():
+        dest.unlink()
+    try:
+        dest_dir.rmdir()
+    except OSError:
+        pass
 
 
 def set_active_profile(data: dict[str, Any], profile: str) -> dict[str, Any]:

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import time
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any, cast
 
 import click
@@ -37,6 +38,7 @@ from .client import get_client, handle_api_errors
 from .completion import completion
 from .formatter import format_option, output
 from .mcp_cmd import mcp
+from .server_cmd import server
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -96,6 +98,7 @@ def main(
 
 main.add_command(completion)
 main.add_command(mcp)
+main.add_command(server)
 
 
 @main.command()
@@ -1145,9 +1148,15 @@ def config(ctx: click.Context) -> None:
     profile, and 'config use' to switch profiles.
 
     \b
+    File-based keys (e.g. server_config_file) store a path to a
+    YAML file. Use 'config get <key> --unfold' to view the file
+    contents.
+
+    \b
     Examples:
       evalhub config set base_url http://localhost:8080
-      evalhub config get base_url
+      evalhub config set server_config_file myserver-config.yaml
+      evalhub config get server_config_file --unfold
       evalhub config list
       evalhub config use prod
     """
@@ -1162,7 +1171,11 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
 
     \b
     Known keys: base_url, token, tenant, provider, insecure, timeout,
-    mcp_transport, mcp_host, mcp_port.
+    mcp_transport, mcp_host, mcp_port, server_config_file.
+
+    \b
+    File-based keys (server_config_file) accept a path to a YAML file.
+    The file is validated and copied into the CLI config directory.
 
     \b
     mcp_transport values:
@@ -1178,8 +1191,7 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
       evalhub config set base_url http://localhost:8080
       evalhub config set token my-api-token
       evalhub config set tenant my-tenant
-      evalhub config set insecure true
-      evalhub config set mcp_transport http
+      evalhub config set server_config_file myserver-config.yaml
       evalhub --profile prod config set base_url https://evalhub.example.com
     """
     if not cfg.is_known_key(key):
@@ -1190,9 +1202,13 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
         )
     profile = ctx.obj.get("profile")
     data = cfg.load_config()
+    profile_name = profile or cfg.get_active_profile(data)
+    if cfg.is_file_key(key):
+        src = Path(value)
+        cfg.validate_config_file(src)
+        value = cfg.store_file_key(key, src, profile_name)
     cfg.set_value(data, key, value, profile=profile)
     cfg.save_config(data)
-    profile_name = profile or cfg.get_active_profile(data)
     click.echo(f"Set '{key}' in profile '{profile_name}'")
 
 
@@ -1203,16 +1219,23 @@ def config_unset(ctx: click.Context, key: str) -> None:
     """Remove a configuration key from the active profile.
 
     \b
+    For file-based keys (e.g. server_config_file), also deletes the
+    stored config file.
+
+    \b
     Examples:
       evalhub config unset mcp_port
+      evalhub config unset server_config_file
       evalhub --profile prod config unset insecure
     """
     profile = ctx.obj.get("profile")
     data = cfg.load_config()
-    removed = cfg.unset_value(data, key, profile=profile)
     profile_name = profile or cfg.get_active_profile(data)
+    removed = cfg.unset_value(data, key, profile=profile)
     if removed:
         cfg.save_config(data)
+        if cfg.is_file_key(key):
+            cfg.remove_file_key(key, profile_name)
         click.echo(f"Unset '{key}' from profile '{profile_name}'")
     else:
         raise click.ClickException(f"Key '{key}' not found in profile '{profile_name}'")
@@ -1223,28 +1246,48 @@ def config_unset(ctx: click.Context, key: str) -> None:
 @click.option(
     "--unmask", is_flag=True, default=False, help="Show the raw value without masking."
 )
+@click.option(
+    "--unfold",
+    is_flag=True,
+    default=False,
+    help="Print the contents of a file-based config key.",
+)
 @click.pass_context
-def config_get(ctx: click.Context, key: str, unmask: bool) -> None:
+def config_get(ctx: click.Context, key: str, unmask: bool, unfold: bool) -> None:
     """Get a configuration value from the active profile.
 
     \b
     Sensitive values (e.g. token) are masked by default.
     Use --unmask to reveal the full value.
+    Use --unfold with file-based keys (e.g. server_config_file) to
+    print the referenced file's contents.
 
     \b
     Examples:
       evalhub config get base_url
-      evalhub config get token
       evalhub config get token --unmask
-      evalhub --profile prod config get base_url
+      evalhub config get server_config_file
+      evalhub config get server_config_file --unfold
     """
+    if unmask and unfold:
+        raise click.ClickException("--unmask and --unfold are mutually exclusive.")
     profile = ctx.obj.get("profile")
     data = cfg.load_config()
     value = cfg.get_value(data, key, profile=profile)
     if value is None:
         profile_name = profile or cfg.get_active_profile(data)
         raise click.ClickException(f"Key '{key}' not found in profile '{profile_name}'")
-    if key in cfg.SENSITIVE_KEYS and not unmask:
+    if unfold:
+        if not cfg.is_file_key(key):
+            raise click.ClickException(
+                f"--unfold is only valid for file-based config keys "
+                f"({', '.join(sorted(cfg.FILE_KEYS))})"
+            )
+        p = Path(str(value))
+        if not p.is_file():
+            raise click.ClickException(f"File not found: {value}")
+        click.echo(p.read_text(), nl=False)
+    elif key in cfg.SENSITIVE_KEYS and not unmask:
         click.echo(cfg.mask_value(str(value)))
     else:
         click.echo(value)

--- a/src/evalhub/cli/mcp_cmd.py
+++ b/src/evalhub/cli/mcp_cmd.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
-import sys
 import time
 import urllib.request
 from typing import Any
@@ -14,7 +12,14 @@ import click
 from evalhub import __version__
 
 from . import config as cfg
-from ._process import find_binary, graceful_stop, live_pid, spawn_background
+from ._process import (
+    find_binary,
+    live_pid,
+    require_not_running,
+    run_foreground,
+    spawn_background,
+    stop_daemon,
+)
 
 MCP_STATE_DIR = cfg.DEFAULT_CONFIG_DIR / "mcp"
 PID_FILE = MCP_STATE_DIR / "pid"
@@ -147,15 +152,7 @@ def mcp_run(ctx: click.Context) -> None:
     """
     binary = find_binary("evalhub-mcp", "EVALHUB_MCP_BIN")
     extra, _ = _generate_config(ctx, default_transport="stdio")
-    cmd = [binary, *extra]
-
-    result = subprocess.run(
-        cmd,
-        stdin=sys.stdin,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-    )
-    ctx.exit(result.returncode)
+    run_foreground([binary, *extra], ctx)
 
 
 @mcp.command("start")
@@ -167,12 +164,7 @@ def mcp_start(ctx: click.Context) -> None:
     otherwise defaults to http. The active CLI profile is used to
     generate ~/.config/evalhub/mcp/config.yaml automatically.
     """
-    pid = live_pid(PID_FILE)
-    if pid is not None:
-        raise click.ClickException(
-            f"MCP server is already running (PID {pid}). "
-            "Stop it first with: evalhub mcp stop"
-        )
+    require_not_running(PID_FILE, "MCP server", "evalhub mcp stop")
 
     binary = find_binary("evalhub-mcp", "EVALHUB_MCP_BIN")
     extra, mcp_config = _generate_config(ctx)
@@ -204,12 +196,7 @@ def mcp_start(ctx: click.Context) -> None:
 @mcp.command("stop")
 def mcp_stop() -> None:
     """Stop the background MCP server."""
-    pid = live_pid(PID_FILE)
-    if pid is None:
-        click.echo("MCP server is not running.")
-        return
-
-    graceful_stop(pid, PID_FILE, _STOP_TIMEOUT, "MCP server")
+    stop_daemon(PID_FILE, _STOP_TIMEOUT, "MCP server")
 
 
 @mcp.command("status")

--- a/src/evalhub/cli/mcp_cmd.py
+++ b/src/evalhub/cli/mcp_cmd.py
@@ -183,7 +183,7 @@ def _fetch_server_info(
 
 @click.group()
 def mcp() -> None:
-    """Manage the evalhub-mcp Go binary (run, start, stop, status)."""
+    """Manage the local evalhub-mcp Go binary."""
 
 
 @mcp.command("run")

--- a/src/evalhub/cli/mcp_cmd.py
+++ b/src/evalhub/cli/mcp_cmd.py
@@ -3,9 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
-import shutil
-import signal
 import subprocess
 import sys
 import time
@@ -17,6 +14,7 @@ import click
 from evalhub import __version__
 
 from . import config as cfg
+from ._process import find_binary, graceful_stop, live_pid, spawn_background
 
 MCP_STATE_DIR = cfg.DEFAULT_CONFIG_DIR / "mcp"
 PID_FILE = MCP_STATE_DIR / "pid"
@@ -25,54 +23,6 @@ CONFIG_FILE = MCP_STATE_DIR / "config.yaml"
 
 _STARTUP_WAIT = 2.0
 _STOP_TIMEOUT = 5.0
-
-
-def _find_mcp_binary() -> str:
-    env = os.environ.get("EVALHUB_MCP_BIN")
-    if env:
-        return env
-    found = shutil.which("evalhub-mcp")
-    if found:
-        return found
-    raise click.ClickException(
-        "Could not find the 'evalhub-mcp' binary.\n"
-        "Install it and ensure it is on your PATH, or set EVALHUB_MCP_BIN."
-    )
-
-
-def _is_process_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
-
-
-_GRACEFUL_SIGNAL: signal.Signals = (
-    signal.CTRL_BREAK_EVENT if sys.platform == "win32" else signal.SIGTERM  # type: ignore[attr-defined]
-)
-_FORCE_SIGNAL: signal.Signals = (
-    signal.SIGTERM if sys.platform == "win32" else signal.SIGKILL
-)
-
-
-def _read_pid() -> int | None:
-    if not PID_FILE.exists():
-        return None
-    try:
-        pid = int(PID_FILE.read_text().strip())
-    except (ValueError, OSError):
-        return None
-    return pid
-
-
-def _live_pid() -> int | None:
-    """Return the PID if the process is alive, cleaning up stale pidfile otherwise."""
-    pid = _read_pid()
-    if pid is not None and not _is_process_alive(pid):
-        PID_FILE.unlink(missing_ok=True)
-        return None
-    return pid
 
 
 def _generate_config(
@@ -195,7 +145,7 @@ def mcp_run(ctx: click.Context) -> None:
     otherwise defaults to stdio. The active CLI profile is used to
     generate ~/.config/evalhub/mcp/config.yaml automatically.
     """
-    binary = _find_mcp_binary()
+    binary = find_binary("evalhub-mcp", "EVALHUB_MCP_BIN")
     extra, _ = _generate_config(ctx, default_transport="stdio")
     cmd = [binary, *extra]
 
@@ -217,14 +167,14 @@ def mcp_start(ctx: click.Context) -> None:
     otherwise defaults to http. The active CLI profile is used to
     generate ~/.config/evalhub/mcp/config.yaml automatically.
     """
-    pid = _live_pid()
+    pid = live_pid(PID_FILE)
     if pid is not None:
         raise click.ClickException(
             f"MCP server is already running (PID {pid}). "
             "Stop it first with: evalhub mcp stop"
         )
 
-    binary = _find_mcp_binary()
+    binary = find_binary("evalhub-mcp", "EVALHUB_MCP_BIN")
     extra, mcp_config = _generate_config(ctx)
     if mcp_config.get("transport") == "stdio":
         raise click.ClickException(
@@ -234,24 +184,8 @@ def mcp_start(ctx: click.Context) -> None:
         )
     cmd = [binary, *extra]
 
-    MCP_STATE_DIR.mkdir(parents=True, exist_ok=True)
-    log_fh = LOG_FILE.open("w")
-
-    creationflags = 0
-    if sys.platform == "win32":
-        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
-
-    try:
-        proc = subprocess.Popen(
-            cmd,
-            stdin=subprocess.DEVNULL,
-            stdout=log_fh,
-            stderr=subprocess.STDOUT,
-            creationflags=creationflags,
-        )
-        time.sleep(_STARTUP_WAIT)
-    finally:
-        log_fh.close()
+    proc = spawn_background(cmd, MCP_STATE_DIR, LOG_FILE)
+    time.sleep(_STARTUP_WAIT)
 
     if proc.poll() is not None:
         output = LOG_FILE.read_text().strip()
@@ -270,30 +204,18 @@ def mcp_start(ctx: click.Context) -> None:
 @mcp.command("stop")
 def mcp_stop() -> None:
     """Stop the background MCP server."""
-    pid = _live_pid()
+    pid = live_pid(PID_FILE)
     if pid is None:
         click.echo("MCP server is not running.")
         return
 
-    os.kill(pid, _GRACEFUL_SIGNAL)
-
-    deadline = time.monotonic() + _STOP_TIMEOUT
-    while time.monotonic() < deadline:
-        if not _is_process_alive(pid):
-            PID_FILE.unlink(missing_ok=True)
-            click.echo("MCP server stopped.")
-            return
-        time.sleep(0.2)
-
-    os.kill(pid, _FORCE_SIGNAL)
-    PID_FILE.unlink(missing_ok=True)
-    click.echo("MCP server force-killed.")
+    graceful_stop(pid, PID_FILE, _STOP_TIMEOUT, "MCP server")
 
 
 @mcp.command("status")
 def mcp_status() -> None:
     """Check if the background MCP server is running."""
-    pid = _live_pid()
+    pid = live_pid(PID_FILE)
     if pid is None:
         click.echo("MCP server is not running.")
         return

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -149,6 +149,12 @@ def server_start(ctx: click.Context) -> None:
             if output:
                 msg += f"\nLog output:\n{output}"
             raise click.ClickException(msg)
+        proc.terminate()
+        try:
+            proc.wait(timeout=_STOP_TIMEOUT)
+        except Exception:
+            proc.kill()
+            proc.wait(timeout=2)
         raise click.ClickException(
             f"Server did not become healthy within {_STARTUP_TIMEOUT}s.\n"
             f"Health check: {scheme}://localhost:{port}/api/v1/health\n"

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import ssl
-import subprocess
-import sys
 import time
 import urllib.request
 from pathlib import Path
@@ -13,7 +11,14 @@ import click
 import yaml
 
 from . import config as cfg
-from ._process import find_binary, graceful_stop, live_pid, spawn_background
+from ._process import (
+    find_binary,
+    live_pid,
+    require_not_running,
+    run_foreground,
+    spawn_background,
+    stop_daemon,
+)
 
 SERVER_STATE_DIR = cfg.DEFAULT_CONFIG_DIR / "server"
 PID_FILE = SERVER_STATE_DIR / "pid"
@@ -33,9 +38,9 @@ def _read_server_config(config_dir: Path) -> tuple[int, bool]:
         data = yaml.safe_load(config_path.read_text())
         svc = data.get("service", {})
         port = int(svc.get("port", _DEFAULT_PORT))
-        cert = str(svc.get("tls_cert_file", ""))
-        key = str(svc.get("tls_key_file", ""))
-        tls = cert != "" and key != ""
+        cert = svc.get("tls_cert_file", "")
+        key = svc.get("tls_key_file", "")
+        tls = bool(cert and key)
         return port, tls
     except (yaml.YAMLError, TypeError, ValueError, AttributeError):
         return _DEFAULT_PORT, False
@@ -52,7 +57,7 @@ def _health_check(port: int, *, tls: bool = False) -> bool:
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
         with urllib.request.urlopen(req, timeout=2, context=ctx) as resp:
-            return int(resp.status) == 200
+            return bool(resp.status == 200)
     except Exception:
         return False
 
@@ -99,62 +104,36 @@ def server() -> None:
 
 
 @server.command("run")
-@click.option(
-    "--config-dir",
-    type=click.Path(exists=True, file_okay=False),
-    default=None,
-    help="Override the config directory (default: profile-based).",
-)
 @click.pass_context
-def server_run(ctx: click.Context, config_dir: str | None) -> None:
+def server_run(ctx: click.Context) -> None:
     """Run eval-hub-server in the foreground.
 
     \b
     Examples:
       evalhub server run
-      evalhub server run --config-dir /path/to/config
       evalhub --profile staging server run
     """
     binary = find_binary("eval-hub-server", "EVALHUB_SERVER_BIN")
-    cfg_dir = Path(config_dir) if config_dir else _resolve_config_dir(ctx)
+    cfg_dir = _resolve_config_dir(ctx)
     _require_config(cfg_dir)
 
-    cmd = [binary, "-local", "-configdir", str(cfg_dir)]
-    result = subprocess.run(
-        cmd,
-        stdin=sys.stdin,
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-    )
-    ctx.exit(result.returncode)
+    run_foreground([binary, "-local", "-configdir", str(cfg_dir)], ctx)
 
 
 @server.command("start")
-@click.option(
-    "--config-dir",
-    type=click.Path(exists=True, file_okay=False),
-    default=None,
-    help="Override the config directory (default: profile-based).",
-)
 @click.pass_context
-def server_start(ctx: click.Context, config_dir: str | None) -> None:
+def server_start(ctx: click.Context) -> None:
     """Start eval-hub-server as a background daemon.
 
     \b
     Examples:
       evalhub server start
-      evalhub server start --config-dir /path/to/config
       evalhub --profile staging server start
     """
-    pid = live_pid(PID_FILE)
-    if pid is not None:
-        raise click.ClickException(
-            f"Server is already running (PID {pid}). "
-            "Stop it first with: evalhub server stop"
-        )
+    require_not_running(PID_FILE, "Server", "evalhub server stop")
 
     binary = find_binary("eval-hub-server", "EVALHUB_SERVER_BIN")
-    cfg_dir = Path(config_dir) if config_dir else _resolve_config_dir(ctx)
+    cfg_dir = _resolve_config_dir(ctx)
     _require_config(cfg_dir)
 
     port, tls = _read_server_config(cfg_dir)
@@ -190,12 +169,7 @@ def server_stop() -> None:
     Examples:
       evalhub server stop
     """
-    pid = live_pid(PID_FILE)
-    if pid is None:
-        click.echo("Server is not running.")
-        return
-
-    graceful_stop(pid, PID_FILE, _STOP_TIMEOUT, "Server")
+    stop_daemon(PID_FILE, _STOP_TIMEOUT, "Server")
 
 
 @server.command("status")

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import os
-import shutil
-import signal
 import ssl
 import subprocess
 import sys
@@ -16,6 +13,7 @@ import click
 import yaml
 
 from . import config as cfg
+from ._process import find_binary, graceful_stop, live_pid, spawn_background
 
 SERVER_STATE_DIR = cfg.DEFAULT_CONFIG_DIR / "server"
 PID_FILE = SERVER_STATE_DIR / "pid"
@@ -26,84 +24,25 @@ _STARTUP_POLL = 0.5
 _STOP_TIMEOUT = 5.0
 _DEFAULT_PORT = 8080
 
-_GRACEFUL_SIGNAL: signal.Signals = (
-    signal.CTRL_BREAK_EVENT if sys.platform == "win32" else signal.SIGTERM  # type: ignore[attr-defined]
-)
-_FORCE_SIGNAL: signal.Signals = (
-    signal.SIGTERM if sys.platform == "win32" else signal.SIGKILL
-)
 
-
-def _find_server_binary() -> str:
-    env = os.environ.get("EVALHUB_SERVER_BIN")
-    if env:
-        return env
-    found = shutil.which("eval-hub-server")
-    if found:
-        return found
-    raise click.ClickException(
-        "Could not find the 'eval-hub-server' binary.\n"
-        "Install it and ensure it is on your PATH, or set EVALHUB_SERVER_BIN."
-    )
-
-
-def _is_process_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
-
-
-def _read_pid() -> int | None:
-    if not PID_FILE.exists():
-        return None
-    try:
-        pid = int(PID_FILE.read_text().strip())
-    except (ValueError, OSError):
-        return None
-    return pid
-
-
-def _live_pid() -> int | None:
-    pid = _read_pid()
-    if pid is not None and not _is_process_alive(pid):
-        PID_FILE.unlink(missing_ok=True)
-        return None
-    return pid
-
-
-def _read_server_port(config_dir: Path) -> int:
+def _read_server_config(config_dir: Path) -> tuple[int, bool]:
     config_path = config_dir / "config.yaml"
     if not config_path.exists():
-        return _DEFAULT_PORT
-    try:
-        data = yaml.safe_load(config_path.read_text())
-        return int(data.get("service", {}).get("port", _DEFAULT_PORT))
-    except (yaml.YAMLError, TypeError, ValueError, AttributeError):
-        return _DEFAULT_PORT
-
-
-def _is_tls_enabled(config_dir: Path) -> bool:
-    config_path = config_dir / "config.yaml"
-    if not config_path.exists():
-        return False
+        return _DEFAULT_PORT, False
     try:
         data = yaml.safe_load(config_path.read_text())
         svc = data.get("service", {})
+        port = int(svc.get("port", _DEFAULT_PORT))
         cert = str(svc.get("tls_cert_file", ""))
         key = str(svc.get("tls_key_file", ""))
-        return cert != "" and key != ""
-    except (yaml.YAMLError, TypeError, AttributeError):
-        return False
-
-
-def _server_scheme(tls: bool) -> str:
-    return "https" if tls else "http"
+        tls = cert != "" and key != ""
+        return port, tls
+    except (yaml.YAMLError, TypeError, ValueError, AttributeError):
+        return _DEFAULT_PORT, False
 
 
 def _health_check(port: int, *, tls: bool = False) -> bool:
-    scheme = _server_scheme(tls)
+    scheme = "https" if tls else "http"
     url = f"{scheme}://localhost:{port}/api/v1/health"
     req = urllib.request.Request(url, method="GET")
     try:
@@ -176,7 +115,7 @@ def server_run(ctx: click.Context, config_dir: str | None) -> None:
       evalhub server run --config-dir /path/to/config
       evalhub --profile staging server run
     """
-    binary = _find_server_binary()
+    binary = find_binary("eval-hub-server", "EVALHUB_SERVER_BIN")
     cfg_dir = Path(config_dir) if config_dir else _resolve_config_dir(ctx)
     _require_config(cfg_dir)
 
@@ -207,39 +146,22 @@ def server_start(ctx: click.Context, config_dir: str | None) -> None:
       evalhub server start --config-dir /path/to/config
       evalhub --profile staging server start
     """
-    pid = _live_pid()
+    pid = live_pid(PID_FILE)
     if pid is not None:
         raise click.ClickException(
             f"Server is already running (PID {pid}). "
             "Stop it first with: evalhub server stop"
         )
 
-    binary = _find_server_binary()
+    binary = find_binary("eval-hub-server", "EVALHUB_SERVER_BIN")
     cfg_dir = Path(config_dir) if config_dir else _resolve_config_dir(ctx)
     _require_config(cfg_dir)
 
-    port = _read_server_port(cfg_dir)
-    tls = _is_tls_enabled(cfg_dir)
-    scheme = _server_scheme(tls)
+    port, tls = _read_server_config(cfg_dir)
+    scheme = "https" if tls else "http"
     cmd = [binary, "-local", "-configdir", str(cfg_dir)]
 
-    SERVER_STATE_DIR.mkdir(parents=True, exist_ok=True)
-    log_fh = LOG_FILE.open("w")
-
-    creationflags = 0
-    if sys.platform == "win32":
-        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
-
-    try:
-        proc = subprocess.Popen(
-            cmd,
-            stdin=subprocess.DEVNULL,
-            stdout=log_fh,
-            stderr=subprocess.STDOUT,
-            creationflags=creationflags,
-        )
-    finally:
-        log_fh.close()
+    proc = spawn_background(cmd, SERVER_STATE_DIR, LOG_FILE)
 
     if not _wait_for_healthy(port, _STARTUP_TIMEOUT, tls=tls):
         if proc.poll() is not None:
@@ -268,51 +190,43 @@ def server_stop() -> None:
     Examples:
       evalhub server stop
     """
-    pid = _live_pid()
+    pid = live_pid(PID_FILE)
     if pid is None:
         click.echo("Server is not running.")
         return
 
-    os.kill(pid, _GRACEFUL_SIGNAL)
-
-    deadline = time.monotonic() + _STOP_TIMEOUT
-    while time.monotonic() < deadline:
-        if not _is_process_alive(pid):
-            PID_FILE.unlink(missing_ok=True)
-            click.echo("Server stopped.")
-            return
-        time.sleep(0.2)
-
-    os.kill(pid, _FORCE_SIGNAL)
-    PID_FILE.unlink(missing_ok=True)
-    click.echo("Server force-killed.")
+    graceful_stop(pid, PID_FILE, _STOP_TIMEOUT, "Server")
 
 
 @server.command("status")
 @click.pass_context
 def server_status(ctx: click.Context) -> None:
-    """Check if the background eval-hub-server is running.
+    """Check if eval-hub-server is running.
+
+    Works for both background (server start) and foreground (server run)
+    by probing the health endpoint directly.
 
     \b
     Examples:
       evalhub server status
     """
-    pid = _live_pid()
-    if pid is None:
+    cfg_dir = _resolve_config_dir(ctx)
+    port, tls = _read_server_config(cfg_dir)
+    scheme = "https" if tls else "http"
+
+    pid = live_pid(PID_FILE)
+    healthy = _health_check(port, tls=tls)
+
+    if not healthy and pid is None:
         click.echo("Server is not running.")
         return
 
-    click.echo(f"Server is running (PID {pid}).")
-
-    cfg_dir = _resolve_config_dir(ctx)
-    port = _read_server_port(cfg_dir)
-    tls = _is_tls_enabled(cfg_dir)
-    scheme = _server_scheme(tls)
-
-    if _health_check(port, tls=tls):
-        click.echo("  Health: healthy")
+    if pid is not None:
+        click.echo(f"Server is running (PID {pid}).")
     else:
-        click.echo("  Health: not responding")
+        click.echo("Server is running.")
 
+    click.echo(f"  Health: {'healthy' if healthy else 'not responding'}")
     click.echo(f"  URL:    {scheme}://localhost:{port}")
-    click.echo(f"  Logs:   {LOG_FILE}")
+    if pid is not None:
+        click.echo(f"  Logs:   {LOG_FILE}")

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -42,8 +42,10 @@ def _read_server_config(config_dir: Path) -> tuple[int, bool]:
         key = svc.get("tls_key_file", "")
         tls = bool(cert and key)
         return port, tls
-    except (yaml.YAMLError, TypeError, ValueError, AttributeError):
-        return _DEFAULT_PORT, False
+    except (yaml.YAMLError, TypeError, ValueError, AttributeError) as exc:
+        raise click.ClickException(
+            f"Failed to parse server config {config_path}: {exc}"
+        ) from exc
 
 
 def _health_check(port: int, *, tls: bool = False) -> bool:

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -1,0 +1,318 @@
+"""Server command group — eval-hub-server lifecycle management."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import ssl
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+import click
+import yaml
+
+from . import config as cfg
+
+SERVER_STATE_DIR = cfg.DEFAULT_CONFIG_DIR / "server"
+PID_FILE = SERVER_STATE_DIR / "pid"
+LOG_FILE = SERVER_STATE_DIR / "server.log"
+
+_STARTUP_TIMEOUT = 30.0
+_STARTUP_POLL = 0.5
+_STOP_TIMEOUT = 5.0
+_DEFAULT_PORT = 8080
+
+_GRACEFUL_SIGNAL: signal.Signals = (
+    signal.CTRL_BREAK_EVENT if sys.platform == "win32" else signal.SIGTERM  # type: ignore[attr-defined]
+)
+_FORCE_SIGNAL: signal.Signals = (
+    signal.SIGTERM if sys.platform == "win32" else signal.SIGKILL
+)
+
+
+def _find_server_binary() -> str:
+    env = os.environ.get("EVALHUB_SERVER_BIN")
+    if env:
+        return env
+    found = shutil.which("eval-hub-server")
+    if found:
+        return found
+    raise click.ClickException(
+        "Could not find the 'eval-hub-server' binary.\n"
+        "Install it and ensure it is on your PATH, or set EVALHUB_SERVER_BIN."
+    )
+
+
+def _is_process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _read_pid() -> int | None:
+    if not PID_FILE.exists():
+        return None
+    try:
+        pid = int(PID_FILE.read_text().strip())
+    except (ValueError, OSError):
+        return None
+    return pid
+
+
+def _live_pid() -> int | None:
+    pid = _read_pid()
+    if pid is not None and not _is_process_alive(pid):
+        PID_FILE.unlink(missing_ok=True)
+        return None
+    return pid
+
+
+def _read_server_port(config_dir: Path) -> int:
+    config_path = config_dir / "config.yaml"
+    if not config_path.exists():
+        return _DEFAULT_PORT
+    try:
+        data = yaml.safe_load(config_path.read_text())
+        return int(data.get("service", {}).get("port", _DEFAULT_PORT))
+    except (yaml.YAMLError, TypeError, ValueError, AttributeError):
+        return _DEFAULT_PORT
+
+
+def _is_tls_enabled(config_dir: Path) -> bool:
+    config_path = config_dir / "config.yaml"
+    if not config_path.exists():
+        return False
+    try:
+        data = yaml.safe_load(config_path.read_text())
+        svc = data.get("service", {})
+        cert = str(svc.get("tls_cert_file", ""))
+        key = str(svc.get("tls_key_file", ""))
+        return cert != "" and key != ""
+    except (yaml.YAMLError, TypeError, AttributeError):
+        return False
+
+
+def _server_scheme(tls: bool) -> str:
+    return "https" if tls else "http"
+
+
+def _health_check(port: int, *, tls: bool = False) -> bool:
+    scheme = _server_scheme(tls)
+    url = f"{scheme}://localhost:{port}/api/v1/health"
+    req = urllib.request.Request(url, method="GET")
+    try:
+        ctx: ssl.SSLContext | None = None
+        if tls:
+            ctx = ssl.create_default_context()
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        with urllib.request.urlopen(req, timeout=2, context=ctx) as resp:
+            return int(resp.status) == 200
+    except Exception:
+        return False
+
+
+def _wait_for_healthy(port: int, timeout: float, *, tls: bool = False) -> bool:
+    deadline = time.monotonic() + timeout
+    delay = _STARTUP_POLL
+    while time.monotonic() < deadline:
+        if _health_check(port, tls=tls):
+            return True
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(delay, remaining))
+        delay = min(delay * 2, 2.0)
+    return _health_check(port, tls=tls)
+
+
+def _server_config_dir(profile_name: str) -> Path:
+    return SERVER_STATE_DIR / profile_name
+
+
+def _resolve_config_dir(ctx: click.Context) -> Path:
+    data = cfg.load_config()
+    profile = ctx.obj.get("profile")
+    value = cfg.get_value(data, "server_config_file", profile=profile)
+    if value:
+        return Path(str(value)).parent
+    profile_name = profile or cfg.get_active_profile(data)
+    return _server_config_dir(profile_name)
+
+
+def _require_config(config_dir: Path) -> None:
+    if not (config_dir / "config.yaml").exists():
+        raise click.ClickException(
+            f"No server config found at {config_dir / 'config.yaml'}.\n"
+            "Set one first with: evalhub config set server_config_file <path>"
+        )
+
+
+@click.group()
+def server() -> None:
+    """Manage the local eval-hub-server binary."""
+
+
+@server.command("run")
+@click.option(
+    "--config-dir",
+    type=click.Path(exists=True, file_okay=False),
+    default=None,
+    help="Override the config directory (default: profile-based).",
+)
+@click.pass_context
+def server_run(ctx: click.Context, config_dir: str | None) -> None:
+    """Run eval-hub-server in the foreground.
+
+    \b
+    Examples:
+      evalhub server run
+      evalhub server run --config-dir /path/to/config
+      evalhub --profile staging server run
+    """
+    binary = _find_server_binary()
+    cfg_dir = Path(config_dir) if config_dir else _resolve_config_dir(ctx)
+    _require_config(cfg_dir)
+
+    cmd = [binary, "-local", "-configdir", str(cfg_dir)]
+    result = subprocess.run(
+        cmd,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+    ctx.exit(result.returncode)
+
+
+@server.command("start")
+@click.option(
+    "--config-dir",
+    type=click.Path(exists=True, file_okay=False),
+    default=None,
+    help="Override the config directory (default: profile-based).",
+)
+@click.pass_context
+def server_start(ctx: click.Context, config_dir: str | None) -> None:
+    """Start eval-hub-server as a background daemon.
+
+    \b
+    Examples:
+      evalhub server start
+      evalhub server start --config-dir /path/to/config
+      evalhub --profile staging server start
+    """
+    pid = _live_pid()
+    if pid is not None:
+        raise click.ClickException(
+            f"Server is already running (PID {pid}). "
+            "Stop it first with: evalhub server stop"
+        )
+
+    binary = _find_server_binary()
+    cfg_dir = Path(config_dir) if config_dir else _resolve_config_dir(ctx)
+    _require_config(cfg_dir)
+
+    port = _read_server_port(cfg_dir)
+    tls = _is_tls_enabled(cfg_dir)
+    scheme = _server_scheme(tls)
+    cmd = [binary, "-local", "-configdir", str(cfg_dir)]
+
+    SERVER_STATE_DIR.mkdir(parents=True, exist_ok=True)
+    log_fh = LOG_FILE.open("w")
+
+    creationflags = 0
+    if sys.platform == "win32":
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=log_fh,
+            stderr=subprocess.STDOUT,
+            creationflags=creationflags,
+        )
+    finally:
+        log_fh.close()
+
+    if not _wait_for_healthy(port, _STARTUP_TIMEOUT, tls=tls):
+        if proc.poll() is not None:
+            output = LOG_FILE.read_text().strip()
+            msg = f"Server crashed on startup (exit code {proc.returncode})."
+            if output:
+                msg += f"\nLog output:\n{output}"
+            raise click.ClickException(msg)
+        raise click.ClickException(
+            f"Server did not become healthy within {_STARTUP_TIMEOUT}s.\n"
+            f"Health check: {scheme}://localhost:{port}/api/v1/health\n"
+            f"Check logs at: {LOG_FILE}"
+        )
+
+    PID_FILE.write_text(str(proc.pid))
+    click.echo(f"Server started (PID {proc.pid}).")
+    click.echo(f"  URL:  {scheme}://localhost:{port}")
+    click.echo(f"  Logs: {LOG_FILE}")
+
+
+@server.command("stop")
+def server_stop() -> None:
+    """Stop the background eval-hub-server.
+
+    \b
+    Examples:
+      evalhub server stop
+    """
+    pid = _live_pid()
+    if pid is None:
+        click.echo("Server is not running.")
+        return
+
+    os.kill(pid, _GRACEFUL_SIGNAL)
+
+    deadline = time.monotonic() + _STOP_TIMEOUT
+    while time.monotonic() < deadline:
+        if not _is_process_alive(pid):
+            PID_FILE.unlink(missing_ok=True)
+            click.echo("Server stopped.")
+            return
+        time.sleep(0.2)
+
+    os.kill(pid, _FORCE_SIGNAL)
+    PID_FILE.unlink(missing_ok=True)
+    click.echo("Server force-killed.")
+
+
+@server.command("status")
+@click.pass_context
+def server_status(ctx: click.Context) -> None:
+    """Check if the background eval-hub-server is running.
+
+    \b
+    Examples:
+      evalhub server status
+    """
+    pid = _live_pid()
+    if pid is None:
+        click.echo("Server is not running.")
+        return
+
+    click.echo(f"Server is running (PID {pid}).")
+
+    cfg_dir = _resolve_config_dir(ctx)
+    port = _read_server_port(cfg_dir)
+    tls = _is_tls_enabled(cfg_dir)
+    scheme = _server_scheme(tls)
+
+    if _health_check(port, tls=tls):
+        click.echo("  Health: healthy")
+    else:
+        click.echo("  Health: not responding")
+
+    click.echo(f"  URL:    {scheme}://localhost:{port}")
+    click.echo(f"  Logs:   {LOG_FILE}")

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -63,7 +63,7 @@ def test_mcp_subcommands_appear_in_help(runner: CliRunner) -> None:
 
 
 @patch("evalhub.cli.mcp_cmd.subprocess.run")
-@patch("evalhub.cli.mcp_cmd._find_mcp_binary", return_value="/usr/bin/evalhub-mcp")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_run_stdio(
     mock_find: MagicMock,
     mock_run: MagicMock,
@@ -85,7 +85,7 @@ def test_mcp_run_stdio(
     assert str(gen_cfg) in cmd
 
 
-@patch("evalhub.cli.mcp_cmd._find_mcp_binary")
+@patch("evalhub.cli.mcp_cmd.find_binary")
 def test_mcp_run_binary_not_found(
     mock_find: MagicMock,
     runner: CliRunner,
@@ -104,8 +104,8 @@ def test_mcp_run_binary_not_found(
 
 
 @patch("evalhub.cli.mcp_cmd.time.sleep")
-@patch("evalhub.cli.mcp_cmd.subprocess.Popen")
-@patch("evalhub.cli.mcp_cmd._find_mcp_binary", return_value="/usr/bin/evalhub-mcp")
+@patch("evalhub.cli._process.subprocess.Popen")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_start_launches_background(
     mock_find: MagicMock,
     mock_popen: MagicMock,
@@ -143,8 +143,8 @@ def test_mcp_start_launches_background(
 
 
 @patch("evalhub.cli.mcp_cmd.time.sleep")
-@patch("evalhub.cli.mcp_cmd.subprocess.Popen")
-@patch("evalhub.cli.mcp_cmd._find_mcp_binary", return_value="/usr/bin/evalhub-mcp")
+@patch("evalhub.cli._process.subprocess.Popen")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_start_already_running(
     mock_find: MagicMock,
     mock_popen: MagicMock,
@@ -160,7 +160,7 @@ def test_mcp_start_already_running(
         "evalhub.cli.mcp_cmd.PID_FILE", pid_file
     ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"), patch(
         "evalhub.cli.mcp_cmd.CONFIG_FILE", tmp_path / "config.yaml"
-    ), patch("evalhub.cli.mcp_cmd._is_process_alive", return_value=True):
+    ), patch("evalhub.cli._process.is_process_alive", return_value=True):
         result = runner.invoke(main, ["mcp", "start"])
 
     assert result.exit_code != 0
@@ -169,7 +169,7 @@ def test_mcp_start_already_running(
     mock_popen.assert_not_called()
 
 
-@patch("evalhub.cli.mcp_cmd.os.kill")
+@patch("evalhub.cli._process.os.kill")
 def test_mcp_stop(
     mock_kill: MagicMock,
     runner: CliRunner,
@@ -182,8 +182,8 @@ def test_mcp_stop(
     alive_calls = iter([True, False])
 
     with patch("evalhub.cli.mcp_cmd.PID_FILE", pid_file), patch(
-        "evalhub.cli.mcp_cmd._is_process_alive", side_effect=alive_calls
-    ), patch("evalhub.cli.mcp_cmd.time.sleep"):
+        "evalhub.cli._process.is_process_alive", side_effect=alive_calls
+    ), patch("evalhub.cli._process.time.sleep"):
         result = runner.invoke(main, ["mcp", "stop"])
 
     assert result.exit_code == 0, result.output
@@ -218,7 +218,7 @@ def test_mcp_status_running_with_server_info(
     with patch("evalhub.cli.mcp_cmd.PID_FILE", pid_file), patch(
         "evalhub.cli.mcp_cmd.CONFIG_FILE", cfg_file
     ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"), patch(
-        "evalhub.cli.mcp_cmd._is_process_alive", return_value=True
+        "evalhub.cli._process.is_process_alive", return_value=True
     ), patch("evalhub.cli.mcp_cmd._fetch_server_info", return_value=server_info):
         result = runner.invoke(main, ["mcp", "status"])
 
@@ -243,7 +243,7 @@ def test_mcp_status_running_server_info_unavailable(
     with patch("evalhub.cli.mcp_cmd.PID_FILE", pid_file), patch(
         "evalhub.cli.mcp_cmd.CONFIG_FILE", cfg_file
     ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"), patch(
-        "evalhub.cli.mcp_cmd._is_process_alive", return_value=True
+        "evalhub.cli._process.is_process_alive", return_value=True
     ), patch("evalhub.cli.mcp_cmd._fetch_server_info", return_value=None):
         result = runner.invoke(main, ["mcp", "status"])
 
@@ -260,7 +260,7 @@ def test_mcp_status_running_server_info_unavailable(
 
 
 @patch("evalhub.cli.mcp_cmd.subprocess.run")
-@patch("evalhub.cli.mcp_cmd._find_mcp_binary", return_value="/usr/bin/evalhub-mcp")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_run_generates_config_from_profile(
     mock_find: MagicMock,
     mock_run: MagicMock,
@@ -295,8 +295,8 @@ def test_mcp_run_generates_config_from_profile(
 
 
 @patch("evalhub.cli.mcp_cmd.time.sleep")
-@patch("evalhub.cli.mcp_cmd.subprocess.Popen")
-@patch("evalhub.cli.mcp_cmd._find_mcp_binary", return_value="/usr/bin/evalhub-mcp")
+@patch("evalhub.cli._process.subprocess.Popen")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_start_generates_config_from_profile(
     mock_find: MagicMock,
     mock_popen: MagicMock,
@@ -337,8 +337,8 @@ def test_mcp_start_generates_config_from_profile(
 
 
 @patch("evalhub.cli.mcp_cmd.time.sleep")
-@patch("evalhub.cli.mcp_cmd.subprocess.Popen")
-@patch("evalhub.cli.mcp_cmd._find_mcp_binary", return_value="/usr/bin/evalhub-mcp")
+@patch("evalhub.cli._process.subprocess.Popen")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_start_rejects_stdio_transport(
     mock_find: MagicMock,
     mock_popen: MagicMock,
@@ -369,7 +369,7 @@ def test_mcp_start_rejects_stdio_transport(
 
 
 @patch("evalhub.cli.mcp_cmd.subprocess.run")
-@patch("evalhub.cli.mcp_cmd._find_mcp_binary", return_value="/usr/bin/evalhub-mcp")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_run_respects_profile_flag(
     mock_find: MagicMock,
     mock_run: MagicMock,

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -62,7 +62,7 @@ def test_mcp_subcommands_appear_in_help(runner: CliRunner) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("evalhub.cli.mcp_cmd.subprocess.run")
+@patch("evalhub.cli._process.subprocess.run")
 @patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_run_stdio(
     mock_find: MagicMock,
@@ -259,7 +259,7 @@ def test_mcp_status_running_server_info_unavailable(
 # ---------------------------------------------------------------------------
 
 
-@patch("evalhub.cli.mcp_cmd.subprocess.run")
+@patch("evalhub.cli._process.subprocess.run")
 @patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_run_generates_config_from_profile(
     mock_find: MagicMock,
@@ -368,7 +368,7 @@ def test_mcp_start_rejects_stdio_transport(
     mock_popen.assert_not_called()
 
 
-@patch("evalhub.cli.mcp_cmd.subprocess.run")
+@patch("evalhub.cli._process.subprocess.run")
 @patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
 def test_mcp_run_respects_profile_flag(
     mock_find: MagicMock,

--- a/tests/unit/test_cli_server.py
+++ b/tests/unit/test_cli_server.py
@@ -117,7 +117,7 @@ def _setup_server_config(
 
 @patch("evalhub.cli.server_cmd.subprocess.run")
 @patch(
-    "evalhub.cli.server_cmd._find_server_binary",
+    "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
 def test_server_run_foreground(
@@ -144,7 +144,7 @@ def test_server_run_foreground(
 
 @patch("evalhub.cli.server_cmd.subprocess.run")
 @patch(
-    "evalhub.cli.server_cmd._find_server_binary",
+    "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
 def test_server_run_config_dir_override(
@@ -168,7 +168,7 @@ def test_server_run_config_dir_override(
 
 
 @patch(
-    "evalhub.cli.server_cmd._find_server_binary",
+    "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
 def test_server_run_no_config_errors(
@@ -195,7 +195,7 @@ def test_server_run_binary_not_found(
     _seed_profile(config_file)
 
     with patch(
-        "evalhub.cli.server_cmd._find_server_binary",
+        "evalhub.cli.server_cmd.find_binary",
         side_effect=ClickException(
             "Could not find the 'eval-hub-server' binary.\n"
             "Install it and ensure it is on your PATH, or set EVALHUB_SERVER_BIN."
@@ -213,9 +213,9 @@ def test_server_run_binary_not_found(
 
 
 @patch("evalhub.cli.server_cmd._wait_for_healthy", return_value=True)
-@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch("evalhub.cli._process.subprocess.Popen")
 @patch(
-    "evalhub.cli.server_cmd._find_server_binary",
+    "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
 def test_server_start_launches_background(
@@ -252,9 +252,9 @@ def test_server_start_launches_background(
     assert pid_file.read_text().strip() == "12345"
 
 
-@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch("evalhub.cli._process.subprocess.Popen")
 @patch(
-    "evalhub.cli.server_cmd._find_server_binary",
+    "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
 def test_server_start_already_running(
@@ -271,7 +271,7 @@ def test_server_start_already_running(
     with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path), patch(
         "evalhub.cli.server_cmd.PID_FILE", pid_file
     ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
-        "evalhub.cli.server_cmd._is_process_alive", return_value=True
+        "evalhub.cli._process.is_process_alive", return_value=True
     ):
         result = runner.invoke(main, ["server", "start"])
 
@@ -282,9 +282,9 @@ def test_server_start_already_running(
 
 
 @patch("evalhub.cli.server_cmd._wait_for_healthy", return_value=False)
-@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch("evalhub.cli._process.subprocess.Popen")
 @patch(
-    "evalhub.cli.server_cmd._find_server_binary",
+    "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
 def test_server_start_crash_on_startup(
@@ -314,9 +314,9 @@ def test_server_start_crash_on_startup(
 
 
 @patch("evalhub.cli.server_cmd._wait_for_healthy", return_value=False)
-@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch("evalhub.cli._process.subprocess.Popen")
 @patch(
-    "evalhub.cli.server_cmd._find_server_binary",
+    "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
 def test_server_start_health_check_timeout(
@@ -345,9 +345,9 @@ def test_server_start_health_check_timeout(
 
 
 @patch("evalhub.cli.server_cmd._wait_for_healthy", return_value=True)
-@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch("evalhub.cli._process.subprocess.Popen")
 @patch(
-    "evalhub.cli.server_cmd._find_server_binary",
+    "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
 def test_server_start_tls_uses_https_scheme(
@@ -379,7 +379,7 @@ def test_server_start_tls_uses_https_scheme(
 
 
 @patch(
-    "evalhub.cli.server_cmd._find_server_binary",
+    "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
 def test_server_start_no_config_errors(
@@ -404,7 +404,7 @@ def test_server_start_no_config_errors(
 # ---------------------------------------------------------------------------
 
 
-@patch("evalhub.cli.server_cmd.os.kill")
+@patch("evalhub.cli._process.os.kill")
 def test_server_stop_success(
     mock_kill: MagicMock,
     runner: CliRunner,
@@ -418,8 +418,8 @@ def test_server_stop_success(
     alive_calls = iter([True, False])
 
     with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
-        "evalhub.cli.server_cmd._is_process_alive", side_effect=alive_calls
-    ), patch("evalhub.cli.server_cmd.time.sleep"):
+        "evalhub.cli._process.is_process_alive", side_effect=alive_calls
+    ), patch("evalhub.cli._process.time.sleep"):
         result = runner.invoke(main, ["server", "stop"])
 
     assert result.exit_code == 0, result.output
@@ -441,7 +441,7 @@ def test_server_stop_not_running(
     assert "not running" in result.output
 
 
-@patch("evalhub.cli.server_cmd.os.kill")
+@patch("evalhub.cli._process.os.kill")
 def test_server_stop_force_kill(
     mock_kill: MagicMock,
     runner: CliRunner,
@@ -453,8 +453,8 @@ def test_server_stop_force_kill(
     pid_file.write_text("12345")
 
     with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
-        "evalhub.cli.server_cmd._is_process_alive", return_value=True
-    ), patch("evalhub.cli.server_cmd.time.sleep"), patch(
+        "evalhub.cli._process.is_process_alive", return_value=True
+    ), patch("evalhub.cli._process.time.sleep"), patch(
         "evalhub.cli.server_cmd._STOP_TIMEOUT", 0
     ):
         result = runner.invoke(main, ["server", "stop"])
@@ -475,8 +475,11 @@ def test_server_status_not_running(
     config_file: Path,
 ) -> None:
     _seed_profile(config_file)
+    _setup_server_config(tmp_path, config_file)
 
-    with patch("evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"):
+    with patch("evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"), patch(
+        "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
+    ), patch("evalhub.cli.server_cmd._health_check", return_value=False):
         result = runner.invoke(main, ["server", "status"])
 
     assert result.exit_code == 0, result.output
@@ -496,7 +499,7 @@ def test_server_status_running_healthy(
     with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
         "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
     ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
-        "evalhub.cli.server_cmd._is_process_alive", return_value=True
+        "evalhub.cli._process.is_process_alive", return_value=True
     ), patch("evalhub.cli.server_cmd._health_check", return_value=True):
         result = runner.invoke(main, ["server", "status"])
 
@@ -505,6 +508,29 @@ def test_server_status_running_healthy(
     assert "12345" in result.output
     assert "healthy" in result.output
     assert "http://localhost:8080" in result.output
+    assert "Logs:" in result.output
+
+
+def test_server_status_healthy_no_pid(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    """Status detects a foreground server via health endpoint even without a PID file."""
+    _seed_profile(config_file)
+    _setup_server_config(tmp_path, config_file)
+
+    with patch("evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"), patch(
+        "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
+    ), patch("evalhub.cli.server_cmd._health_check", return_value=True):
+        result = runner.invoke(main, ["server", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "running" in result.output
+    assert "healthy" in result.output
+    assert "http://localhost:8080" in result.output
+    assert "PID" not in result.output
+    assert "Logs:" not in result.output
 
 
 def test_server_status_tls_uses_https_scheme(
@@ -520,7 +546,7 @@ def test_server_status_tls_uses_https_scheme(
     with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
         "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
     ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
-        "evalhub.cli.server_cmd._is_process_alive", return_value=True
+        "evalhub.cli._process.is_process_alive", return_value=True
     ), patch("evalhub.cli.server_cmd._health_check", return_value=True) as mock_hc:
         result = runner.invoke(main, ["server", "status"])
 
@@ -543,7 +569,7 @@ def test_server_status_running_unhealthy(
     with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
         "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
     ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
-        "evalhub.cli.server_cmd._is_process_alive", return_value=True
+        "evalhub.cli._process.is_process_alive", return_value=True
     ), patch("evalhub.cli.server_cmd._health_check", return_value=False):
         result = runner.invoke(main, ["server", "status"])
 

--- a/tests/unit/test_cli_server.py
+++ b/tests/unit/test_cli_server.py
@@ -13,6 +13,8 @@ import yaml
 from click.testing import CliRunner
 from evalhub.cli.main import main
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 def config_file(tmp_path: Path) -> Iterator[Path]:
@@ -29,6 +31,8 @@ def config_file(tmp_path: Path) -> Iterator[Path]:
         os.environ.pop("EVALHUB_CONFIG", None)
     if saved_token is not None:
         os.environ["EVALHUB_TOKEN"] = saved_token
+    else:
+        os.environ.pop("EVALHUB_TOKEN", None)
 
 
 def _seed_profile(config_file: Path, profile: str = "default", **kwargs: str) -> None:

--- a/tests/unit/test_cli_server.py
+++ b/tests/unit/test_cli_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -64,7 +65,7 @@ def test_server_subcommands_appear_in_help(runner: CliRunner) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _patch_server_state(tmp_path: Path):
+def _patch_server_state(tmp_path: Path) -> tuple[Any, Any, Any]:
     """Context manager that patches all server state dir paths to tmp_path."""
     return (
         patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path),
@@ -73,7 +74,7 @@ def _patch_server_state(tmp_path: Path):
     )
 
 
-def _apply_patches(*patches):
+def _apply_patches(*patches: Any) -> list[Any]:
     """Enter multiple patches; return list to exit later. Not a context manager."""
     started = []
     for p in patches:
@@ -115,7 +116,7 @@ def _setup_server_config(
 # ---------------------------------------------------------------------------
 
 
-@patch("evalhub.cli.server_cmd.subprocess.run")
+@patch("evalhub.cli._process.subprocess.run")
 @patch(
     "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
@@ -140,31 +141,6 @@ def test_server_run_foreground(
     assert cmd[0] == "/usr/bin/eval-hub-server"
     assert "-local" in cmd
     assert "-configdir" in cmd
-
-
-@patch("evalhub.cli.server_cmd.subprocess.run")
-@patch(
-    "evalhub.cli.server_cmd.find_binary",
-    return_value="/usr/bin/eval-hub-server",
-)
-def test_server_run_config_dir_override(
-    mock_find: MagicMock,
-    mock_run: MagicMock,
-    runner: CliRunner,
-    tmp_path: Path,
-    config_file: Path,
-) -> None:
-    _seed_profile(config_file)
-    custom_dir = tmp_path / "custom"
-    custom_dir.mkdir()
-    (custom_dir / "config.yaml").write_text(yaml.safe_dump({"service": {"port": 9999}}))
-    mock_run.return_value = MagicMock(returncode=0)
-
-    result = runner.invoke(main, ["server", "run", "--config-dir", str(custom_dir)])
-
-    assert result.exit_code == 0, result.output
-    cmd = mock_run.call_args[0][0]
-    assert str(custom_dir) in cmd
 
 
 @patch(
@@ -583,7 +559,7 @@ def test_server_status_running_unhealthy(
 # ---------------------------------------------------------------------------
 
 
-def _patch_store_dir(tmp_path: Path):
+def _patch_store_dir(tmp_path: Path) -> Any:
     """Patch _FILE_KEY_STORE_DIRS so file keys write under tmp_path."""
     return patch(
         "evalhub.cli.config._FILE_KEY_STORE_DIRS",

--- a/tests/unit/test_cli_server.py
+++ b/tests/unit/test_cli_server.py
@@ -1,0 +1,797 @@
+"""Unit tests for the EvalHub CLI server subcommand."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+from evalhub.cli.main import main
+
+
+@pytest.fixture()
+def config_file(tmp_path: Path) -> Iterator[Path]:
+    """Provide a temporary config file path and isolate from env vars."""
+    path = tmp_path / "config.yaml"
+    saved_config = os.environ.get("EVALHUB_CONFIG")
+    saved_token = os.environ.get("EVALHUB_TOKEN")
+    os.environ["EVALHUB_CONFIG"] = str(path)
+    os.environ.pop("EVALHUB_TOKEN", None)
+    yield path
+    if saved_config is not None:
+        os.environ["EVALHUB_CONFIG"] = saved_config
+    else:
+        os.environ.pop("EVALHUB_CONFIG", None)
+    if saved_token is not None:
+        os.environ["EVALHUB_TOKEN"] = saved_token
+
+
+def _seed_profile(config_file: Path, profile: str = "default", **kwargs: str) -> None:
+    """Write a profile into the config file."""
+    data: dict[str, object] = {"active_profile": profile, "profiles": {profile: kwargs}}
+    config_file.write_text(yaml.safe_dump(data))
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Help / discoverability
+# ---------------------------------------------------------------------------
+
+
+def test_server_appears_in_help(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0
+    assert "server" in result.output
+
+
+def test_server_subcommands_appear_in_help(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["server", "--help"])
+    assert result.exit_code == 0
+    for sub in ("run", "start", "stop", "status"):
+        assert sub in result.output
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+def _patch_server_state(tmp_path: Path):
+    """Context manager that patches all server state dir paths to tmp_path."""
+    return (
+        patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path),
+        patch("evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"),
+        patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"),
+    )
+
+
+def _apply_patches(*patches):
+    """Enter multiple patches; return list to exit later. Not a context manager."""
+    started = []
+    for p in patches:
+        p.start()
+        started.append(p)
+    return started
+
+
+def _setup_server_config(
+    tmp_path: Path,
+    config_file: Path,
+    profile: str = "default",
+    *,
+    tls: bool = False,
+) -> Path:
+    """Create a minimal server config and register it in the CLI profile."""
+    cfg_dir = tmp_path / profile
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    svc: dict[str, object] = {"port": 8080}
+    if tls:
+        svc["tls_cert_file"] = "/tmp/server.crt"
+        svc["tls_key_file"] = "/tmp/server.key"
+    server_yaml = cfg_dir / "config.yaml"
+    server_yaml.write_text(yaml.safe_dump({"service": svc}))
+    data = (
+        yaml.safe_load(config_file.read_text())
+        if config_file.exists()
+        else {"active_profile": profile, "profiles": {profile: {}}}
+    )
+    data.setdefault("profiles", {}).setdefault(profile, {})["server_config_file"] = str(
+        server_yaml
+    )
+    config_file.write_text(yaml.safe_dump(data))
+    return cfg_dir
+
+
+# ---------------------------------------------------------------------------
+# server run
+# ---------------------------------------------------------------------------
+
+
+@patch("evalhub.cli.server_cmd.subprocess.run")
+@patch(
+    "evalhub.cli.server_cmd._find_server_binary",
+    return_value="/usr/bin/eval-hub-server",
+)
+def test_server_run_foreground(
+    mock_find: MagicMock,
+    mock_run: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    _setup_server_config(tmp_path, config_file)
+    mock_run.return_value = MagicMock(returncode=0)
+
+    with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path):
+        result = runner.invoke(main, ["server", "run"])
+
+    assert result.exit_code == 0, result.output
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "/usr/bin/eval-hub-server"
+    assert "-local" in cmd
+    assert "-configdir" in cmd
+
+
+@patch("evalhub.cli.server_cmd.subprocess.run")
+@patch(
+    "evalhub.cli.server_cmd._find_server_binary",
+    return_value="/usr/bin/eval-hub-server",
+)
+def test_server_run_config_dir_override(
+    mock_find: MagicMock,
+    mock_run: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    custom_dir = tmp_path / "custom"
+    custom_dir.mkdir()
+    (custom_dir / "config.yaml").write_text(yaml.safe_dump({"service": {"port": 9999}}))
+    mock_run.return_value = MagicMock(returncode=0)
+
+    result = runner.invoke(main, ["server", "run", "--config-dir", str(custom_dir)])
+
+    assert result.exit_code == 0, result.output
+    cmd = mock_run.call_args[0][0]
+    assert str(custom_dir) in cmd
+
+
+@patch(
+    "evalhub.cli.server_cmd._find_server_binary",
+    return_value="/usr/bin/eval-hub-server",
+)
+def test_server_run_no_config_errors(
+    mock_find: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+
+    with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path):
+        result = runner.invoke(main, ["server", "run"])
+
+    assert result.exit_code != 0
+    assert "No server config found" in result.output
+
+
+def test_server_run_binary_not_found(
+    runner: CliRunner,
+    config_file: Path,
+) -> None:
+    from click import ClickException
+
+    _seed_profile(config_file)
+
+    with patch(
+        "evalhub.cli.server_cmd._find_server_binary",
+        side_effect=ClickException(
+            "Could not find the 'eval-hub-server' binary.\n"
+            "Install it and ensure it is on your PATH, or set EVALHUB_SERVER_BIN."
+        ),
+    ):
+        result = runner.invoke(main, ["server", "run"])
+
+    assert result.exit_code != 0
+    assert "eval-hub-server" in result.output
+
+
+# ---------------------------------------------------------------------------
+# server start
+# ---------------------------------------------------------------------------
+
+
+@patch("evalhub.cli.server_cmd._wait_for_healthy", return_value=True)
+@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch(
+    "evalhub.cli.server_cmd._find_server_binary",
+    return_value="/usr/bin/eval-hub-server",
+)
+def test_server_start_launches_background(
+    mock_find: MagicMock,
+    mock_popen: MagicMock,
+    mock_healthy: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    _setup_server_config(tmp_path, config_file)
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 12345
+    mock_proc.poll.return_value = None
+    mock_popen.return_value = mock_proc
+
+    pid_file = tmp_path / "pid"
+    with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path), patch(
+        "evalhub.cli.server_cmd.PID_FILE", pid_file
+    ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"):
+        result = runner.invoke(main, ["server", "start"])
+
+    assert result.exit_code == 0, result.output
+    assert "12345" in result.output
+    assert "http://localhost:8080" in result.output
+
+    cmd = mock_popen.call_args[0][0]
+    assert "-local" in cmd
+    assert "-configdir" in cmd
+
+    assert pid_file.exists()
+    assert pid_file.read_text().strip() == "12345"
+
+
+@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch(
+    "evalhub.cli.server_cmd._find_server_binary",
+    return_value="/usr/bin/eval-hub-server",
+)
+def test_server_start_already_running(
+    mock_find: MagicMock,
+    mock_popen: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    pid_file = tmp_path / "pid"
+    pid_file.write_text("99999")
+
+    with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path), patch(
+        "evalhub.cli.server_cmd.PID_FILE", pid_file
+    ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
+        "evalhub.cli.server_cmd._is_process_alive", return_value=True
+    ):
+        result = runner.invoke(main, ["server", "start"])
+
+    assert result.exit_code != 0
+    assert "already running" in result.output
+    assert "evalhub server stop" in result.output
+    mock_popen.assert_not_called()
+
+
+@patch("evalhub.cli.server_cmd._wait_for_healthy", return_value=False)
+@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch(
+    "evalhub.cli.server_cmd._find_server_binary",
+    return_value="/usr/bin/eval-hub-server",
+)
+def test_server_start_crash_on_startup(
+    mock_find: MagicMock,
+    mock_popen: MagicMock,
+    mock_healthy: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    _setup_server_config(tmp_path, config_file)
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 11111
+    mock_proc.poll.return_value = 1
+    mock_proc.returncode = 1
+    mock_popen.return_value = mock_proc
+
+    with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path), patch(
+        "evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"
+    ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"):
+        result = runner.invoke(main, ["server", "start"])
+
+    assert result.exit_code != 0
+    assert "crashed on startup" in result.output
+
+
+@patch("evalhub.cli.server_cmd._wait_for_healthy", return_value=False)
+@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch(
+    "evalhub.cli.server_cmd._find_server_binary",
+    return_value="/usr/bin/eval-hub-server",
+)
+def test_server_start_health_check_timeout(
+    mock_find: MagicMock,
+    mock_popen: MagicMock,
+    mock_healthy: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    _setup_server_config(tmp_path, config_file)
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 22222
+    mock_proc.poll.return_value = None  # process still alive, just not healthy
+    mock_popen.return_value = mock_proc
+
+    with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path), patch(
+        "evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"
+    ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"):
+        result = runner.invoke(main, ["server", "start"])
+
+    assert result.exit_code != 0
+    assert "not become healthy" in result.output
+
+
+@patch("evalhub.cli.server_cmd._wait_for_healthy", return_value=True)
+@patch("evalhub.cli.server_cmd.subprocess.Popen")
+@patch(
+    "evalhub.cli.server_cmd._find_server_binary",
+    return_value="/usr/bin/eval-hub-server",
+)
+def test_server_start_tls_uses_https_scheme(
+    mock_find: MagicMock,
+    mock_popen: MagicMock,
+    mock_healthy: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    _setup_server_config(tmp_path, config_file, tls=True)
+
+    mock_proc = MagicMock()
+    mock_proc.pid = 12345
+    mock_proc.poll.return_value = None
+    mock_popen.return_value = mock_proc
+
+    pid_file = tmp_path / "pid"
+    with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path), patch(
+        "evalhub.cli.server_cmd.PID_FILE", pid_file
+    ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"):
+        result = runner.invoke(main, ["server", "start"])
+
+    assert result.exit_code == 0, result.output
+    assert "https://localhost:8080" in result.output
+    assert "http://localhost:8080" not in result.output
+    mock_healthy.assert_called_once_with(8080, 30.0, tls=True)
+
+
+@patch(
+    "evalhub.cli.server_cmd._find_server_binary",
+    return_value="/usr/bin/eval-hub-server",
+)
+def test_server_start_no_config_errors(
+    mock_find: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+
+    with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path), patch(
+        "evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"
+    ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"):
+        result = runner.invoke(main, ["server", "start"])
+
+    assert result.exit_code != 0
+    assert "No server config found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# server stop
+# ---------------------------------------------------------------------------
+
+
+@patch("evalhub.cli.server_cmd.os.kill")
+def test_server_stop_success(
+    mock_kill: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    pid_file = tmp_path / "pid"
+    pid_file.write_text("12345")
+
+    alive_calls = iter([True, False])
+
+    with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
+        "evalhub.cli.server_cmd._is_process_alive", side_effect=alive_calls
+    ), patch("evalhub.cli.server_cmd.time.sleep"):
+        result = runner.invoke(main, ["server", "stop"])
+
+    assert result.exit_code == 0, result.output
+    assert "stopped" in result.output
+    assert not pid_file.exists()
+
+
+def test_server_stop_not_running(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+
+    with patch("evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"):
+        result = runner.invoke(main, ["server", "stop"])
+
+    assert result.exit_code == 0, result.output
+    assert "not running" in result.output
+
+
+@patch("evalhub.cli.server_cmd.os.kill")
+def test_server_stop_force_kill(
+    mock_kill: MagicMock,
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    pid_file = tmp_path / "pid"
+    pid_file.write_text("12345")
+
+    with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
+        "evalhub.cli.server_cmd._is_process_alive", return_value=True
+    ), patch("evalhub.cli.server_cmd.time.sleep"), patch(
+        "evalhub.cli.server_cmd._STOP_TIMEOUT", 0
+    ):
+        result = runner.invoke(main, ["server", "stop"])
+
+    assert result.exit_code == 0, result.output
+    assert "force-killed" in result.output
+    assert not pid_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# server status
+# ---------------------------------------------------------------------------
+
+
+def test_server_status_not_running(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+
+    with patch("evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"):
+        result = runner.invoke(main, ["server", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "not running" in result.output
+
+
+def test_server_status_running_healthy(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    pid_file = tmp_path / "pid"
+    pid_file.write_text("12345")
+    _setup_server_config(tmp_path, config_file)
+
+    with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
+        "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
+    ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
+        "evalhub.cli.server_cmd._is_process_alive", return_value=True
+    ), patch("evalhub.cli.server_cmd._health_check", return_value=True):
+        result = runner.invoke(main, ["server", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "running" in result.output
+    assert "12345" in result.output
+    assert "healthy" in result.output
+    assert "http://localhost:8080" in result.output
+
+
+def test_server_status_tls_uses_https_scheme(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    pid_file = tmp_path / "pid"
+    pid_file.write_text("12345")
+    _setup_server_config(tmp_path, config_file, tls=True)
+
+    with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
+        "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
+    ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
+        "evalhub.cli.server_cmd._is_process_alive", return_value=True
+    ), patch("evalhub.cli.server_cmd._health_check", return_value=True) as mock_hc:
+        result = runner.invoke(main, ["server", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "https://localhost:8080" in result.output
+    assert "http://localhost:8080" not in result.output
+    mock_hc.assert_called_once_with(8080, tls=True)
+
+
+def test_server_status_running_unhealthy(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    pid_file = tmp_path / "pid"
+    pid_file.write_text("12345")
+    _setup_server_config(tmp_path, config_file)
+
+    with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
+        "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
+    ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
+        "evalhub.cli.server_cmd._is_process_alive", return_value=True
+    ), patch("evalhub.cli.server_cmd._health_check", return_value=False):
+        result = runner.invoke(main, ["server", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "running" in result.output
+    assert "not responding" in result.output
+
+
+# ---------------------------------------------------------------------------
+# config set/get/unset server_config_file
+# ---------------------------------------------------------------------------
+
+
+def _patch_store_dir(tmp_path: Path):
+    """Patch _FILE_KEY_STORE_DIRS so file keys write under tmp_path."""
+    return patch(
+        "evalhub.cli.config._FILE_KEY_STORE_DIRS",
+        {"server_config_file": tmp_path / "server"},
+    )
+
+
+def test_config_set_server_config_file_copies_and_stores(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    src = tmp_path / "myconfig.yaml"
+    src.write_text(yaml.safe_dump({"service": {"port": 9090}}))
+
+    with _patch_store_dir(tmp_path):
+        result = runner.invoke(main, ["config", "set", "server_config_file", str(src)])
+
+    assert result.exit_code == 0, result.output
+    assert "server_config_file" in result.output
+
+    dest = tmp_path / "server" / "default" / "config.yaml"
+    assert dest.exists()
+    loaded = yaml.safe_load(dest.read_text())
+    assert loaded["service"]["port"] == 9090
+
+    get_result = runner.invoke(main, ["config", "get", "server_config_file"])
+    assert get_result.exit_code == 0
+    assert str(dest) in get_result.output
+
+
+def test_config_set_server_config_file_validates_yaml(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    src = tmp_path / "bad.yaml"
+    src.write_text(": :\n  - :\n  bad: [unterminated")
+
+    result = runner.invoke(main, ["config", "set", "server_config_file", str(src)])
+
+    assert result.exit_code != 0
+    assert "Invalid YAML" in result.output
+
+
+def test_config_set_server_config_file_rejects_non_mapping(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    src = tmp_path / "list.yaml"
+    src.write_text("- item1\n- item2\n")
+
+    result = runner.invoke(main, ["config", "set", "server_config_file", str(src)])
+
+    assert result.exit_code != 0
+    assert "mapping" in result.output
+
+
+def test_config_set_server_config_file_not_found(
+    runner: CliRunner,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    result = runner.invoke(
+        main, ["config", "set", "server_config_file", "/nonexistent/path.yaml"]
+    )
+    assert result.exit_code != 0
+    assert "File not found" in result.output
+
+
+def test_config_set_server_config_file_respects_profile(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    data = {
+        "active_profile": "default",
+        "profiles": {
+            "default": {"base_url": "http://localhost:8080"},
+            "staging": {"base_url": "https://staging.example.com"},
+        },
+    }
+    config_file.write_text(yaml.safe_dump(data))
+
+    src = tmp_path / "staging.yaml"
+    src.write_text(yaml.safe_dump({"service": {"port": 8081}}))
+
+    with _patch_store_dir(tmp_path):
+        result = runner.invoke(
+            main,
+            [
+                "--profile",
+                "staging",
+                "config",
+                "set",
+                "server_config_file",
+                str(src),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "staging" in result.output
+    assert (tmp_path / "server" / "staging" / "config.yaml").exists()
+    assert not (tmp_path / "server" / "default" / "config.yaml").exists()
+
+
+def test_config_get_server_config_file_unfold(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    src = tmp_path / "myconfig.yaml"
+    content = yaml.safe_dump(
+        {"service": {"port": 9090}, "database": {"path": "data.db"}}
+    )
+    src.write_text(content)
+
+    with _patch_store_dir(tmp_path):
+        runner.invoke(main, ["config", "set", "server_config_file", str(src)])
+
+    result = runner.invoke(main, ["config", "get", "server_config_file", "--unfold"])
+    assert result.exit_code == 0, result.output
+    assert "9090" in result.output
+    assert "data.db" in result.output
+
+
+def test_config_get_unfold_file_missing(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    src = tmp_path / "myconfig.yaml"
+    src.write_text(yaml.safe_dump({"key": "value"}))
+
+    with _patch_store_dir(tmp_path):
+        runner.invoke(main, ["config", "set", "server_config_file", str(src)])
+
+    dest = tmp_path / "server" / "default" / "config.yaml"
+    dest.unlink()
+
+    result = runner.invoke(main, ["config", "get", "server_config_file", "--unfold"])
+    assert result.exit_code != 0
+    assert "File not found" in result.output
+
+
+def test_config_get_unfold_non_file_key_errors(
+    runner: CliRunner,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file, base_url="http://localhost:8080")
+    result = runner.invoke(main, ["config", "get", "base_url", "--unfold"])
+    assert result.exit_code != 0
+    assert "file-based" in result.output
+
+
+def test_config_get_unmask_and_unfold_mutually_exclusive(
+    runner: CliRunner,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file, token="secret")
+    result = runner.invoke(main, ["config", "get", "token", "--unmask", "--unfold"])
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_config_unset_server_config_file_deletes_stored_copy(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    src = tmp_path / "myconfig.yaml"
+    src.write_text(yaml.safe_dump({"key": "value"}))
+
+    with _patch_store_dir(tmp_path):
+        runner.invoke(main, ["config", "set", "server_config_file", str(src)])
+
+        dest = tmp_path / "server" / "default" / "config.yaml"
+        assert dest.exists()
+
+        result = runner.invoke(main, ["config", "unset", "server_config_file"])
+
+    assert result.exit_code == 0, result.output
+    assert "Unset" in result.output
+    assert not dest.exists()
+    assert not (tmp_path / "server" / "default").exists()
+
+    get_result = runner.invoke(main, ["config", "get", "server_config_file"])
+    assert get_result.exit_code != 0
+
+
+def test_config_list_shows_server_config_file(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    src = tmp_path / "myconfig.yaml"
+    src.write_text(yaml.safe_dump({"key": "value"}))
+
+    with _patch_store_dir(tmp_path):
+        runner.invoke(main, ["config", "set", "server_config_file", str(src)])
+
+    result = runner.invoke(main, ["config", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "server_config_file" in result.output
+
+
+def test_config_set_then_unfold_roundtrip(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    src = tmp_path / "myconfig.yaml"
+    original = {"service": {"port": 7070, "host": "0.0.0.0"}}
+    src.write_text(yaml.safe_dump(original))
+
+    with _patch_store_dir(tmp_path):
+        set_result = runner.invoke(
+            main, ["config", "set", "server_config_file", str(src)]
+        )
+    assert set_result.exit_code == 0, set_result.output
+
+    unfold_result = runner.invoke(
+        main, ["config", "get", "server_config_file", "--unfold"]
+    )
+    assert unfold_result.exit_code == 0, unfold_result.output
+    loaded = yaml.safe_load(unfold_result.output)
+    assert loaded == original


### PR DESCRIPTION
## What and why

Add `evalhub server` command group with run/start/stop/status and config management (set/show/unset), mirroring the mcp subcommand pattern.

Set the server config file
```
╰─➤  evalhub config set server_config_file myserver-config.yaml
Set 'server_config_file' in profile 'default'
```

config list does not unfold the yaml
```
╰─➤  evalhub config list
Profile: default
  base_url: http://localhost:8080
  server_config_file: /Users/gnaulak/.config/evalhub/server/default/config.yaml

  Missing required keys: token, tenant
```

To check the server yaml use config get with --unfold:
```
╰─➤  evalhub config get server_config_file --unfold
service:
  port: 8080
  ready_file: "/tmp/repo-ready"

# Database configuration
database:
  driver: sqlite
  url: file::eval_hub:?mode=memory&cache=shared
```

To start the server in foreground
```
evalhub server run
```

To start the server in background:
```
╰─➤  evalhub server start
Server started (PID 36693).
  URL:  http://localhost:8080
  Logs: /Users/gnaulak/.config/evalhub/server/server.log

╰─➤  evalhub server status
Server is running (PID 36693).
  Health: healthy
  URL:    http://localhost:8080
  Logs:   /Users/gnaulak/.config/evalhub/server/server.log

╰─➤  evalhub server stop
Server stopped.
```

This support tls:
```
╰─➤  evalhub config set server_config_file myserver-config-tls.yaml
Set 'server_config_file' in profile 'default'

╰─➤  evalhub server start
Server started (PID 37009).
  URL:  https://localhost:8080
  Logs: /Users/gnaulak/.config/evalhub/server/server.log

╰─➤  curl -k https://localhost:8080/api/v1/health
{"status":"healthy","timestamp":"2026-06-30T17:01:05.99972Z","build":"0.4.3","build_date":"2026-06-22T08:33:42+0000","git_hash":"6110928"}
```

To unset:
```
╰─➤  evalhub config unset server_config_file
Unset 'server_config_file' from profile 'default'
```

Closes # https://redhat.atlassian.net/browse/RHOAIENG-68000

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added an `evalhub server` command group (`run`, `start`, `stop`, `status`).
  * Introduced file-backed configuration keys, including viewing stored file contents via `--unfold`.

* **Bug Fixes**
  * Improved daemon lifecycle handling for reliable start/stop/status behavior (including graceful shutdown, PID handling, and log/health checks).
  * Refined MLflow tag/metadata conversion for more consistent experiment lookups.

* **Tests**
  * Added unit test coverage for the `server` command lifecycle and config workflows.
  * Updated MCP CLI unit tests to match the new process-management flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->