### PR TITLE
feat(cli): replace individual MCP profile keys with file-based config `mcp_config_file`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-e2e:
 
 .PHONY: ruff
 ruff:
-	uv run ruff check --fix src/evalhub
+	uv run ruff check --fix src/evalhub tests
 	uv run ruff format src tests
 
 .PHONY: mypy

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -211,18 +211,10 @@ def remove_file_key(key: str, profile_name: str) -> None:
 
 def resolve_component_config_dir(
     data: dict[str, Any],
-    config_key: str,
     state_dir: Path,
     profile: str | None = None,
 ) -> Path:
-    """Return the config directory for a component (MCP, server, etc.).
-
-    If the profile has *config_key* set, its parent directory is returned.
-    Otherwise falls back to ``state_dir / <profile_name>``.
-    """
-    value = get_value(data, config_key, profile=profile)
-    if value:
-        return Path(str(value)).parent
+    """Return the config directory for a component (MCP, server, etc.)."""
     profile_name = profile or get_active_profile(data)
     return state_dir / profile_name
 

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -33,14 +33,12 @@ OPTIONAL_KEYS = (
     "provider",
     "insecure",
     "timeout",
-    "mcp_transport",
-    "mcp_host",
-    "mcp_port",
+    "mcp_config_file",
     "server_config_file",
 )
 KNOWN_KEYS = set(REQUIRED_KEYS) | set(OPTIONAL_KEYS)
 SENSITIVE_KEYS = frozenset({"token"})
-FILE_KEYS = frozenset({"server_config_file"})
+FILE_KEYS = frozenset({"mcp_config_file", "server_config_file"})
 
 DEFAULT_PROFILE = "default"
 
@@ -154,6 +152,7 @@ def is_file_key(key: str) -> bool:
 
 
 _FILE_KEY_STORE_DIRS: dict[str, Path] = {
+    "mcp_config_file": DEFAULT_CONFIG_DIR / "mcp",
     "server_config_file": DEFAULT_CONFIG_DIR / "server",
 }
 
@@ -203,6 +202,24 @@ def remove_file_key(key: str, profile_name: str) -> None:
         pass
 
 
+def resolve_component_config_dir(
+    data: dict[str, Any],
+    config_key: str,
+    state_dir: Path,
+    profile: str | None = None,
+) -> Path:
+    """Return the config directory for a component (MCP, server, etc.).
+
+    If the profile has *config_key* set, its parent directory is returned.
+    Otherwise falls back to ``state_dir / <profile_name>``.
+    """
+    value = get_value(data, config_key, profile=profile)
+    if value:
+        return Path(str(value)).parent
+    profile_name = profile or get_active_profile(data)
+    return state_dir / profile_name
+
+
 def set_active_profile(data: dict[str, Any], profile: str) -> dict[str, Any]:
     """Switch the active profile."""
     data["active_profile"] = profile
@@ -214,22 +231,3 @@ def parse_bool(value: Any, *, default: bool = False) -> bool:
     if value is None:
         return default
     return str(value).lower() in ("true", "1", "yes")
-
-
-def build_mcp_config(
-    profile: dict[str, Any], *, default_transport: str = "http"
-) -> dict[str, Any]:
-    """Build the Go MCP binary config dict from a CLI profile."""
-    try:
-        port = int(profile.get("mcp_port", 3001))
-    except (TypeError, ValueError):
-        port = 3001
-    return {
-        "base_url": profile.get("base_url", "http://localhost:8080"),
-        "token": profile.get("token", ""),
-        "tenant": profile.get("tenant", ""),
-        "insecure": parse_bool(profile.get("insecure")),
-        "transport": profile.get("mcp_transport", default_transport),
-        "host": profile.get("mcp_host", "localhost"),
-        "port": port,
-    }

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -52,6 +52,13 @@ def mask_value(
     return f"{value[:prefix_len]}***{value[-suffix_len:]}"
 
 
+def mask_mapping(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *mapping* with sensitive values masked."""
+    return {
+        k: mask_value(str(v)) if k in SENSITIVE_KEYS else v for k, v in mapping.items()
+    }
+
+
 def _config_path() -> Path:
     """Return the config file path, respecting EVALHUB_CONFIG env var."""
     env = os.environ.get("EVALHUB_CONFIG")

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -1148,15 +1148,16 @@ def config(ctx: click.Context) -> None:
     profile, and 'config use' to switch profiles.
 
     \b
-    File-based keys (e.g. server_config_file) store a path to a
-    YAML file. Use 'config get <key> --unfold' to view the file
-    contents.
+    File-based keys (e.g. mcp_config_file, server_config_file) store
+    a path to a YAML file. Use 'config get <key> --unfold' to view
+    the file contents.
 
     \b
     Examples:
       evalhub config set base_url http://localhost:8080
+      evalhub config set mcp_config_file mcp-config.yaml
       evalhub config set server_config_file myserver-config.yaml
-      evalhub config get server_config_file --unfold
+      evalhub config get mcp_config_file --unfold
       evalhub config list
       evalhub config use prod
     """
@@ -1171,26 +1172,19 @@ def config_set(ctx: click.Context, key: str, value: str) -> None:
 
     \b
     Known keys: base_url, token, tenant, provider, insecure, timeout,
-    mcp_transport, mcp_host, mcp_port, server_config_file.
+    mcp_config_file, server_config_file.
 
     \b
-    File-based keys (server_config_file) accept a path to a YAML file.
-    The file is validated and copied into the CLI config directory.
-
-    \b
-    mcp_transport values:
-      stdio    — default for 'evalhub mcp run'
-      http     — Streamable HTTP, default for 'evalhub mcp start'
-      http-sse — legacy HTTP+SSE
-    When mcp_transport is not set, each command uses its own default.
-    mcp_host default: localhost
-    mcp_port default: 3001
+    File-based keys (mcp_config_file, server_config_file) accept a
+    path to a YAML file. The file is validated and copied into the
+    CLI config directory.
 
     \b
     Examples:
       evalhub config set base_url http://localhost:8080
       evalhub config set token my-api-token
       evalhub config set tenant my-tenant
+      evalhub config set mcp_config_file mcp-config.yaml
       evalhub config set server_config_file myserver-config.yaml
       evalhub --profile prod config set base_url https://evalhub.example.com
     """
@@ -1224,7 +1218,7 @@ def config_unset(ctx: click.Context, key: str) -> None:
 
     \b
     Examples:
-      evalhub config unset mcp_port
+      evalhub config unset mcp_config_file
       evalhub config unset server_config_file
       evalhub --profile prod config unset insecure
     """
@@ -1266,7 +1260,7 @@ def config_get(ctx: click.Context, key: str, unmask: bool, unfold: bool) -> None
     Examples:
       evalhub config get base_url
       evalhub config get token --unmask
-      evalhub config get server_config_file
+      evalhub config get mcp_config_file --unfold
       evalhub config get server_config_file --unfold
     """
     if unmask and unfold:

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -1253,18 +1253,17 @@ def config_get(ctx: click.Context, key: str, unmask: bool, unfold: bool) -> None
     \b
     Sensitive values (e.g. token) are masked by default.
     Use --unmask to reveal the full value.
-    Use --unfold with file-based keys (e.g. server_config_file) to
-    print the referenced file's contents.
+    Use --unfold with file-based keys (e.g. mcp_config_file) to
+    print the referenced file's contents (sensitive values masked
+    by default; combine with --unmask to reveal them).
 
     \b
     Examples:
       evalhub config get base_url
       evalhub config get token --unmask
       evalhub config get mcp_config_file --unfold
-      evalhub config get server_config_file --unfold
+      evalhub config get mcp_config_file --unfold --unmask
     """
-    if unmask and unfold:
-        raise click.ClickException("--unmask and --unfold are mutually exclusive.")
     profile = ctx.obj.get("profile")
     data = cfg.load_config()
     value = cfg.get_value(data, key, profile=profile)
@@ -1280,7 +1279,15 @@ def config_get(ctx: click.Context, key: str, unmask: bool, unfold: bool) -> None
         p = Path(str(value))
         if not p.is_file():
             raise click.ClickException(f"File not found: {value}")
-        click.echo(p.read_text(), nl=False)
+        text = p.read_text()
+        if unmask:
+            click.echo(text, nl=False)
+        else:
+            parsed = cfg.mask_mapping(yaml.safe_load(text))
+            click.echo(
+                yaml.safe_dump(parsed, default_flow_style=False, sort_keys=False),
+                nl=False,
+            )
     elif key in cfg.SENSITIVE_KEYS and not unmask:
         click.echo(cfg.mask_value(str(value)))
     else:
@@ -1308,9 +1315,8 @@ def config_list(ctx: click.Context) -> None:
     if not prof:
         click.echo("  (no configuration values)")
     else:
-        for k, v in prof.items():
-            display = cfg.mask_value(str(v)) if k in cfg.SENSITIVE_KEYS else v
-            click.echo(f"  {k}: {display}")
+        for k, v in cfg.mask_mapping(prof).items():
+            click.echo(f"  {k}: {v}")
     missing = cfg.missing_required_keys(data, profile=profile)
     if missing:
         click.echo(f"\n  Missing required keys: {', '.join(missing)}")

--- a/src/evalhub/cli/mcp_cmd.py
+++ b/src/evalhub/cli/mcp_cmd.py
@@ -194,7 +194,7 @@ def mcp_run(ctx: click.Context) -> None:
     data = cfg.load_config()
     profile_name = ctx.obj.get("profile")
     cfg_dir = cfg.resolve_component_config_dir(
-        data, "mcp_config_file", MCP_STATE_DIR, profile=profile_name
+        data, MCP_STATE_DIR, profile=profile_name
     )
     _, config_path = _generate_merged_config(
         cfg.get_profile(data, profile_name),
@@ -225,7 +225,7 @@ def mcp_start(ctx: click.Context) -> None:
     data = cfg.load_config()
     profile_name = ctx.obj.get("profile")
     cfg_dir = cfg.resolve_component_config_dir(
-        data, "mcp_config_file", MCP_STATE_DIR, profile=profile_name
+        data, MCP_STATE_DIR, profile=profile_name
     )
 
     merged, config_path = _generate_merged_config(
@@ -285,7 +285,7 @@ def mcp_status(ctx: click.Context) -> None:
     data = cfg.load_config()
     profile_name = ctx.obj.get("profile")
     cfg_dir = cfg.resolve_component_config_dir(
-        data, "mcp_config_file", MCP_STATE_DIR, profile=profile_name
+        data, MCP_STATE_DIR, profile=profile_name
     )
     merged, _ = _generate_merged_config(cfg.get_profile(data, profile_name), cfg_dir)
     host = merged.get("host", "localhost")

--- a/src/evalhub/cli/mcp_cmd.py
+++ b/src/evalhub/cli/mcp_cmd.py
@@ -197,7 +197,9 @@ def mcp_run(ctx: click.Context) -> None:
         data, "mcp_config_file", MCP_STATE_DIR, profile=profile_name
     )
     _, config_path = _generate_merged_config(
-        cfg.get_profile(data, profile_name), cfg_dir
+        cfg.get_profile(data, profile_name),
+        cfg_dir,
+        defaults={"transport": "stdio"},
     )
     run_foreground([binary, "--config", str(config_path)], ctx)
 

--- a/src/evalhub/cli/mcp_cmd.py
+++ b/src/evalhub/cli/mcp_cmd.py
@@ -71,7 +71,9 @@ def _generate_merged_config(
         try:
             merged["port"] = int(merged["port"])
         except (TypeError, ValueError):
-            merged["port"] = _DEFAULT_PORT
+            raise click.ClickException(
+                f"Invalid port value: {merged['port']!r} (must be an integer)"
+            )
 
     dest = config_dir / GENERATED_CONFIG
     cfg.save_config(merged, dest)

--- a/src/evalhub/cli/mcp_cmd.py
+++ b/src/evalhub/cli/mcp_cmd.py
@@ -34,6 +34,16 @@ _STOP_TIMEOUT = 5.0
 _DEFAULT_PORT = 3001
 
 
+def _resolve_mcp_config(ctx: click.Context) -> tuple[dict[str, Any], Path]:
+    """Return (profile_dict, config_dir) for the active MCP profile."""
+    data = cfg.load_config()
+    profile_name = ctx.obj.get("profile")
+    cfg_dir = cfg.resolve_component_config_dir(
+        data, MCP_STATE_DIR, profile=profile_name
+    )
+    return cfg.get_profile(data, profile_name), cfg_dir
+
+
 def _generate_merged_config(
     profile: dict[str, Any],
     config_dir: Path,
@@ -191,15 +201,9 @@ def mcp_run(ctx: click.Context) -> None:
       evalhub --profile staging mcp run
     """
     binary = find_binary("evalhub-mcp", "EVALHUB_MCP_BIN")
-    data = cfg.load_config()
-    profile_name = ctx.obj.get("profile")
-    cfg_dir = cfg.resolve_component_config_dir(
-        data, MCP_STATE_DIR, profile=profile_name
-    )
+    profile, cfg_dir = _resolve_mcp_config(ctx)
     _, config_path = _generate_merged_config(
-        cfg.get_profile(data, profile_name),
-        cfg_dir,
-        defaults={"transport": "stdio"},
+        profile, cfg_dir, defaults={"transport": "stdio"}
     )
     run_foreground([binary, "--config", str(config_path)], ctx)
 
@@ -222,16 +226,9 @@ def mcp_start(ctx: click.Context) -> None:
     require_not_running(PID_FILE, "MCP server", "evalhub mcp stop")
 
     binary = find_binary("evalhub-mcp", "EVALHUB_MCP_BIN")
-    data = cfg.load_config()
-    profile_name = ctx.obj.get("profile")
-    cfg_dir = cfg.resolve_component_config_dir(
-        data, MCP_STATE_DIR, profile=profile_name
-    )
-
+    profile, cfg_dir = _resolve_mcp_config(ctx)
     merged, config_path = _generate_merged_config(
-        cfg.get_profile(data, profile_name),
-        cfg_dir,
-        defaults={"transport": "http"},
+        profile, cfg_dir, defaults={"transport": "http"}
     )
     transport = merged["transport"]
     host = merged.get("host", "localhost")
@@ -282,12 +279,12 @@ def mcp_status(ctx: click.Context) -> None:
 
     click.echo(f"MCP server is running (PID {pid}).")
 
-    data = cfg.load_config()
-    profile_name = ctx.obj.get("profile")
-    cfg_dir = cfg.resolve_component_config_dir(
-        data, MCP_STATE_DIR, profile=profile_name
-    )
-    merged, _ = _generate_merged_config(cfg.get_profile(data, profile_name), cfg_dir)
+    _, cfg_dir = _resolve_mcp_config(ctx)
+    config_path = cfg_dir / GENERATED_CONFIG
+    try:
+        merged = yaml.safe_load(config_path.read_text()) or {}
+    except (FileNotFoundError, yaml.YAMLError):
+        merged = {}
     host = merged.get("host", "localhost")
     port = merged.get("port", _DEFAULT_PORT)
 

--- a/src/evalhub/cli/mcp_cmd.py
+++ b/src/evalhub/cli/mcp_cmd.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import json
 import time
 import urllib.request
+from pathlib import Path
 from typing import Any
 
 import click
+import yaml
 
 from evalhub import __version__
 
@@ -24,26 +26,56 @@ from ._process import (
 MCP_STATE_DIR = cfg.DEFAULT_CONFIG_DIR / "mcp"
 PID_FILE = MCP_STATE_DIR / "pid"
 LOG_FILE = MCP_STATE_DIR / "mcp.log"
-CONFIG_FILE = MCP_STATE_DIR / "config.yaml"
+GENERATED_CONFIG = "mcp-config.yaml"
 
 _STARTUP_WAIT = 2.0
 _STOP_TIMEOUT = 5.0
 
+_DEFAULT_PORT = 3001
 
-def _generate_config(
-    ctx: click.Context,
-    *,
-    default_transport: str = "http",
-) -> tuple[list[str], dict[str, object]]:
-    """Build MCP config from the active CLI profile.
 
-    Returns (extra_cli_args, mcp_config_dict).
+def _generate_merged_config(
+    profile: dict[str, Any],
+    config_dir: Path,
+    defaults: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], Path]:
+    """Merge root profile connection keys with MCP config.
+
+    If ``config_dir / "config.yaml"`` does not exist it is treated as
+    empty — the generated config will contain only values sourced from
+    the root CLI profile (if any).  MCP config keys take precedence.
+    *defaults* are applied first and overridden by both profile and
+    MCP config values.  The merged result is written to
+    ``config_dir / GENERATED_CONFIG`` and returned along with the path.
     """
-    data = cfg.load_config()
-    profile = cfg.get_profile(data, ctx.obj.get("profile"))
-    mcp_config = cfg.build_mcp_config(profile, default_transport=default_transport)
-    cfg.save_config(mcp_config, CONFIG_FILE)
-    return ["--config", str(CONFIG_FILE)], mcp_config
+    merged: dict[str, Any] = dict(defaults) if defaults else {}
+    for key in ("base_url", "token", "tenant", "insecure"):
+        val = profile.get(key)
+        if val is not None:
+            merged[key] = val
+
+    mcp_path = config_dir / "config.yaml"
+    if mcp_path.exists():
+        try:
+            mcp_data = yaml.safe_load(mcp_path.read_text()) or {}
+        except (yaml.YAMLError, TypeError) as exc:
+            raise click.ClickException(
+                f"Failed to parse MCP config {mcp_path}: {exc}"
+            ) from exc
+        merged.update(mcp_data)
+
+    if "insecure" in merged:
+        merged["insecure"] = cfg.parse_bool(merged["insecure"])
+
+    if "port" in merged:
+        try:
+            merged["port"] = int(merged["port"])
+        except (TypeError, ValueError):
+            merged["port"] = _DEFAULT_PORT
+
+    dest = config_dir / GENERATED_CONFIG
+    cfg.save_config(merged, dest)
+    return merged, dest
 
 
 _JSONRPC_VERSION = "2.0"
@@ -146,13 +178,26 @@ def mcp() -> None:
 def mcp_run(ctx: click.Context) -> None:
     """Run the evalhub-mcp binary in the foreground.
 
-    Uses the mcp_transport value from the active profile if set,
-    otherwise defaults to stdio. The active CLI profile is used to
-    generate ~/.config/evalhub/mcp/config.yaml automatically.
+    \b
+    Reads MCP-specific settings from the MCP config file and merges
+    connection keys (base_url, token, tenant, insecure) from the
+    active CLI profile. MCP config values take precedence.
+
+    \b
+    Examples:
+      evalhub mcp run
+      evalhub --profile staging mcp run
     """
     binary = find_binary("evalhub-mcp", "EVALHUB_MCP_BIN")
-    extra, _ = _generate_config(ctx, default_transport="stdio")
-    run_foreground([binary, *extra], ctx)
+    data = cfg.load_config()
+    profile_name = ctx.obj.get("profile")
+    cfg_dir = cfg.resolve_component_config_dir(
+        data, "mcp_config_file", MCP_STATE_DIR, profile=profile_name
+    )
+    _, config_path = _generate_merged_config(
+        cfg.get_profile(data, profile_name), cfg_dir
+    )
+    run_foreground([binary, "--config", str(config_path)], ctx)
 
 
 @mcp.command("start")
@@ -160,21 +205,44 @@ def mcp_run(ctx: click.Context) -> None:
 def mcp_start(ctx: click.Context) -> None:
     """Start the Go MCP binary as a background daemon.
 
-    Uses the mcp_transport value from the active profile if set,
-    otherwise defaults to http. The active CLI profile is used to
-    generate ~/.config/evalhub/mcp/config.yaml automatically.
+    \b
+    Reads MCP-specific settings from the MCP config file and merges
+    connection keys (base_url, token, tenant, insecure) from the
+    active CLI profile. MCP config values take precedence.
+
+    \b
+    Examples:
+      evalhub mcp start
+      evalhub --profile staging mcp start
     """
     require_not_running(PID_FILE, "MCP server", "evalhub mcp stop")
 
     binary = find_binary("evalhub-mcp", "EVALHUB_MCP_BIN")
-    extra, mcp_config = _generate_config(ctx)
-    if mcp_config.get("transport") == "stdio":
+    data = cfg.load_config()
+    profile_name = ctx.obj.get("profile")
+    cfg_dir = cfg.resolve_component_config_dir(
+        data, "mcp_config_file", MCP_STATE_DIR, profile=profile_name
+    )
+
+    merged, config_path = _generate_merged_config(
+        cfg.get_profile(data, profile_name),
+        cfg_dir,
+        defaults={"transport": "http"},
+    )
+    transport = merged["transport"]
+    host = merged.get("host", "localhost")
+    port = merged.get("port", _DEFAULT_PORT)
+
+    if transport == "stdio":
         raise click.ClickException(
-            "Cannot start in background with stdio transport.\n"
-            "Use 'evalhub mcp run' for stdio, or set a network transport:\n"
-            "  evalhub config set mcp_transport http"
+            "'evalhub mcp start' can be used only in non-stdio transport mode.\n"
+            "Use 'evalhub mcp run' for stdio, or update your MCP config\n"
+            "to use a different transport:\n"
+            "  evalhub config set mcp_config_file <myconfig.yaml>\n"
+            "where myconfig.yaml contains:\n"
+            "  transport: http"
         )
-    cmd = [binary, *extra]
+    cmd = [binary, "--config", str(config_path)]
 
     proc = spawn_background(cmd, MCP_STATE_DIR, LOG_FILE)
     time.sleep(_STARTUP_WAIT)
@@ -188,8 +256,8 @@ def mcp_start(ctx: click.Context) -> None:
 
     PID_FILE.write_text(str(proc.pid))
     click.echo(f"MCP server started (PID {proc.pid}).")
-    click.echo(f"  Transport: {mcp_config['transport']}")
-    click.echo(f"  URL:       http://{mcp_config['host']}:{mcp_config['port']}")
+    click.echo(f"  Transport: {transport}")
+    click.echo(f"  URL:       http://{host}:{port}")
     click.echo(f"  Logs:      {LOG_FILE}")
 
 
@@ -200,7 +268,8 @@ def mcp_stop() -> None:
 
 
 @mcp.command("status")
-def mcp_status() -> None:
+@click.pass_context
+def mcp_status(ctx: click.Context) -> None:
     """Check if the background MCP server is running."""
     pid = live_pid(PID_FILE)
     if pid is None:
@@ -209,9 +278,15 @@ def mcp_status() -> None:
 
     click.echo(f"MCP server is running (PID {pid}).")
 
-    mcp_cfg = cfg.load_config(CONFIG_FILE)
-    host = str(mcp_cfg.get("host", "localhost"))
-    port = int(mcp_cfg.get("port", 3001))
+    data = cfg.load_config()
+    profile_name = ctx.obj.get("profile")
+    cfg_dir = cfg.resolve_component_config_dir(
+        data, "mcp_config_file", MCP_STATE_DIR, profile=profile_name
+    )
+    merged, _ = _generate_merged_config(cfg.get_profile(data, profile_name), cfg_dir)
+    host = merged.get("host", "localhost")
+    port = merged.get("port", _DEFAULT_PORT)
+
     info = _fetch_server_info(host, port)
     if info:
         name = info.get("name", "unknown")

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -78,18 +78,14 @@ def _wait_for_healthy(port: int, timeout: float, *, tls: bool = False) -> bool:
     return _health_check(port, tls=tls)
 
 
-def _server_config_dir(profile_name: str) -> Path:
-    return SERVER_STATE_DIR / profile_name
-
-
 def _resolve_config_dir(ctx: click.Context) -> Path:
     data = cfg.load_config()
-    profile = ctx.obj.get("profile")
-    value = cfg.get_value(data, "server_config_file", profile=profile)
-    if value:
-        return Path(str(value)).parent
-    profile_name = profile or cfg.get_active_profile(data)
-    return _server_config_dir(profile_name)
+    return cfg.resolve_component_config_dir(
+        data,
+        "server_config_file",
+        SERVER_STATE_DIR,
+        profile=ctx.obj.get("profile"),
+    )
 
 
 def _require_config(config_dir: Path) -> None:

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -82,7 +82,6 @@ def _resolve_config_dir(ctx: click.Context) -> Path:
     data = cfg.load_config()
     return cfg.resolve_component_config_dir(
         data,
-        "server_config_file",
         SERVER_STATE_DIR,
         profile=ctx.obj.get("profile"),
     )

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -14,7 +14,6 @@ from click.testing import CliRunner
 from evalhub.cli.config import (
     DEFAULT_PROFILE,
     FILE_KEYS,
-    KNOWN_KEYS,
     OPTIONAL_KEYS,
     REQUIRED_KEYS,
     SENSITIVE_KEYS,

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -447,9 +447,6 @@ class TestMcpConfigFileKey:
     def test_mcp_config_file_in_optional_keys(self) -> None:
         assert "mcp_config_file" in OPTIONAL_KEYS
 
-    def test_mcp_config_file_in_known_keys(self) -> None:
-        assert "mcp_config_file" in KNOWN_KEYS
-
     def test_mcp_config_file_in_file_keys(self) -> None:
         assert "mcp_config_file" in FILE_KEYS
 

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -23,6 +23,7 @@ from evalhub.cli.config import (
     get_value,
     is_known_key,
     load_config,
+    mask_mapping,
     mask_value,
     missing_required_keys,
     parse_bool,
@@ -405,6 +406,21 @@ class TestMaskValue:
 
     def test_sensitive_keys_contains_token(self) -> None:
         assert "token" in SENSITIVE_KEYS
+
+
+class TestMaskMapping:
+    def test_masks_sensitive_keys(self) -> None:
+        mapping = {"base_url": "http://localhost", "token": "super-secret-tok"}
+        result = mask_mapping(mapping)
+        assert result["base_url"] == "http://localhost"
+        assert result["token"] == "sup***ok"
+
+    def test_leaves_non_sensitive_keys_unchanged(self) -> None:
+        mapping = {"host": "localhost", "port": 3001}
+        assert mask_mapping(mapping) == mapping
+
+    def test_empty_mapping(self) -> None:
+        assert mask_mapping({}) == {}
 
 
 class TestConfigMasking:

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -13,11 +13,11 @@ import yaml
 from click.testing import CliRunner
 from evalhub.cli.config import (
     DEFAULT_PROFILE,
+    FILE_KEYS,
     KNOWN_KEYS,
     OPTIONAL_KEYS,
     REQUIRED_KEYS,
     SENSITIVE_KEYS,
-    build_mcp_config,
     get_active_profile,
     get_profile,
     get_value,
@@ -443,62 +443,15 @@ class TestConfigMasking:
         assert "longtoken123" not in result.output
 
 
-class TestMcpConfigKeys:
-    def test_mcp_keys_in_optional_keys(self) -> None:
-        for key in ("mcp_transport", "mcp_host", "mcp_port"):
-            assert key in OPTIONAL_KEYS
+class TestMcpConfigFileKey:
+    def test_mcp_config_file_in_optional_keys(self) -> None:
+        assert "mcp_config_file" in OPTIONAL_KEYS
 
-    def test_mcp_keys_in_known_keys(self) -> None:
-        for key in ("mcp_transport", "mcp_host", "mcp_port"):
-            assert key in KNOWN_KEYS
+    def test_mcp_config_file_in_known_keys(self) -> None:
+        assert "mcp_config_file" in KNOWN_KEYS
 
-
-class TestBuildMcpConfig:
-    def test_defaults_from_empty_profile(self) -> None:
-        result = build_mcp_config({})
-        assert result == {
-            "base_url": "http://localhost:8080",
-            "token": "",
-            "tenant": "",
-            "insecure": False,
-            "transport": "http",
-            "host": "localhost",
-            "port": 3001,
-        }
-
-    def test_maps_profile_values(self) -> None:
-        profile = {
-            "base_url": "https://evalhub.example.com",
-            "token": "my-token",
-            "tenant": "team-a",
-            "insecure": "true",
-        }
-        result = build_mcp_config(profile)
-        assert result["base_url"] == "https://evalhub.example.com"
-        assert result["token"] == "my-token"
-        assert result["tenant"] == "team-a"
-        assert result["insecure"] is True
-        assert result["transport"] == "http"
-        assert result["host"] == "localhost"
-        assert result["port"] == 3001
-
-    def test_mcp_specific_overrides(self) -> None:
-        profile = {
-            "base_url": "http://localhost:8080",
-            "token": "t",
-            "tenant": "x",
-            "mcp_transport": "http-sse",
-            "mcp_host": "0.0.0.0",
-            "mcp_port": "9999",
-        }
-        result = build_mcp_config(profile)
-        assert result["transport"] == "http-sse"
-        assert result["host"] == "0.0.0.0"
-        assert result["port"] == 9999
-
-    def test_invalid_port_falls_back_to_default(self) -> None:
-        result = build_mcp_config({"mcp_port": "not-a-number"})
-        assert result["port"] == 3001
+    def test_mcp_config_file_in_file_keys(self) -> None:
+        assert "mcp_config_file" in FILE_KEYS
 
 
 class TestParseBool:

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -489,7 +489,6 @@ def test_merge_respects_profile_flag(
                 "base_url": "https://prod.example.com",
                 "token": "prod-tok",
                 "tenant": "prod-t",
-                "mcp_config_file": str(tmp_path / "mcp" / "prod" / "config.yaml"),
             },
         },
     }
@@ -497,7 +496,8 @@ def test_merge_respects_profile_flag(
     cfg_dir = _write_mcp_config(tmp_path / "mcp" / "prod", transport="stdio")
     mock_run.return_value = MagicMock(returncode=0)
 
-    result = runner.invoke(main, ["--profile", "prod", "mcp", "run"])
+    with patch("evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir):
+        result = runner.invoke(main, ["--profile", "prod", "mcp", "run"])
     assert result.exit_code == 0, result.output
 
     generated = yaml.safe_load((cfg_dir / GENERATED_CONFIG).read_text())

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -106,14 +106,14 @@ def test_mcp_run_no_mcp_config_uses_root_profile(
 
 @patch("evalhub.cli._process.subprocess.run")
 @patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
-def test_mcp_run_no_config_at_all_generates_empty(
+def test_mcp_run_no_config_at_all_defaults_to_stdio(
     mock_find: MagicMock,
     mock_run: MagicMock,
     runner: CliRunner,
     config_file: Path,
     tmp_path: Path,
 ) -> None:
-    """When neither MCP config nor root profile keys exist, mcp-config.yaml is empty."""
+    """When neither MCP config nor root profile keys exist, transport defaults to stdio."""
     cfg_dir = tmp_path / "mcp" / "default"
     mock_run.return_value = MagicMock(returncode=0)
 
@@ -122,7 +122,7 @@ def test_mcp_run_no_config_at_all_generates_empty(
     assert result.exit_code == 0, result.output
 
     generated = yaml.safe_load((cfg_dir / GENERATED_CONFIG).read_text()) or {}
-    assert generated == {}
+    assert generated == {"transport": "stdio"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from evalhub.cli.main import main
-from evalhub.cli.mcp_cmd import _fetch_server_info
+from evalhub.cli.mcp_cmd import GENERATED_CONFIG, _fetch_server_info
 
 
 @pytest.fixture()
@@ -39,6 +39,19 @@ def _seed_profile(config_file: Path, profile: str = "default", **kwargs: str) ->
     config_file.write_text(yaml.safe_dump(data))
 
 
+def _write_mcp_config(cfg_dir: Path, **overrides: object) -> Path:
+    """Write an MCP config.yaml into *cfg_dir* and return the directory."""
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    data: dict[str, object] = {
+        "transport": "http",
+        "host": "localhost",
+        "port": 3001,
+    }
+    data.update(overrides)
+    (cfg_dir / "config.yaml").write_text(yaml.safe_dump(data))
+    return cfg_dir
+
+
 @pytest.fixture()
 def runner() -> CliRunner:
     return CliRunner()
@@ -58,13 +71,68 @@ def test_mcp_subcommands_appear_in_help(runner: CliRunner) -> None:
 
 
 # ---------------------------------------------------------------------------
+# No MCP config.yaml — generated from root profile only
+# ---------------------------------------------------------------------------
+
+
+@patch("evalhub.cli._process.subprocess.run")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
+def test_mcp_run_no_mcp_config_uses_root_profile(
+    mock_find: MagicMock,
+    mock_run: MagicMock,
+    runner: CliRunner,
+    config_file: Path,
+    tmp_path: Path,
+) -> None:
+    """When no MCP config.yaml exists, mcp-config.yaml is generated from root profile."""
+    _seed_profile(
+        config_file,
+        base_url="https://prod.example.com",
+        token="prod-token",
+        tenant="team-a",
+    )
+    cfg_dir = tmp_path / "mcp" / "default"
+    mock_run.return_value = MagicMock(returncode=0)
+
+    with patch("evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir):
+        result = runner.invoke(main, ["mcp", "run"])
+    assert result.exit_code == 0, result.output
+
+    generated = yaml.safe_load((cfg_dir / GENERATED_CONFIG).read_text())
+    assert generated["base_url"] == "https://prod.example.com"
+    assert generated["token"] == "prod-token"
+    assert generated["tenant"] == "team-a"
+
+
+@patch("evalhub.cli._process.subprocess.run")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
+def test_mcp_run_no_config_at_all_generates_empty(
+    mock_find: MagicMock,
+    mock_run: MagicMock,
+    runner: CliRunner,
+    config_file: Path,
+    tmp_path: Path,
+) -> None:
+    """When neither MCP config nor root profile keys exist, mcp-config.yaml is empty."""
+    cfg_dir = tmp_path / "mcp" / "default"
+    mock_run.return_value = MagicMock(returncode=0)
+
+    with patch("evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir):
+        result = runner.invoke(main, ["mcp", "run"])
+    assert result.exit_code == 0, result.output
+
+    generated = yaml.safe_load((cfg_dir / GENERATED_CONFIG).read_text()) or {}
+    assert generated == {}
+
+
+# ---------------------------------------------------------------------------
 # Go binary subcommands
 # ---------------------------------------------------------------------------
 
 
 @patch("evalhub.cli._process.subprocess.run")
 @patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
-def test_mcp_run_stdio(
+def test_mcp_run(
     mock_find: MagicMock,
     mock_run: MagicMock,
     runner: CliRunner,
@@ -72,9 +140,9 @@ def test_mcp_run_stdio(
     tmp_path: Path,
 ) -> None:
     mock_run.return_value = MagicMock(returncode=0)
-    gen_cfg = tmp_path / "mcp" / "config.yaml"
+    cfg_dir = _write_mcp_config(tmp_path / "mcp" / "default", transport="stdio")
 
-    with patch("evalhub.cli.mcp_cmd.CONFIG_FILE", gen_cfg):
+    with patch("evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir):
         result = runner.invoke(main, ["mcp", "run"])
     assert result.exit_code == 0, result.output
 
@@ -82,7 +150,7 @@ def test_mcp_run_stdio(
     cmd = mock_run.call_args[0][0]
     assert cmd[0] == "/usr/bin/evalhub-mcp"
     assert "--config" in cmd
-    assert str(gen_cfg) in cmd
+    assert str(cfg_dir / GENERATED_CONFIG) in cmd
 
 
 @patch("evalhub.cli.mcp_cmd.find_binary")
@@ -119,11 +187,15 @@ def test_mcp_start_launches_background(
     mock_proc.poll.return_value = None
     mock_popen.return_value = mock_proc
 
-    with patch("evalhub.cli.mcp_cmd.MCP_STATE_DIR", tmp_path), patch(
+    cfg_dir = _write_mcp_config(
+        tmp_path / "mcp" / "default", transport="http", host="localhost", port=3001
+    )
+
+    with patch(
+        "evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir
+    ), patch("evalhub.cli.mcp_cmd.MCP_STATE_DIR", tmp_path), patch(
         "evalhub.cli.mcp_cmd.PID_FILE", tmp_path / "pid"
-    ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"), patch(
-        "evalhub.cli.mcp_cmd.CONFIG_FILE", tmp_path / "config.yaml"
-    ):
+    ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"):
         result = runner.invoke(main, ["mcp", "start"])
 
     assert result.exit_code == 0, result.output
@@ -133,10 +205,7 @@ def test_mcp_start_launches_background(
 
     cmd = mock_popen.call_args[0][0]
     assert "--config" in cmd
-
-    gen_cfg = tmp_path / "config.yaml"
-    loaded = yaml.safe_load(gen_cfg.read_text())
-    assert loaded["transport"] == "http"
+    assert str(cfg_dir / GENERATED_CONFIG) in cmd
 
     pid_content = (tmp_path / "pid").read_text().strip()
     assert pid_content == "12345"
@@ -159,13 +228,78 @@ def test_mcp_start_already_running(
     with patch("evalhub.cli.mcp_cmd.MCP_STATE_DIR", tmp_path), patch(
         "evalhub.cli.mcp_cmd.PID_FILE", pid_file
     ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"), patch(
-        "evalhub.cli.mcp_cmd.CONFIG_FILE", tmp_path / "config.yaml"
-    ), patch("evalhub.cli._process.is_process_alive", return_value=True):
+        "evalhub.cli._process.is_process_alive", return_value=True
+    ):
         result = runner.invoke(main, ["mcp", "start"])
 
     assert result.exit_code != 0
     assert "already running" in result.output
     assert "evalhub mcp stop" in result.output
+    mock_popen.assert_not_called()
+
+
+@patch("evalhub.cli.mcp_cmd.time.sleep")
+@patch("evalhub.cli._process.subprocess.Popen")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
+def test_mcp_start_defaults_to_http_when_no_transport(
+    mock_find: MagicMock,
+    mock_popen: MagicMock,
+    mock_sleep: MagicMock,
+    runner: CliRunner,
+    config_file: Path,
+    tmp_path: Path,
+) -> None:
+    """When no transport is configured, mcp start defaults to http."""
+    mock_proc = MagicMock()
+    mock_proc.pid = 12345
+    mock_proc.poll.return_value = None
+    mock_popen.return_value = mock_proc
+
+    cfg_dir = _write_mcp_config(
+        tmp_path / "mcp" / "default", host="localhost", port=3001
+    )
+    mcp_cfg = cfg_dir / "config.yaml"
+    data = yaml.safe_load(mcp_cfg.read_text())
+    del data["transport"]
+    mcp_cfg.write_text(yaml.safe_dump(data))
+
+    with patch(
+        "evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir
+    ), patch("evalhub.cli.mcp_cmd.MCP_STATE_DIR", tmp_path), patch(
+        "evalhub.cli.mcp_cmd.PID_FILE", tmp_path / "pid"
+    ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"):
+        result = runner.invoke(main, ["mcp", "start"])
+
+    assert result.exit_code == 0, result.output
+    assert "Transport: http" in result.output
+
+    generated = yaml.safe_load((cfg_dir / GENERATED_CONFIG).read_text())
+    assert generated["transport"] == "http"
+
+
+@patch("evalhub.cli.mcp_cmd.time.sleep")
+@patch("evalhub.cli._process.subprocess.Popen")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
+def test_mcp_start_rejects_stdio_transport(
+    mock_find: MagicMock,
+    mock_popen: MagicMock,
+    mock_sleep: MagicMock,
+    runner: CliRunner,
+    config_file: Path,
+    tmp_path: Path,
+) -> None:
+    cfg_dir = _write_mcp_config(tmp_path / "mcp" / "default", transport="stdio")
+
+    with patch(
+        "evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir
+    ), patch("evalhub.cli.mcp_cmd.MCP_STATE_DIR", tmp_path), patch(
+        "evalhub.cli.mcp_cmd.PID_FILE", tmp_path / "pid"
+    ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"):
+        result = runner.invoke(main, ["mcp", "start"])
+
+    assert result.exit_code != 0
+    assert "stdio" in result.output
+    assert "evalhub mcp run" in result.output
     mock_popen.assert_not_called()
 
 
@@ -210,13 +344,15 @@ def test_mcp_status_running_with_server_info(
 ) -> None:
     pid_file = tmp_path / "pid"
     pid_file.write_text("12345")
-    cfg_file = tmp_path / "config.yaml"
-    cfg_file.write_text(yaml.safe_dump({"host": "localhost", "port": 3001}))
+
+    cfg_dir = _write_mcp_config(
+        tmp_path / "mcp" / "default", host="localhost", port=3001
+    )
 
     server_info = {"name": "evalhub-mcp", "version": "1.2.3"}
 
     with patch("evalhub.cli.mcp_cmd.PID_FILE", pid_file), patch(
-        "evalhub.cli.mcp_cmd.CONFIG_FILE", cfg_file
+        "evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir
     ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"), patch(
         "evalhub.cli._process.is_process_alive", return_value=True
     ), patch("evalhub.cli.mcp_cmd._fetch_server_info", return_value=server_info):
@@ -237,11 +373,13 @@ def test_mcp_status_running_server_info_unavailable(
 ) -> None:
     pid_file = tmp_path / "pid"
     pid_file.write_text("12345")
-    cfg_file = tmp_path / "config.yaml"
-    cfg_file.write_text(yaml.safe_dump({"host": "127.0.0.1", "port": 4000}))
+
+    cfg_dir = _write_mcp_config(
+        tmp_path / "mcp" / "default", host="127.0.0.1", port=4000
+    )
 
     with patch("evalhub.cli.mcp_cmd.PID_FILE", pid_file), patch(
-        "evalhub.cli.mcp_cmd.CONFIG_FILE", cfg_file
+        "evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir
     ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"), patch(
         "evalhub.cli._process.is_process_alive", return_value=True
     ), patch("evalhub.cli.mcp_cmd._fetch_server_info", return_value=None):
@@ -255,19 +393,20 @@ def test_mcp_status_running_server_info_unavailable(
 
 
 # ---------------------------------------------------------------------------
-# Config generation tests
+# Merge behavior — root profile fallback + MCP override
 # ---------------------------------------------------------------------------
 
 
 @patch("evalhub.cli._process.subprocess.run")
 @patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
-def test_mcp_run_generates_config_from_profile(
+def test_merge_inherits_connection_keys_from_profile(
     mock_find: MagicMock,
     mock_run: MagicMock,
     runner: CliRunner,
     config_file: Path,
     tmp_path: Path,
 ) -> None:
+    """Connection keys absent from MCP config are sourced from root profile."""
     _seed_profile(
         config_file,
         base_url="https://prod.example.com",
@@ -275,108 +414,69 @@ def test_mcp_run_generates_config_from_profile(
         tenant="team-a",
         insecure="true",
     )
+    cfg_dir = _write_mcp_config(
+        tmp_path / "mcp" / "default", transport="stdio", host="localhost", port=3001
+    )
     mock_run.return_value = MagicMock(returncode=0)
-    gen_cfg = tmp_path / "mcp" / "config.yaml"
 
-    with patch("evalhub.cli.mcp_cmd.CONFIG_FILE", gen_cfg):
+    with patch("evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir):
         result = runner.invoke(main, ["mcp", "run"])
-
     assert result.exit_code == 0, result.output
-    assert gen_cfg.exists()
 
-    loaded = yaml.safe_load(gen_cfg.read_text())
-    assert loaded["base_url"] == "https://prod.example.com"
-    assert loaded["token"] == "prod-token"
-    assert loaded["tenant"] == "team-a"
-    assert loaded["insecure"] is True
-    assert loaded["transport"] == "stdio"
-    assert loaded["host"] == "localhost"
-    assert loaded["port"] == 3001
-
-
-@patch("evalhub.cli.mcp_cmd.time.sleep")
-@patch("evalhub.cli._process.subprocess.Popen")
-@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
-def test_mcp_start_generates_config_from_profile(
-    mock_find: MagicMock,
-    mock_popen: MagicMock,
-    mock_sleep: MagicMock,
-    runner: CliRunner,
-    config_file: Path,
-    tmp_path: Path,
-) -> None:
-    _seed_profile(
-        config_file,
-        base_url="https://staging.example.com",
-        token="staging-token",
-        tenant="team-b",
-    )
-    mock_proc = MagicMock()
-    mock_proc.pid = 54321
-    mock_proc.poll.return_value = None
-    mock_popen.return_value = mock_proc
-
-    with patch("evalhub.cli.mcp_cmd.MCP_STATE_DIR", tmp_path), patch(
-        "evalhub.cli.mcp_cmd.PID_FILE", tmp_path / "pid"
-    ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"), patch(
-        "evalhub.cli.mcp_cmd.CONFIG_FILE", tmp_path / "config.yaml"
-    ):
-        result = runner.invoke(main, ["mcp", "start"])
-
-    assert result.exit_code == 0, result.output
-    gen_cfg = tmp_path / "config.yaml"
-    assert gen_cfg.exists()
-
-    loaded = yaml.safe_load(gen_cfg.read_text())
-    assert loaded["base_url"] == "https://staging.example.com"
-    assert loaded["token"] == "staging-token"
-    assert loaded["transport"] == "http"
-
-    cmd = mock_popen.call_args[0][0]
-    assert "--config" in cmd
-
-
-@patch("evalhub.cli.mcp_cmd.time.sleep")
-@patch("evalhub.cli._process.subprocess.Popen")
-@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
-def test_mcp_start_rejects_stdio_transport(
-    mock_find: MagicMock,
-    mock_popen: MagicMock,
-    mock_sleep: MagicMock,
-    runner: CliRunner,
-    config_file: Path,
-    tmp_path: Path,
-) -> None:
-    _seed_profile(
-        config_file,
-        base_url="http://localhost:8080",
-        token="t",
-        tenant="x",
-        mcp_transport="stdio",
-    )
-
-    with patch("evalhub.cli.mcp_cmd.MCP_STATE_DIR", tmp_path), patch(
-        "evalhub.cli.mcp_cmd.PID_FILE", tmp_path / "pid"
-    ), patch("evalhub.cli.mcp_cmd.LOG_FILE", tmp_path / "mcp.log"), patch(
-        "evalhub.cli.mcp_cmd.CONFIG_FILE", tmp_path / "config.yaml"
-    ):
-        result = runner.invoke(main, ["mcp", "start"])
-
-    assert result.exit_code != 0
-    assert "stdio" in result.output
-    assert "evalhub mcp run" in result.output
-    mock_popen.assert_not_called()
+    generated = yaml.safe_load((cfg_dir / GENERATED_CONFIG).read_text())
+    assert generated["base_url"] == "https://prod.example.com"
+    assert generated["token"] == "prod-token"
+    assert generated["tenant"] == "team-a"
+    assert generated["insecure"] is True
+    assert generated["transport"] == "stdio"
+    assert generated["host"] == "localhost"
+    assert generated["port"] == 3001
 
 
 @patch("evalhub.cli._process.subprocess.run")
 @patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
-def test_mcp_run_respects_profile_flag(
+def test_merge_mcp_config_overrides_profile(
     mock_find: MagicMock,
     mock_run: MagicMock,
     runner: CliRunner,
     config_file: Path,
     tmp_path: Path,
 ) -> None:
+    """MCP config keys take precedence over root profile keys."""
+    _seed_profile(
+        config_file,
+        base_url="https://prod.example.com",
+        token="prod-token",
+        tenant="team-a",
+    )
+    cfg_dir = _write_mcp_config(
+        tmp_path / "mcp" / "default",
+        base_url="http://localhost:8080",
+        token="dev-token",
+        transport="stdio",
+    )
+    mock_run.return_value = MagicMock(returncode=0)
+
+    with patch("evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir):
+        result = runner.invoke(main, ["mcp", "run"])
+    assert result.exit_code == 0, result.output
+
+    generated = yaml.safe_load((cfg_dir / GENERATED_CONFIG).read_text())
+    assert generated["base_url"] == "http://localhost:8080"
+    assert generated["token"] == "dev-token"
+    assert generated["tenant"] == "team-a"
+
+
+@patch("evalhub.cli._process.subprocess.run")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
+def test_merge_respects_profile_flag(
+    mock_find: MagicMock,
+    mock_run: MagicMock,
+    runner: CliRunner,
+    config_file: Path,
+    tmp_path: Path,
+) -> None:
+    """--profile flag selects which root profile to merge from."""
     data = {
         "active_profile": "default",
         "profiles": {
@@ -389,21 +489,21 @@ def test_mcp_run_respects_profile_flag(
                 "base_url": "https://prod.example.com",
                 "token": "prod-tok",
                 "tenant": "prod-t",
+                "mcp_config_file": str(tmp_path / "mcp" / "prod" / "config.yaml"),
             },
         },
     }
     config_file.write_text(yaml.safe_dump(data))
+    cfg_dir = _write_mcp_config(tmp_path / "mcp" / "prod", transport="stdio")
     mock_run.return_value = MagicMock(returncode=0)
-    gen_cfg = tmp_path / "mcp" / "config.yaml"
 
-    with patch("evalhub.cli.mcp_cmd.CONFIG_FILE", gen_cfg):
-        result = runner.invoke(main, ["--profile", "prod", "mcp", "run"])
-
+    result = runner.invoke(main, ["--profile", "prod", "mcp", "run"])
     assert result.exit_code == 0, result.output
-    loaded = yaml.safe_load(gen_cfg.read_text())
-    assert loaded["base_url"] == "https://prod.example.com"
-    assert loaded["token"] == "prod-tok"
-    assert loaded["tenant"] == "prod-t"
+
+    generated = yaml.safe_load((cfg_dir / GENERATED_CONFIG).read_text())
+    assert generated["base_url"] == "https://prod.example.com"
+    assert generated["token"] == "prod-tok"
+    assert generated["tenant"] == "prod-t"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -507,6 +507,51 @@ def test_merge_respects_profile_flag(
 
 
 # ---------------------------------------------------------------------------
+# Merge error handling
+# ---------------------------------------------------------------------------
+
+
+@patch("evalhub.cli._process.subprocess.run")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
+def test_merge_rejects_malformed_mcp_config(
+    mock_find: MagicMock,
+    mock_run: MagicMock,
+    runner: CliRunner,
+    config_file: Path,
+    tmp_path: Path,
+) -> None:
+    """A MCP config.yaml with invalid YAML produces a clear error."""
+    cfg_dir = tmp_path / "mcp" / "default"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(": invalid: yaml: [")
+
+    with patch("evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir):
+        result = runner.invoke(main, ["mcp", "run"])
+
+    assert result.exit_code != 0
+    assert "Failed to parse MCP config" in result.output
+
+
+@patch("evalhub.cli._process.subprocess.run")
+@patch("evalhub.cli.mcp_cmd.find_binary", return_value="/usr/bin/evalhub-mcp")
+def test_merge_rejects_invalid_port(
+    mock_find: MagicMock,
+    mock_run: MagicMock,
+    runner: CliRunner,
+    config_file: Path,
+    tmp_path: Path,
+) -> None:
+    """A non-numeric port in MCP config produces a clear error."""
+    cfg_dir = _write_mcp_config(tmp_path / "mcp" / "default", port="not-a-number")
+
+    with patch("evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir):
+        result = runner.invoke(main, ["mcp", "run"])
+
+    assert result.exit_code != 0
+    assert "Invalid port value" in result.output
+
+
+# ---------------------------------------------------------------------------
 # _fetch_server_info tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -377,6 +377,9 @@ def test_mcp_status_running_server_info_unavailable(
     cfg_dir = _write_mcp_config(
         tmp_path / "mcp" / "default", host="127.0.0.1", port=4000
     )
+    (cfg_dir / "mcp-config.yaml").write_text(
+        yaml.safe_dump({"host": "127.0.0.1", "port": 4000})
+    )
 
     with patch("evalhub.cli.mcp_cmd.PID_FILE", pid_file), patch(
         "evalhub.cli.config.resolve_component_config_dir", return_value=cfg_dir

--- a/tests/unit/test_cli_server.py
+++ b/tests/unit/test_cli_server.py
@@ -725,14 +725,46 @@ def test_config_get_unfold_non_file_key_errors(
     assert "file-based" in result.output
 
 
-def test_config_get_unmask_and_unfold_mutually_exclusive(
+def test_config_get_unfold_masks_sensitive_keys(
     runner: CliRunner,
+    tmp_path: Path,
     config_file: Path,
 ) -> None:
-    _seed_profile(config_file, token="secret")
-    result = runner.invoke(main, ["config", "get", "token", "--unmask", "--unfold"])
-    assert result.exit_code != 0
-    assert "mutually exclusive" in result.output
+    _seed_profile(config_file)
+    src = tmp_path / "myconfig.yaml"
+    src.write_text(
+        yaml.safe_dump({"base_url": "http://localhost", "token": "super-secret-tok"})
+    )
+
+    with _patch_store_dir(tmp_path):
+        runner.invoke(main, ["config", "set", "server_config_file", str(src)])
+
+    result = runner.invoke(main, ["config", "get", "server_config_file", "--unfold"])
+    assert result.exit_code == 0, result.output
+    assert "super-secret-tok" not in result.output
+    assert "sup***ok" in result.output
+    assert "http://localhost" in result.output
+
+
+def test_config_get_unfold_with_unmask(
+    runner: CliRunner,
+    tmp_path: Path,
+    config_file: Path,
+) -> None:
+    _seed_profile(config_file)
+    src = tmp_path / "myconfig.yaml"
+    src.write_text(
+        yaml.safe_dump({"base_url": "http://localhost", "token": "super-secret-tok"})
+    )
+
+    with _patch_store_dir(tmp_path):
+        runner.invoke(main, ["config", "set", "server_config_file", str(src)])
+
+    result = runner.invoke(
+        main, ["config", "get", "server_config_file", "--unfold", "--unmask"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "super-secret-tok" in result.output
 
 
 def test_config_unset_server_config_file_deletes_stored_copy(


### PR DESCRIPTION
## What and why

Changes:
- config for mcp : `mcp_transport, mcp_port, mcp_host` are removed in favour of `mcp_config_file`
- `evalhub config get mcp_config_file --unfold --unmask` , --unfold and --unmask will reveal the file content and unmask `token` if present
- if profile is empty: `evalhub mcp run` will default to `transport=stdio` with other defaults http:localhost:8080 (server)
- if profile is empty: `evalhub mcp start` will default to `transport=http` with other defaults http:localhost:8080 (server) http:localhost:3001 (mcp)
- The mcp config shares the following keys with the root config `base_url, token, tenant, insecure` . The `mcp_config_file` is given priority > then root config , if none are set , none of the four listed will be in the generated `mcp-config.yaml` passed to the `evalhub-mcp` (which will defaults to the Go defaults)
- When user sets a config. e.g.
`evalhub --profile dev1 config set mcp_config_file user-config.yaml` . evalhub cli saves this to `~/.config/mcp/<profile>/config.yaml` ; and on `evalhub mcp start/run` . it aggregates this `<profile>/config.yaml` with the `root config` to get the effective `base_url, token, tenant, insecure` values, saves it to `<profile>/mcp-config.yaml` . This `<profile>/mcp-config.yaml` is the actual config file passed to `evalhub-mcp` go binary.

**Config resolution Examples:**

```
# 1. With empty profile

╰─➤  evalhub config list
Profile: default
  (no configuration values)

  Missing required keys: base_url, token, tenant

## evalhub mcp start

╰─➤  evalhub mcp start 
MCP server started (PID 34197).
  Transport: http
  URL:       http://localhost:3001
  Logs:      /Users/gnaulak/.config/evalhub/mcp/mcp.log

### generated mcp-config.yaml
╰─➤  cat ~/.config/evalhub/mcp/default/mcp-config.yaml
transport: http


## evalhub mcp run
### generated mcp-config.yaml
╰─➤  cat ~/.config/evalhub/mcp/default/mcp-config.yaml 
transport: stdio


# 2. With `mcp_config_file` override: base_url eg.

╰─➤  evalhub config list
Profile: dev1
  base_url: http://localhost:8080
  mcp_config_file: /Users/gnaulak/.config/evalhub/mcp/dev1/config.yaml

  Missing required keys: token, tenant


╰─➤  evalhub config get mcp_config_file --unfold
base_url: https://evalhub-evalhub-test.apps.rosa.gbn-dev.vqoo.p3.openshiftapps.com
tenant: dataplane
token: sha***8M
insecure: true
transport: http
host: localhost
port: 3002

## Over here even though `base_url` is present in root config, the effective one for the MCP will be the one from the mcp_config_file; else it would have picked up the one from the base url


# 3. With `mcp_config_file` override: No base_url in mcp_config_file but in root config

╰─➤  evalhub config list
Profile: dev1
  base_url: http://localhost:8080
  mcp_config_file: /Users/gnaulak/.config/evalhub/mcp/dev1/config.yaml

  Missing required keys: token, tenant

╰─➤  evalhub config get mcp_config_file --unfold
transport: http
host: localhost
port: 3001

╰─➤  evalhub config list
Profile: dev1
  base_url: http://localhost:8080
  mcp_config_file: /Users/gnaulak/.config/evalhub/mcp/dev1/config.yaml

  Missing required keys: token, tenant

╰─➤  evalhub mcp start
MCP server started (PID 36744).
  Transport: http
  URL:       http://localhost:3001
  Logs:      /Users/gnaulak/.config/evalhub/mcp/mcp.log

╰─➤  cat ~/.config/evalhub/mcp/dev1/mcp-config.yaml
transport: http
base_url: http://localhost:8080
host: localhost
port: 3001

### Over here the final mcp-config.yaml have the base_url from the root config as the fallback

```



Closes # https://redhat.atlassian.net/browse/RHOAIENG-73120

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No
`mcp_transport, mcp_port, mcp_host` were introduced only recently no release cut out yet, so we should be good here



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional MCP-related configuration file and profile-aware config directory resolution.
  * MCP commands now use merged configuration values, with generated settings stored per profile.
* **Bug Fixes**
  * Improved handling of missing or partial MCP settings by falling back to sensible defaults.
  * Added clearer errors for invalid port values and malformed MCP configuration files.
* **Tests**
  * Expanded command coverage for config merging, profile selection, and startup/status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->