### PR TITLE
feat(client): add job log fetch and watch APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ make test-e2e
 
 - **`models/`** — Pydantic v2 request/response models (JobStatus, EvaluationStatus, BenchmarkConfig, etc.). Always importable with zero optional deps.
 - **`adapter/`** — SDK for framework developers. `FrameworkAdapter` is the abstract base class; implementers override `run_benchmark_job(config, callbacks) -> JobResults`. Includes `DefaultCallbacks`, `AdapterSettings` (env-based config), and `OCIArtifactPersister`.
-- **`client/`** — `AsyncEvalHubClient` and `SyncEvalHubClient` with nested resource classes (providers, benchmarks, collections, jobs). Requires `httpx`.
+- **`client/`** — `AsyncEvalHubClient` and `SyncEvalHubClient` with nested resource classes (providers, benchmarks, collections, jobs). Job resources support `submit`, `get`, `list`, `cancel`, `wait_for_completion`, `get_logs`, and `watch_logs`. Log helpers live in `client/job_logs.py` (`JobLogOptions`, `JobLogUpdate`). Requires `httpx`.
 - **`cli/`** — Click command groups (`eval`, `provider`, `benchmark`, `collection`, `config`, `health`, `mcp`). Entry point: `evalhub.cli.bootstrap:main`. The `mcp` subcommand manages the standalone Go binary (`evalhub-mcp`).
 
 ### Adapter job lifecycle (Kubernetes)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The EvalHub SDK provides a standardized way to create framework adapters that ca
 
 The SDK creates a common API layer that allows EvalHub to communicate with ANY evaluation framework. Users only need to write minimal "glue" code to connect their framework to the standardized interface.
 
-```
+```text
 EvalHub → (Standard API) → Your Framework Adapter → Your Evaluation Framework
 ```
 
@@ -58,17 +58,21 @@ graph TB
 The SDK is organized into distinct, focused packages:
 
 **Core (`evalhub.models`)** - Shared data models
+
 - Request/response models for API communication
 - Common data structures for evaluations and benchmarks
 
 **Adapter SDK (`evalhub.adapter`)** - Framework adapter components
+
 - `FrameworkAdapter` base class with `run_benchmark_job()` method
 - Job specification models (`JobSpec`, `JobResults`)
 - Callback interface for status updates and OCI artifacts
 - Example implementations
 
 **Client SDK (`evalhub.client`)** - REST API client for EvalHub service
+
 - HTTP client for submitting evaluations to EvalHub
+- Job lifecycle: submit, status, cancel, wait, and **log fetch/watch**
 - Resource navigation (providers, benchmarks, collections)
 - See [Getting Started with the CLI](https://eval-hub.github.io/getting-started/cli/)
 
@@ -229,6 +233,7 @@ results = adapter.run_benchmark_job(adapter.job_spec, callbacks)
 ```
 
 **Key Points:**
+
 - **Status updates**: Sent to sidecar if `sidecar_url` is provided, otherwise logged locally. Both `report_status` and `report_results` events always include `benchmark_index` (and `provider_id` when set) so the service can associate events with the correct benchmark in multi-benchmark jobs.
 - **OCI artifacts**: Created via SDK callbacks and pushed to the OCI registry through the sidecar-authenticated flow when mode is Kubernetes.
 
@@ -315,7 +320,7 @@ The EvalHub SDK is organized into distinct packages based on your use case:
 ### Which Package Should I Use?
 
 | Use Case | Primary Package | Description |
-|----------|----------------|-------------|
+| -------- | --------------- | ----------- |
 | **Building an Adapter** | `evalhub.adapter` | Create a framework adapter for your evaluation framework |
 | **Interacting with EvalHub** | `evalhub.client` | REST API client for submitting evaluations |
 | **Data Models** | `evalhub.models` | Request/response models for API communication |
@@ -323,6 +328,7 @@ The EvalHub SDK is organized into distinct packages based on your use case:
 ### Import Patterns
 
 **Framework Adapter Developer:**
+
 ```python
 # Building your adapter
 from evalhub.adapter import (
@@ -343,21 +349,41 @@ from evalhub.adapter import (
 ```
 
 **EvalHub Service User:**
+
 ```python
 # Interacting with EvalHub REST API
 from evalhub import (
-    EvalHubClient,
+    JobLogOptions,
+    SyncEvalHubClient,
     BenchmarkConfig,
     EvaluationExports,
     EvaluationExportsOCI,
+    JobLogOptions,
     JobSubmissionRequest,
     ModelConfig,
     OCIConnectionConfig,
     OCICoordinates,
 )
+
+# Watch job logs while polling status until the job completes
+with SyncEvalHubClient() as client:
+    for update in client.jobs.watch_logs(
+        "job-id",
+        options=JobLogOptions(tail_lines=500),
+        poll_interval=2.0,
+    ):
+        if update.logs:
+            print(update.logs, end="")
 ```
 
 ## Examples
+
+### Watch job logs
+
+Stream workload logs while a job runs using the client API or the example script:
+
+- **Script:** [`examples/watch_job_logs.py`](examples/watch_job_logs.py) — runnable against a local or remote cluster; see [`examples/README.md`](examples/README.md)
+- **Client API:** `client.jobs.get_logs()` for a one-shot snapshot; `client.jobs.watch_logs()` to poll logs and status until the job reaches a terminal state (yields `JobLogUpdate` with incremental `logs` and current `job`)
 
 ### Contributed Adapters
 
@@ -372,6 +398,7 @@ The SDK includes a reference implementation showing all adapter patterns:
 **Example Adapter**: `examples/simple_adapter/simple_adapter.py`
 
 This example demonstrates:
+
 - Loading JobSpec from mounted ConfigMap
 - Validating configuration
 - Loading benchmark data
@@ -436,6 +463,7 @@ class MyFrameworkAdapter(FrameworkAdapter):
 ### Key Data Models
 
 **JobSpec** - Configuration loaded from ConfigMap:
+
 ```python
 class JobSpec(BaseModel):
     # Mandatory fields
@@ -458,6 +486,7 @@ class JobSpec(BaseModel):
 ```
 
 Load a job spec from file:
+
 ```python
 from evalhub.adapter import JobSpec
 
@@ -469,6 +498,7 @@ spec = JobSpec.from_file(settings.resolved_job_spec_path)
 ```
 
 **JobCallbacks** - Interface for service communication:
+
 ```python
 class JobCallbacks(ABC):
     @abstractmethod
@@ -483,6 +513,7 @@ class JobCallbacks(ABC):
 When using `DefaultCallbacks`, pass `benchmark_index` (and optionally `provider_id`) from the job spec so that status and result events sent to the service always include `benchmark_index`, allowing the service to associate events with the correct benchmark in multi-benchmark jobs.
 
 **JobResults** - Returned when job completes:
+
 ```python
 class JobResults(BaseModel):
     id: str
@@ -654,8 +685,8 @@ def test_settings_parse(monkeypatch):
 
 ### Quality Assurance
 
-
 Run all quality checks:
+
 ```bash
 # Format code
 ruff format .

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,34 +18,22 @@ evalhub config set tenant my-team --profile prod
 
 Using a CLI profile:
 
+When you submit a job:
+
+```shell
+uv run evalhub eval run --config eval.yaml --profile prod
+# → prints something like: Job submitted: 86c904cc-cdcf-452d-b9d8-754a7d6391ec
+```
+
 ```shell
 cd eval-hub-sdk
-uv run python examples/watch_job_logs.py eval-abc123 --profile prod
-```
-
-Using explicit flags / env vars:
-
-```shell
-export EVALHUB_BASE_URL=https://evalhub.apps.my-cluster.example.com
-export EVALHUB_TOKEN="$(oc whoami -t)"   # or your API token
-export EVALHUB_TENANT=my-team
-uv run python examples/watch_job_logs.py eval-abc123
-```
-
-OpenShift from inside the cluster (service account token):
-
-```shell
-uv run python examples/watch_job_logs.py eval-abc123 \
-  --base-url https://evalhub.evalhub.svc:8080 \
-  --token-file /var/run/secrets/kubernetes.io/serviceaccount/token \
-  --ca-bundle /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-  --tenant default
+uv run python examples/watch_job_logs.py "<job_id>" --profile prod
 ```
 
 #### Useful flags
 
 ```shell
-uv run python examples/watch_job_logs.py eval-abc123 --profile prod \
+uv run python examples/watch_job_logs.py "<job_id>" --profile prod \
   --benchmark-index 0 \      # single benchmark only
   --tail-lines 500 \         # lines per poll
   --poll-interval 3 \        # seconds between polls

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,10 +8,12 @@ The script streams new log lines to stdout and prints the final job state to std
 
 ### 1. Configure a profile (optional, reusable)
 
+This is for the current user in namespace (tenant) `my-team` and the `default` profile:
+
 ```shell
-evalhub config set base_url https://evalhub.apps.my-cluster.example.com --profile prod
-evalhub config set token "$EVALHUB_TOKEN" --profile prod
-evalhub config set tenant my-team --profile prod
+evalhub config set base_url https://evalhub.apps.my-cluster.example.com
+evalhub config set token $(oc whoami -t)
+evalhub config set tenant my-team
 ```
 
 ### 2. Watch logs for a running job
@@ -21,13 +23,13 @@ Using a CLI profile:
 When you submit a job:
 
 ```shell
-uv run evalhub eval run --config eval.yaml --profile prod
+uv run evalhub eval run --config eval.yaml
 # → prints something like: Job submitted: 86c904cc-cdcf-452d-b9d8-754a7d6391ec
 ```
 
 ```shell
 cd eval-hub-sdk
-uv run python examples/watch_job_logs.py --profile prod "<job_id>"
+uv run python examples/watch_job_logs.py "<job_id>"
 ```
 
 #### Useful flags

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,54 @@
+# How to run the examples
+
+## Watching logs
+
+**File:** [watch_job_logs.py.](watch_job_logs.py.)
+
+The script streams new log lines to stdout and prints the final job state to stderr when the job reaches a terminal state. Exit code is 1 if the job ends in failed. Use Ctrl+C to stop early.
+
+### 1. Configure a profile (optional, reusable)
+
+```shell
+evalhub config set base_url https://evalhub.apps.my-cluster.example.com --profile prod
+evalhub config set token "$EVALHUB_TOKEN" --profile prod
+evalhub config set tenant my-team --profile prod
+```
+
+### 2. Watch logs for a running job
+
+Using a CLI profile:
+
+```shell
+cd eval-hub-sdk
+uv run python examples/watch_job_logs.py eval-abc123 --profile prod
+```
+
+Using explicit flags / env vars:
+
+```shell
+export EVALHUB_BASE_URL=https://evalhub.apps.my-cluster.example.com
+export EVALHUB_TOKEN="$(oc whoami -t)"   # or your API token
+export EVALHUB_TENANT=my-team
+uv run python examples/watch_job_logs.py eval-abc123
+```
+
+OpenShift from inside the cluster (service account token):
+
+```shell
+uv run python examples/watch_job_logs.py eval-abc123 \
+  --base-url https://evalhub.evalhub.svc:8080 \
+  --token-file /var/run/secrets/kubernetes.io/serviceaccount/token \
+  --ca-bundle /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+  --tenant default
+```
+
+#### Useful flags
+
+```shell
+uv run python examples/watch_job_logs.py eval-abc123 --profile prod \
+  --benchmark-index 0 \      # single benchmark only
+  --tail-lines 500 \         # lines per poll
+  --poll-interval 3 \        # seconds between polls
+  --timestamps \             # include K8s timestamps
+  --timeout 3600             # give up after 1 hour
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,65 +2,104 @@
 
 ## Watching logs
 
-**File:** [watch_job_logs.py.](watch_job_logs.py.)
+**File:** [watch_job_logs.py](watch_job_logs.py)
 
-The script streams new log lines to stdout and prints the final job state to stderr when the job reaches a terminal state. Exit code is 1 if the job ends in failed. Use Ctrl+C to stop early.
+The script streams new log lines to stdout and prints the final job state to
+stderr when the job reaches a terminal state.
 
-### 1. Configure a profile (optional, reusable)
+### Exit codes
 
-This is for the current user in namespace (tenant) `my-team` and the `default` profile:
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Job reached a terminal state (completed, cancelled, partially_failed) |
+| `1` | Job finished `failed` |
+| `2` | Watch ended before completion (timeout or non-terminal last state) |
+| `3` | HTTP/request error |
+| `130` | Interrupted with Ctrl+C |
+
+### 1. Configure connection (optional, reusable)
+
+**Default profile** (used when `--profile` is omitted):
 
 ```shell
 evalhub config set base_url https://evalhub.apps.my-cluster.example.com
-evalhub config set token $(oc whoami -t)
+evalhub config set token "$(oc whoami -t)"
 evalhub config set tenant my-team
 ```
 
-### 2. Watch logs for a running job
+**Named profile** (use with `--profile prod`):
 
-Using a CLI profile:
+```shell
+evalhub config set base_url https://evalhub.apps.my-cluster.example.com --profile prod
+evalhub config set token "$(oc whoami -t)" --profile prod
+evalhub config set tenant my-team --profile prod
+```
 
-When you submit a job:
+### 2. Get a job ID
+
+Submit a job or list existing jobs:
 
 ```shell
 uv run evalhub eval run --config eval.yaml
-# → prints something like: Job submitted: 86c904cc-cdcf-452d-b9d8-754a7d6391ec
+# → Job submitted: 86c904cc-cdcf-452d-b9d8-754a7d6391ec
+
+uv run evalhub eval status --status running
 ```
+
+### 3. Watch logs
+
+**Default profile** (reads `~/.config/evalhub/config.yaml`):
 
 ```shell
 cd eval-hub-sdk
-uv run python examples/watch_job_logs.py "<job_id>"
+uv run python examples/watch_job_logs.py 86c904cc-cdcf-452d-b9d8-754a7d6391ec
 ```
 
-#### Useful flags
+**Named profile:**
+
+```shell
+uv run python examples/watch_job_logs.py 86c904cc-cdcf-452d-b9d8-754a7d6391ec --profile prod
+```
+
+**Explicit remote settings** (no profile file required):
+
+```shell
+export EVALHUB_BASE_URL=https://evalhub.apps.my-cluster.example.com
+export EVALHUB_TOKEN="$(oc whoami -t)"
+export EVALHUB_TENANT=my-team
+
+uv run python examples/watch_job_logs.py 86c904cc-cdcf-452d-b9d8-754a7d6391ec
+```
+
+Or pass flags directly:
+
+```shell
+uv run python examples/watch_job_logs.py 86c904cc-cdcf-452d-b9d8-754a7d6391ec \
+  --base-url https://evalhub.apps.my-cluster.example.com \
+  --token "$(oc whoami -t)" \
+  --tenant my-team
+```
+
+**Inside a cluster** (service account token):
+
+```shell
+uv run python examples/watch_job_logs.py 86c904cc-cdcf-452d-b9d8-754a7d6391ec \
+  --base-url https://evalhub.evalhub.svc:8080 \
+  --token-file /var/run/secrets/kubernetes.io/serviceaccount/token \
+  --ca-bundle /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+  --tenant default
+```
+
+### Useful flags
 
 ```shell
 uv run python examples/watch_job_logs.py --help
 ```
 
-```shell
-usage: watch_job_logs.py [-h] [--profile PROFILE] [--base-url BASE_URL] [--token TOKEN] [--token-file TOKEN_FILE]
-                         [--tenant TENANT] [--ca-bundle CA_BUNDLE] [--insecure] [--benchmark-index BENCHMARK_INDEX]
-                         [--tail-lines TAIL_LINES] [--poll-interval POLL_INTERVAL] [--timeout TIMEOUT] [--timestamps]
-                         job_id
+Common options:
 
-Stream evaluation job logs until the job completes.
-
-positional arguments:
-  job_id                            Evaluation job ID to watch
-
-options:
-  -h, --help                        show this help message and exit
-  --profile PROFILE                 EvalHub CLI profile name (reads ~/.config/evalhub/config.yaml)
-  --base-url BASE_URL               EvalHub base URL (or set EVALHUB_BASE_URL)
-  --token TOKEN                     Bearer token (or set EVALHUB_TOKEN)
-  --token-file TOKEN_FILE           Read bearer token from a file (e.g. Kubernetes service account)
-  --tenant TENANT                   X-Tenant header value (or set EVALHUB_TENANT)
-  --ca-bundle CA_BUNDLE             Path to CA bundle for TLS verification
-  --insecure                        Skip TLS certificate verification
-  --benchmark-index BENCHMARK_INDEX Watch logs for a single benchmark index only
-  --tail-lines TAIL_LINES           Max log lines per poll (default: 1000)
-  --poll-interval POLL_INTERVAL     Seconds between polls (default: 2.0)
-  --timeout TIMEOUT                 Stop watching after this many seconds
-  --timestamps                      Include Kubernetes log timestamps when supported
-```
+- `--benchmark-index 0` — watch a single benchmark only
+- `--tail-lines 500` — max lines returned per poll (default: 1000)
+- `--poll-interval 3` — seconds between polls (default: 2.0)
+- `--timeout 3600` — stop watching after one hour
+- `--timestamps` — include Kubernetes log timestamps when supported

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,16 +27,38 @@ uv run evalhub eval run --config eval.yaml --profile prod
 
 ```shell
 cd eval-hub-sdk
-uv run python examples/watch_job_logs.py "<job_id>" --profile prod
+uv run python examples/watch_job_logs.py --profile prod "<job_id>"
 ```
 
 #### Useful flags
 
 ```shell
-uv run python examples/watch_job_logs.py "<job_id>" --profile prod \
-  --benchmark-index 0 \      # single benchmark only
-  --tail-lines 500 \         # lines per poll
-  --poll-interval 3 \        # seconds between polls
-  --timestamps \             # include K8s timestamps
-  --timeout 3600             # give up after 1 hour
+uv run python examples/watch_job_logs.py --help
+```
+
+```shell
+usage: watch_job_logs.py [-h] [--profile PROFILE] [--base-url BASE_URL] [--token TOKEN] [--token-file TOKEN_FILE]
+                         [--tenant TENANT] [--ca-bundle CA_BUNDLE] [--insecure] [--benchmark-index BENCHMARK_INDEX]
+                         [--tail-lines TAIL_LINES] [--poll-interval POLL_INTERVAL] [--timeout TIMEOUT] [--timestamps]
+                         job_id
+
+Stream evaluation job logs until the job completes.
+
+positional arguments:
+  job_id                            Evaluation job ID to watch
+
+options:
+  -h, --help                        show this help message and exit
+  --profile PROFILE                 EvalHub CLI profile name (reads ~/.config/evalhub/config.yaml)
+  --base-url BASE_URL               EvalHub base URL (or set EVALHUB_BASE_URL)
+  --token TOKEN                     Bearer token (or set EVALHUB_TOKEN)
+  --token-file TOKEN_FILE           Read bearer token from a file (e.g. Kubernetes service account)
+  --tenant TENANT                   X-Tenant header value (or set EVALHUB_TENANT)
+  --ca-bundle CA_BUNDLE             Path to CA bundle for TLS verification
+  --insecure                        Skip TLS certificate verification
+  --benchmark-index BENCHMARK_INDEX Watch logs for a single benchmark index only
+  --tail-lines TAIL_LINES           Max log lines per poll (default: 1000)
+  --poll-interval POLL_INTERVAL     Seconds between polls (default: 2.0)
+  --timeout TIMEOUT                 Stop watching after this many seconds
+  --timestamps                      Include Kubernetes log timestamps when supported
 ```

--- a/examples/watch_job_logs.py
+++ b/examples/watch_job_logs.py
@@ -157,6 +157,42 @@ def _create_client(args: argparse.Namespace) -> SyncEvalHubClient:
     )
 
 
+def _format_http_error(exc: httpx.HTTPError) -> str:
+    """Format an HTTP error with server response details when available."""
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return str(exc)
+
+    response = exc.response
+    lines = [f"HTTP {response.status_code} {response.reason_phrase} for {response.request.url}"]
+
+    body = response.text.strip()
+    if not body:
+        return "\n".join(lines)
+
+    try:
+        payload = response.json()
+    except ValueError:
+        lines.append(body)
+        return "\n".join(lines)
+
+    if isinstance(payload, dict):
+        message = payload.get("message")
+        message_code = payload.get("message_code")
+        trace = payload.get("trace")
+        if message_code:
+            lines.append(f"message_code: {message_code}")
+        if message:
+            lines.append(f"message: {message}")
+        if trace:
+            lines.append(f"trace: {trace}")
+        if not (message or message_code):
+            lines.append(body)
+    else:
+        lines.append(body)
+
+    return "\n".join(lines)
+
+
 def main() -> int:
     args = _build_parser().parse_args()
     options = JobLogOptions(tail_lines=args.tail_lines, timestamps=args.timestamps)
@@ -186,7 +222,7 @@ def main() -> int:
         except TimeoutError:
             print("\nTimed out before job reached a terminal state.", file=sys.stderr)
         except httpx.HTTPError as exc:
-            print(f"\nRequest failed: {exc}", file=sys.stderr)
+            print(f"\nRequest failed:\n{_format_http_error(exc)}", file=sys.stderr)
             return 3
         except KeyboardInterrupt:
             print("\nStopped.", file=sys.stderr)

--- a/examples/watch_job_logs.py
+++ b/examples/watch_job_logs.py
@@ -34,6 +34,7 @@ import sys
 from pathlib import Path
 
 from evalhub import JobLogOptions, SyncEvalHubClient
+from evalhub.client.job_logs import TERMINAL_JOB_STATES
 from evalhub.models import JobStatus
 
 
@@ -156,6 +157,7 @@ def main() -> int:
         print(f"  tenant: {args.tenant}", file=sys.stderr)
 
     final_state: JobStatus | None = None
+    reached_terminal = False
     with _create_client(args) as client:
         try:
             for update in client.jobs.watch_logs(
@@ -168,11 +170,20 @@ def main() -> int:
                 if update.logs:
                     print(update.logs, end="", flush=True)
                 final_state = update.job.effective_state
+                reached_terminal = final_state in TERMINAL_JOB_STATES
+        except TimeoutError:
+            print("\nTimed out before job reached a terminal state.", file=sys.stderr)
         except KeyboardInterrupt:
             print("\nStopped.", file=sys.stderr)
             return 130
 
     print(file=sys.stderr)
+    if not reached_terminal:
+        print(
+            f"Watch ended before completion (last state: {final_state}).",
+            file=sys.stderr,
+        )
+        return 2
     print(f"Job finished with state: {final_state}", file=sys.stderr)
     if final_state == JobStatus.FAILED:
         return 1

--- a/examples/watch_job_logs.py
+++ b/examples/watch_job_logs.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Watch evaluation job logs on a local or remote EvalHub cluster.
+
+Examples:
+
+  # Remote cluster with explicit flags
+  uv run python examples/watch_job_logs.py eval-abc123 \\
+    --base-url https://evalhub.apps.my-cluster.example.com \\
+    --token "$EVALHUB_TOKEN" \\
+    --tenant my-team
+
+  # Use an evalhub CLI profile (evalhub config set/use first)
+  uv run python examples/watch_job_logs.py eval-abc123 --profile prod
+
+  # Environment variables instead of flags
+  export EVALHUB_BASE_URL=https://evalhub.apps.my-cluster.example.com
+  export EVALHUB_TOKEN=...
+  export EVALHUB_TENANT=my-team
+  uv run python examples/watch_job_logs.py eval-abc123
+
+  # OpenShift service-account token file + cluster CA
+  uv run python examples/watch_job_logs.py eval-abc123 \\
+    --base-url https://evalhub.evalhub.svc:8080 \\
+    --token-file /var/run/secrets/kubernetes.io/serviceaccount/token \\
+    --ca-bundle /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \\
+    --tenant default
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from evalhub import JobLogOptions, SyncEvalHubClient
+from evalhub.models import JobStatus
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Stream evaluation job logs until the job completes.",
+    )
+    parser.add_argument("job_id", help="Evaluation job ID to watch")
+    parser.add_argument(
+        "--profile",
+        help="EvalHub CLI profile name (reads ~/.config/evalhub/config.yaml)",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=os.environ.get("EVALHUB_BASE_URL"),
+        help="EvalHub base URL (or set EVALHUB_BASE_URL)",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("EVALHUB_TOKEN"),
+        help="Bearer token (or set EVALHUB_TOKEN)",
+    )
+    parser.add_argument(
+        "--token-file",
+        help="Read bearer token from a file (e.g. Kubernetes service account)",
+    )
+    parser.add_argument(
+        "--tenant",
+        default=os.environ.get("EVALHUB_TENANT"),
+        help="X-Tenant header value (or set EVALHUB_TENANT)",
+    )
+    parser.add_argument(
+        "--ca-bundle",
+        help="Path to CA bundle for TLS verification",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Skip TLS certificate verification",
+    )
+    parser.add_argument(
+        "--benchmark-index",
+        type=int,
+        help="Watch logs for a single benchmark index only",
+    )
+    parser.add_argument(
+        "--tail-lines",
+        type=int,
+        default=1000,
+        help="Max log lines per poll (default: 1000)",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=2.0,
+        help="Seconds between polls (default: 2.0)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        help="Stop watching after this many seconds",
+    )
+    parser.add_argument(
+        "--timestamps",
+        action="store_true",
+        help="Include Kubernetes log timestamps when supported",
+    )
+    return parser
+
+
+def _resolve_token(args: argparse.Namespace) -> str | None:
+    if args.token_file:
+        return Path(args.token_file).read_text().strip()
+    return args.token
+
+
+def _create_client(args: argparse.Namespace) -> SyncEvalHubClient:
+    token = _resolve_token(args)
+
+    if args.profile:
+        from evalhub.cli import config as cfg
+
+        data = cfg.load_config()
+        prof = cfg.get_profile(data, args.profile)
+        return SyncEvalHubClient(
+            base_url=(args.base_url or prof.get("base_url", "http://localhost:8080")),
+            auth_token=token or prof.get("token"),
+            ca_bundle_path=args.ca_bundle,
+            insecure=args.insecure or cfg.parse_bool(prof.get("insecure")),
+            tenant=args.tenant if args.tenant is not None else prof.get("tenant"),
+            timeout=float(prof.get("timeout", 60.0)),
+        )
+
+    if not args.base_url:
+        raise SystemExit(
+            "Missing --base-url (or EVALHUB_BASE_URL). "
+            "Use --profile or pass --base-url explicitly."
+        )
+
+    return SyncEvalHubClient(
+        base_url=args.base_url,
+        auth_token=token,
+        ca_bundle_path=args.ca_bundle,
+        insecure=args.insecure,
+        tenant=args.tenant,
+        timeout=60.0,
+    )
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    options = JobLogOptions(tail_lines=args.tail_lines, timestamps=args.timestamps)
+
+    print(f"Watching logs for job {args.job_id!r}...", file=sys.stderr)
+    if args.base_url or args.profile:
+        target = args.base_url or f"profile:{args.profile}"
+        print(f"  server: {target}", file=sys.stderr)
+    if args.tenant:
+        print(f"  tenant: {args.tenant}", file=sys.stderr)
+
+    final_state: JobStatus | None = None
+    with _create_client(args) as client:
+        try:
+            for update in client.jobs.watch_logs(
+                args.job_id,
+                benchmark_index=args.benchmark_index,
+                options=options,
+                poll_interval=args.poll_interval,
+                timeout=args.timeout,
+            ):
+                if update.logs:
+                    print(update.logs, end="", flush=True)
+                final_state = update.job.effective_state
+        except KeyboardInterrupt:
+            print("\nStopped.", file=sys.stderr)
+            return 130
+
+    print(file=sys.stderr)
+    print(f"Job finished with state: {final_state}", file=sys.stderr)
+    if final_state == JobStatus.FAILED:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/watch_job_logs.py
+++ b/examples/watch_job_logs.py
@@ -32,7 +32,9 @@ import argparse
 import os
 import sys
 from pathlib import Path
+from typing import cast
 
+import httpx
 from evalhub import JobLogOptions, SyncEvalHubClient
 from evalhub.client.job_logs import TERMINAL_JOB_STATES
 from evalhub.models import JobStatus
@@ -108,8 +110,18 @@ def _build_parser() -> argparse.ArgumentParser:
 def _resolve_token(args: argparse.Namespace) -> str | None:
     if args.token_file:
         return Path(args.token_file).read_text().strip()
-    token: str | None = args.token
-    return token
+    return cast(str | None, args.token)
+
+
+def _resolve_base_url(args: argparse.Namespace, profile_name: str, prof: dict) -> str:
+    base_url = args.base_url or prof.get("base_url")
+    if not base_url:
+        raise SystemExit(
+            f"Missing base_url for profile {profile_name!r}. "
+            "Pass --base-url, set EVALHUB_BASE_URL, or run: "
+            "evalhub config set base_url <url>"
+        )
+    return str(base_url)
 
 
 def _create_client(args: argparse.Namespace) -> SyncEvalHubClient:
@@ -121,7 +133,7 @@ def _create_client(args: argparse.Namespace) -> SyncEvalHubClient:
         data = cfg.load_config()
         prof = cfg.get_profile(data, args.profile)
         return SyncEvalHubClient(
-            base_url=(args.base_url or prof.get("base_url", "http://localhost:8080")),
+            base_url=_resolve_base_url(args, args.profile, prof),
             auth_token=token or prof.get("token"),
             ca_bundle_path=args.ca_bundle,
             insecure=args.insecure or cfg.parse_bool(prof.get("insecure")),
@@ -173,6 +185,9 @@ def main() -> int:
                 reached_terminal = final_state in TERMINAL_JOB_STATES
         except TimeoutError:
             print("\nTimed out before job reached a terminal state.", file=sys.stderr)
+        except httpx.HTTPError as exc:
+            print(f"\nRequest failed: {exc}", file=sys.stderr)
+            return 3
         except KeyboardInterrupt:
             print("\nStopped.", file=sys.stderr)
             return 130

--- a/examples/watch_job_logs.py
+++ b/examples/watch_job_logs.py
@@ -163,7 +163,9 @@ def _format_http_error(exc: httpx.HTTPError) -> str:
         return str(exc)
 
     response = exc.response
-    lines = [f"HTTP {response.status_code} {response.reason_phrase} for {response.request.url}"]
+    lines = [
+        f"HTTP {response.status_code} {response.reason_phrase} for {response.request.url}"
+    ]
 
     body = response.text.strip()
     if not body:

--- a/examples/watch_job_logs.py
+++ b/examples/watch_job_logs.py
@@ -107,7 +107,8 @@ def _build_parser() -> argparse.ArgumentParser:
 def _resolve_token(args: argparse.Namespace) -> str | None:
     if args.token_file:
         return Path(args.token_file).read_text().strip()
-    return args.token
+    token: str | None = args.token
+    return token
 
 
 def _create_client(args: argparse.Namespace) -> SyncEvalHubClient:

--- a/src/evalhub/__init__.py
+++ b/src/evalhub/__init__.py
@@ -85,6 +85,8 @@ try:
     from .client import (
         AsyncEvalHubClient,
         EvalHubClient,
+        JobLogOptions,
+        JobLogUpdate,
         SyncEvalHubClient,
     )
 
@@ -93,6 +95,8 @@ try:
             "AsyncEvalHubClient",
             "SyncEvalHubClient",
             "EvalHubClient",  # Alias for AsyncEvalHubClient
+            "JobLogOptions",
+            "JobLogUpdate",
         ]
     )
 except ImportError:

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -16,6 +16,7 @@ import click
 import yaml
 
 import evalhub
+from evalhub.client.job_logs import TERMINAL_JOB_STATES, JobLogOptions
 from evalhub.models import (
     BenchmarkConfig,
     CollectionCreateRequest,
@@ -213,7 +214,7 @@ def _build_request_from_flags(
     default=None,
     help=(
         "YAML or JSON file with the full job body. When set, all other "
-        "job-related flags on this command are ignored; use --wait, "
+        "job-related flags on this command are ignored; use --wait, --watch, "
         "--timeout, --poll-interval, and --format with --config as needed."
     ),
 )
@@ -282,14 +283,24 @@ def _build_request_from_flags(
     "--wait", "wait_for", is_flag=True, default=False, help="Block until job completes."
 )
 @click.option(
-    "--timeout", type=float, default=None, help="Timeout in seconds when using --wait."
+    "--watch",
+    "watch_for",
+    is_flag=True,
+    default=False,
+    help="Stream job logs until the job completes.",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=None,
+    help="Timeout in seconds when using --wait or --watch.",
 )
 @click.option(
     "--poll-interval",
     type=float,
     default=5.0,
     show_default=True,
-    help="Poll interval in seconds when using --wait.",
+    help="Poll interval in seconds when using --wait or --watch.",
 )
 @format_option()
 @click.pass_context
@@ -315,6 +326,7 @@ def eval_run(
     test_data_s3_key: str | None,
     test_data_s3_secret: str | None,
     wait_for: bool,
+    watch_for: bool,
     timeout: float | None,
     poll_interval: float,
     output_format: str,
@@ -329,6 +341,7 @@ def eval_run(
     Examples:
       evalhub eval run --config eval.yaml
       evalhub eval run --config eval.yaml --wait
+      evalhub eval run --config eval.yaml --watch
       evalhub eval run --name my-eval --model-url http://vllm:8000/v1 \\
           --model-name llama3 --provider lm_evaluation_harness -b mmlu -b hellaswag
       evalhub eval run --name my-eval --model-url http://vllm:8000/v1 \\
@@ -348,6 +361,9 @@ def eval_run(
           --test-data-s3-bucket evalhub-test --test-data-s3-key dataset/ \\
           --test-data-s3-secret evalhub-s3-credentials
     """
+    if wait_for and watch_for:
+        raise click.UsageError("--wait and --watch are mutually exclusive.")
+
     client = get_client(ctx)
 
     if config_file:
@@ -430,7 +446,11 @@ def eval_run(
     structured = output_format in ("json", "yaml")
     click.echo(f"Job submitted: {job.id}", err=structured)
 
-    if wait_for:
+    if watch_for:
+        job = _watch_job_logs(
+            ctx, client, job.id, poll_interval=poll_interval, timeout=timeout
+        )
+    elif wait_for:
         click.echo(f"Waiting for job {job.id} to complete...", err=structured)
         job = client.jobs.wait_for_completion(
             job.id, timeout=timeout, poll_interval=poll_interval
@@ -442,7 +462,7 @@ def eval_run(
         if job.effective_state == JobStatus.FAILED:
             ctx.exit(1)
 
-    if structured:
+    if structured and not watch_for:
         output([job.model_dump(mode="json")], output_format=output_format)
 
 
@@ -569,6 +589,52 @@ def _parse_since(value: str) -> datetime:
     amount, unit = int(m.group(1)), m.group(2)
     delta = timedelta(hours=amount) if unit == "h" else timedelta(days=amount)
     return datetime.now(tz=UTC) - delta
+
+
+def _watch_job_logs(
+    ctx: click.Context,
+    client: Any,
+    job_id: str,
+    *,
+    poll_interval: float,
+    timeout: float | None,
+) -> Any:
+    """Stream job logs until the job reaches a terminal state."""
+    final_state: JobStatus | None = None
+    final_job = None
+    options = JobLogOptions()
+
+    click.echo(f"Watching logs for job {job_id}...", err=True)
+    try:
+        for update in client.jobs.watch_logs(
+            job_id,
+            options=options,
+            poll_interval=poll_interval,
+            timeout=timeout,
+        ):
+            if update.logs:
+                click.echo(update.logs, nl=False)
+            final_job = update.job
+            final_state = update.job.effective_state
+    except TimeoutError:
+        click.echo(
+            f"\nTimed out before job {job_id} reached a terminal state.",
+            err=True,
+        )
+        ctx.exit(2)
+
+    click.echo(err=True)
+    if final_state not in TERMINAL_JOB_STATES:
+        click.echo(
+            f"Watch ended before completion (last state: {final_state}).",
+            err=True,
+        )
+        ctx.exit(2)
+
+    click.echo(f"Job {job_id} finished with state: {final_state.value}", err=True)
+    if final_state == JobStatus.FAILED:
+        ctx.exit(1)
+    return final_job
 
 
 def _watch_job(client: Any, job_id: str, poll_interval: float) -> None:
@@ -870,14 +936,24 @@ def collections_delete(ctx: click.Context, collection_id: str) -> None:
     "--wait", "wait_for", is_flag=True, default=False, help="Block until job completes."
 )
 @click.option(
-    "--timeout", type=float, default=None, help="Timeout in seconds when using --wait."
+    "--watch",
+    "watch_for",
+    is_flag=True,
+    default=False,
+    help="Stream job logs until the job completes.",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=None,
+    help="Timeout in seconds when using --wait or --watch.",
 )
 @click.option(
     "--poll-interval",
     type=float,
     default=5.0,
     show_default=True,
-    help="Poll interval in seconds when using --wait.",
+    help="Poll interval in seconds when using --wait or --watch.",
 )
 @format_option()
 @click.pass_context
@@ -890,6 +966,7 @@ def collections_run(
     name: str | None,
     queue: str | None,
     wait_for: bool,
+    watch_for: bool,
     timeout: float | None,
     poll_interval: float,
     output_format: str,
@@ -903,9 +980,13 @@ def collections_run(
     Examples:
       evalhub collections run rag-safety --model-url http://vllm:8000/v1 --model-name llama3
       evalhub collections run rag-safety --model-url http://vllm:8000/v1 --model-name llama3 --wait
+      evalhub collections run rag-safety --model-url http://vllm:8000/v1 --model-name llama3 --watch
       evalhub collections run rag-safety --model-url http://vllm:8000/v1 --model-name llama3 \\
           --queue my-local-queue
     """
+    if wait_for and watch_for:
+        raise click.UsageError("--wait and --watch are mutually exclusive.")
+
     client = get_client(ctx)
     collection = client.collections.get(collection_id)
 
@@ -934,7 +1015,11 @@ def collections_run(
     structured = output_format in ("json", "yaml")
     click.echo(f"Job submitted: {job.id}", err=structured)
 
-    if wait_for:
+    if watch_for:
+        job = _watch_job_logs(
+            ctx, client, job.id, poll_interval=poll_interval, timeout=timeout
+        )
+    elif wait_for:
         click.echo(f"Waiting for job {job.id} to complete...", err=structured)
         job = client.jobs.wait_for_completion(
             job.id, timeout=timeout, poll_interval=poll_interval
@@ -946,7 +1031,7 @@ def collections_run(
         if job.effective_state == JobStatus.FAILED:
             ctx.exit(1)
 
-    if structured:
+    if structured and not watch_for:
         output([job.model_dump(mode="json")], output_format=output_format)
 
 

--- a/src/evalhub/client/__init__.py
+++ b/src/evalhub/client/__init__.py
@@ -54,6 +54,7 @@ from .base import (
     JobNotFoundError,
 )
 from .evalhub import AsyncEvalHubClient, EvalHubClient, SyncEvalHubClient
+from .job_logs import JobLogOptions, JobLogUpdate
 
 __all__ = [
     # Base classes
@@ -62,6 +63,9 @@ __all__ = [
     "ClientError",
     "JobNotFoundError",
     "JobCanNotBeCancelledError",
+    # Job log types
+    "JobLogOptions",
+    "JobLogUpdate",
     # Main clients (recommended)
     "AsyncEvalHubClient",
     "SyncEvalHubClient",

--- a/src/evalhub/client/job_logs.py
+++ b/src/evalhub/client/job_logs.py
@@ -73,6 +73,29 @@ def build_logs_path(job_id: str, benchmark_index: int | None = None) -> str:
     return f"/evaluations/jobs/{job_id}/benchmarks/{benchmark_index}/logs"
 
 
+def _suffix_prefix_overlap(seen: str, current: str) -> int:
+    """Return length of the longest suffix of *seen* matching a prefix of *current*."""
+    if not seen or not current:
+        return 0
+    # KMP prefix function on current + sentinel + seen is O(len(seen) + len(current)).
+    combined = f"{current}\x00{seen}"
+    pi = _kmp_prefix_lengths(combined)
+    return min(pi[-1], len(current))
+
+
+def _kmp_prefix_lengths(text: str) -> list[int]:
+    """Build the KMP prefix-function (pi) table for *text*."""
+    pi = [0] * len(text)
+    for i in range(1, len(text)):
+        j = pi[i - 1]
+        while j > 0 and text[i] != text[j]:
+            j = pi[j - 1]
+        if text[i] == text[j]:
+            j += 1
+        pi[i] = j
+    return pi
+
+
 def log_delta(seen: str, current: str) -> str:
     """Return only the portion of *current* that has not been emitted yet."""
     if not current:
@@ -81,11 +104,8 @@ def log_delta(seen: str, current: str) -> str:
         return current
     if current.startswith(seen):
         return current[len(seen) :]
-    max_overlap = min(len(seen), len(current))
-    for overlap in range(max_overlap, 0, -1):
-        if seen[-overlap:] == current[:overlap]:
-            return current[overlap:]
-    return current
+    overlap = _suffix_prefix_overlap(seen, current)
+    return current[overlap:]
 
 
 def is_terminal_job(job: EvaluationJob) -> bool:

--- a/src/evalhub/client/job_logs.py
+++ b/src/evalhub/client/job_logs.py
@@ -28,7 +28,6 @@ class JobLogOptions:
 
     tail_lines: int = DEFAULT_LOG_TAIL_LINES
     timestamps: bool = False
-    previous: bool = False
     since_seconds: int | None = None
 
     def __post_init__(self) -> None:
@@ -62,8 +61,6 @@ def build_log_query_params(options: JobLogOptions) -> dict[str, str]:
     params = {"tail_lines": str(options.tail_lines)}
     if options.timestamps:
         params["timestamps"] = "true"
-    if options.previous:
-        params["previous"] = "true"
     if options.since_seconds is not None:
         params["since_seconds"] = str(options.since_seconds)
     return params

--- a/src/evalhub/client/job_logs.py
+++ b/src/evalhub/client/job_logs.py
@@ -48,11 +48,13 @@ class JobLogUpdate:
 
 
 class _AsyncJobLogClient(Protocol):
-    async def _request_get(self, path: str, **kwargs: Any) -> Any: ...
+    async def _request_get(self, path: str, **kwargs: Any) -> Any:
+        ...
 
 
 class _SyncJobLogClient(Protocol):
-    def _request_get(self, path: str, **kwargs: Any) -> Any: ...
+    def _request_get(self, path: str, **kwargs: Any) -> Any:
+        ...
 
 
 def build_log_query_params(options: JobLogOptions) -> dict[str, str]:

--- a/src/evalhub/client/job_logs.py
+++ b/src/evalhub/client/job_logs.py
@@ -1,0 +1,130 @@
+"""Shared helpers for evaluation job log APIs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+from ..models import EvaluationJob, JobStatus
+
+if TYPE_CHECKING:
+    pass
+
+DEFAULT_LOG_TAIL_LINES = 1000
+MAX_LOG_TAIL_LINES = 10000
+TERMINAL_JOB_STATES = frozenset(
+    {
+        JobStatus.COMPLETED,
+        JobStatus.FAILED,
+        JobStatus.CANCELLED,
+        JobStatus.PARTIALLY_FAILED,
+    }
+)
+
+
+@dataclass(frozen=True)
+class JobLogOptions:
+    """Query options for evaluation job log endpoints."""
+
+    tail_lines: int = DEFAULT_LOG_TAIL_LINES
+    timestamps: bool = False
+    previous: bool = False
+    since_seconds: int | None = None
+
+    def __post_init__(self) -> None:
+        if not 1 <= self.tail_lines <= MAX_LOG_TAIL_LINES:
+            msg = f"tail_lines must be between 1 and {MAX_LOG_TAIL_LINES}"
+            raise ValueError(msg)
+        if self.since_seconds is not None and self.since_seconds < 1:
+            raise ValueError("since_seconds must be >= 1 when provided")
+
+
+@dataclass(frozen=True)
+class JobLogUpdate:
+    """Incremental log and status update while watching a job."""
+
+    logs: str
+    job: EvaluationJob
+
+
+class _AsyncJobLogClient(Protocol):
+    async def _request_get(self, path: str, **kwargs: Any) -> Any: ...
+
+
+class _SyncJobLogClient(Protocol):
+    def _request_get(self, path: str, **kwargs: Any) -> Any: ...
+
+
+def build_log_query_params(options: JobLogOptions) -> dict[str, str]:
+    """Build query parameters for log endpoints."""
+    params = {"tail_lines": str(options.tail_lines)}
+    if options.timestamps:
+        params["timestamps"] = "true"
+    if options.previous:
+        params["previous"] = "true"
+    if options.since_seconds is not None:
+        params["since_seconds"] = str(options.since_seconds)
+    return params
+
+
+def build_logs_path(job_id: str, benchmark_index: int | None = None) -> str:
+    """Build the API path for job or benchmark log endpoints."""
+    if benchmark_index is None:
+        return f"/evaluations/jobs/{job_id}/logs"
+    return f"/evaluations/jobs/{job_id}/benchmarks/{benchmark_index}/logs"
+
+
+def log_delta(seen: str, current: str) -> str:
+    """Return only the portion of *current* that has not been emitted yet."""
+    if not current:
+        return ""
+    if not seen:
+        return current
+    if current.startswith(seen):
+        return current[len(seen) :]
+    max_overlap = min(len(seen), len(current))
+    for overlap in range(max_overlap, 0, -1):
+        if seen[-overlap:] == current[:overlap]:
+            return current[overlap:]
+    return current
+
+
+def is_terminal_job(job: EvaluationJob) -> bool:
+    """Return True when the job has reached a terminal state."""
+    return job.effective_state in TERMINAL_JOB_STATES
+
+
+async def fetch_job_logs(
+    client: _AsyncJobLogClient,
+    job_id: str,
+    *,
+    benchmark_index: int | None = None,
+    options: JobLogOptions | None = None,
+    tenant: str | None = None,
+) -> str:
+    """Fetch a snapshot of evaluation job logs."""
+    opts = options or JobLogOptions()
+    response = await client._request_get(
+        build_logs_path(job_id, benchmark_index),
+        params=build_log_query_params(opts),
+        tenant=tenant,
+    )
+    return cast(str, response.text)
+
+
+def fetch_job_logs_sync(
+    client: _SyncJobLogClient,
+    job_id: str,
+    *,
+    benchmark_index: int | None = None,
+    options: JobLogOptions | None = None,
+    tenant: str | None = None,
+) -> str:
+    """Fetch a snapshot of evaluation job logs (sync)."""
+    opts = options or JobLogOptions()
+    response = client._request_get(
+        build_logs_path(job_id, benchmark_index),
+        params=build_log_query_params(opts),
+        tenant=tenant,
+    )
+    return cast(str, response.text)

--- a/src/evalhub/client/resources/jobs.py
+++ b/src/evalhub/client/resources/jobs.py
@@ -182,12 +182,7 @@ class AsyncJobsResource:
 
             # Check if job is in a terminal state (also considers
             # benchmark-level completion when the server hasn't promoted it)
-            if job.effective_state in (
-                JobStatus.COMPLETED,
-                JobStatus.FAILED,
-                JobStatus.CANCELLED,
-                JobStatus.PARTIALLY_FAILED,
-            ):
+            if is_terminal_job(job):
                 return job
 
             if timeout and (time.time() - start_time) > timeout:
@@ -437,12 +432,7 @@ class SyncJobsResource:
 
             # Check if job is in a terminal state (also considers
             # benchmark-level completion when the server hasn't promoted it)
-            if job.effective_state in (
-                JobStatus.COMPLETED,
-                JobStatus.FAILED,
-                JobStatus.CANCELLED,
-                JobStatus.PARTIALLY_FAILED,
-            ):
+            if is_terminal_job(job):
                 return job
 
             if timeout and (time.time() - start_time) > timeout:

--- a/src/evalhub/client/resources/jobs.py
+++ b/src/evalhub/client/resources/jobs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import AsyncIterator, Iterator
 
 import httpx
 
@@ -19,6 +20,14 @@ from ..base import (
     BaseSyncClient,
     JobCanNotBeCancelledError,
     JobNotFoundError,
+)
+from ..job_logs import (
+    JobLogOptions,
+    JobLogUpdate,
+    fetch_job_logs,
+    fetch_job_logs_sync,
+    is_terminal_job,
+    log_delta,
 )
 
 logger = logging.getLogger(__name__)
@@ -188,6 +197,96 @@ class AsyncJobsResource:
 
             await asyncio.sleep(poll_interval)
 
+    async def get_logs(
+        self,
+        job_id: str,
+        *,
+        benchmark_index: int | None = None,
+        options: JobLogOptions | None = None,
+        tenant: str | None = None,
+    ) -> str:
+        """Fetch evaluation job logs as plain text.
+
+        Args:
+            job_id: The job identifier
+            benchmark_index: When set, fetch logs for a single benchmark index
+            options: Log query options (tail_lines, timestamps, etc.)
+            tenant: Tenant override for this request (default: client-level tenant)
+
+        Returns:
+            str: Plain-text job logs
+
+        Raises:
+            httpx.HTTPError: If request fails
+        """
+        return await fetch_job_logs(
+            self._client,
+            job_id,
+            benchmark_index=benchmark_index,
+            options=options,
+            tenant=tenant,
+        )
+
+    async def watch_logs(
+        self,
+        job_id: str,
+        *,
+        benchmark_index: int | None = None,
+        options: JobLogOptions | None = None,
+        poll_interval: float = 2.0,
+        timeout: float | None = None,
+        tenant: str | None = None,
+    ) -> AsyncIterator[JobLogUpdate]:
+        """Stream job logs while polling status until the job completes.
+
+        The EvalHub server returns on-demand log snapshots, so this method
+        polls ``get_logs`` and ``get`` until the job reaches a terminal state.
+        Each yielded :class:`JobLogUpdate` contains only new log content since
+        the previous poll (which may be empty) and the current job status.
+
+        Args:
+            job_id: The job identifier
+            benchmark_index: When set, watch logs for a single benchmark index
+            options: Log query options (tail_lines, timestamps, etc.)
+            poll_interval: Seconds between status and log polls
+            timeout: Maximum time to watch in seconds (optional)
+            tenant: Tenant override for this request (default: client-level tenant)
+
+        Yields:
+            JobLogUpdate: Incremental log content and current job status
+
+        Raises:
+            TimeoutError: If the job does not complete within timeout
+            httpx.HTTPError: If request fails
+        """
+        start_time = time.time()
+        seen = ""
+        log_options = options or JobLogOptions()
+
+        while True:
+            job = await self.get(job_id, tenant=tenant)
+            logs = await self.get_logs(
+                job_id,
+                benchmark_index=benchmark_index,
+                options=log_options,
+                tenant=tenant,
+            )
+            delta = log_delta(seen, logs)
+            if logs:
+                seen = logs
+            yield JobLogUpdate(logs=delta, job=job)
+
+            if is_terminal_job(job):
+                return
+
+            if timeout is not None and (time.time() - start_time) > timeout:
+                raise TimeoutError(
+                    f"Job {job_id} did not complete within {timeout} seconds "
+                    "while watching logs"
+                )
+
+            await asyncio.sleep(poll_interval)
+
 
 class SyncJobsResource:
     """Synchronous resource for evaluation job operations."""
@@ -349,6 +448,96 @@ class SyncJobsResource:
             if timeout and (time.time() - start_time) > timeout:
                 raise TimeoutError(
                     f"Job {job_id} did not complete within {timeout} seconds"
+                )
+
+            time.sleep(poll_interval)
+
+    def get_logs(
+        self,
+        job_id: str,
+        *,
+        benchmark_index: int | None = None,
+        options: JobLogOptions | None = None,
+        tenant: str | None = None,
+    ) -> str:
+        """Fetch evaluation job logs as plain text.
+
+        Args:
+            job_id: The job identifier
+            benchmark_index: When set, fetch logs for a single benchmark index
+            options: Log query options (tail_lines, timestamps, etc.)
+            tenant: Tenant override for this request (default: client-level tenant)
+
+        Returns:
+            str: Plain-text job logs
+
+        Raises:
+            httpx.HTTPError: If request fails
+        """
+        return fetch_job_logs_sync(
+            self._client,
+            job_id,
+            benchmark_index=benchmark_index,
+            options=options,
+            tenant=tenant,
+        )
+
+    def watch_logs(
+        self,
+        job_id: str,
+        *,
+        benchmark_index: int | None = None,
+        options: JobLogOptions | None = None,
+        poll_interval: float = 2.0,
+        timeout: float | None = None,
+        tenant: str | None = None,
+    ) -> Iterator[JobLogUpdate]:
+        """Stream job logs while polling status until the job completes.
+
+        The EvalHub server returns on-demand log snapshots, so this method
+        polls ``get_logs`` and ``get`` until the job reaches a terminal state.
+        Each yielded :class:`JobLogUpdate` contains only new log content since
+        the previous poll (which may be empty) and the current job status.
+
+        Args:
+            job_id: The job identifier
+            benchmark_index: When set, watch logs for a single benchmark index
+            options: Log query options (tail_lines, timestamps, etc.)
+            poll_interval: Seconds between status and log polls
+            timeout: Maximum time to watch in seconds (optional)
+            tenant: Tenant override for this request (default: client-level tenant)
+
+        Yields:
+            JobLogUpdate: Incremental log content and current job status
+
+        Raises:
+            TimeoutError: If the job does not complete within timeout
+            httpx.HTTPError: If request fails
+        """
+        start_time = time.time()
+        seen = ""
+        log_options = options or JobLogOptions()
+
+        while True:
+            job = self.get(job_id, tenant=tenant)
+            logs = self.get_logs(
+                job_id,
+                benchmark_index=benchmark_index,
+                options=log_options,
+                tenant=tenant,
+            )
+            delta = log_delta(seen, logs)
+            if logs:
+                seen = logs
+            yield JobLogUpdate(logs=delta, job=job)
+
+            if is_terminal_job(job):
+                return
+
+            if timeout is not None and (time.time() - start_time) > timeout:
+                raise TimeoutError(
+                    f"Job {job_id} did not complete within {timeout} seconds "
+                    "while watching logs"
                 )
 
             time.sleep(poll_interval)

--- a/tests/unit/test_cli_collections.py
+++ b/tests/unit/test_cli_collections.py
@@ -12,9 +12,11 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from evalhub.cli.main import main
+from evalhub.client.job_logs import JobLogUpdate
 from evalhub.models.api import (
     BenchmarkReference,
     Collection,
+    JobStatus,
     PassCriteria,
     Resource,
 )
@@ -686,6 +688,42 @@ class TestCollectionsRun:
         req = mock_client.jobs.submit.call_args[0][0]
         assert req.queue is None
 
+    def test_run_with_watch(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        collection = _make_collection(
+            id="rag-safety",
+            benchmarks=[_make_benchmark_ref()],
+        )
+        mock_client.collections.get.return_value = collection
+
+        job = MagicMock()
+        job.id = "job-abc"
+        mock_client.jobs.submit.return_value = job
+        completed = MagicMock()
+        completed.effective_state = JobStatus.COMPLETED
+        mock_client.jobs.watch_logs.return_value = iter(
+            [JobLogUpdate(logs="log line\n", job=completed)]
+        )
+
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main,
+                [
+                    "collections",
+                    "run",
+                    "rag-safety",
+                    "--model-url",
+                    "http://vllm:8000/v1",
+                    "--model-name",
+                    "llama3",
+                    "--watch",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "log line" in result.output
+        mock_client.jobs.watch_logs.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Help
@@ -714,3 +752,4 @@ class TestCollectionsHelp:
         assert "--model-url" in result.output
         assert "--model-name" in result.output
         assert "--wait" in result.output
+        assert "--watch" in result.output

--- a/tests/unit/test_cli_eval.py
+++ b/tests/unit/test_cli_eval.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from evalhub.cli.main import main
+from evalhub.client.job_logs import JobLogUpdate
 from evalhub.models.api import (
     BenchmarkConfig,
     BenchmarkResult,
@@ -326,6 +327,113 @@ class TestEvalRun:
                 ],
             )
         assert result.exit_code == 1
+
+    def test_run_with_watch(
+        self,
+        runner: CliRunner,
+        config_file: Path,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cfg = {
+            "name": "my-eval",
+            "model": {"url": "http://vllm:8000/v1", "name": "llama3"},
+            "benchmarks": [{"id": "mmlu", "provider_id": "lm_eval"}],
+        }
+        cfg_path = tmp_path / "eval.yaml"
+        cfg_path.write_text(yaml.safe_dump(cfg))
+
+        submitted = _make_job()
+        completed = _make_job(state=JobStatus.COMPLETED)
+        mock_client.jobs.submit.return_value = submitted
+        mock_client.jobs.watch_logs.return_value = iter(
+            [
+                JobLogUpdate(logs="starting\n", job=_make_job(state=JobStatus.RUNNING)),
+                JobLogUpdate(logs="done\n", job=completed),
+            ]
+        )
+
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main,
+                [
+                    "eval",
+                    "run",
+                    "--config",
+                    str(cfg_path),
+                    "--watch",
+                ],
+            )
+        assert result.exit_code == 0
+        assert "starting" in result.output
+        assert "done" in result.output
+        assert "finished with state: completed" in result.output
+        mock_client.jobs.watch_logs.assert_called_once()
+
+    def test_run_with_watch_failed(
+        self,
+        runner: CliRunner,
+        config_file: Path,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cfg = {
+            "name": "my-eval",
+            "model": {"url": "http://vllm:8000/v1", "name": "llama3"},
+            "benchmarks": [{"id": "mmlu", "provider_id": "lm_eval"}],
+        }
+        cfg_path = tmp_path / "eval.yaml"
+        cfg_path.write_text(yaml.safe_dump(cfg))
+
+        submitted = _make_job()
+        failed = _make_job(state=JobStatus.FAILED)
+        mock_client.jobs.submit.return_value = submitted
+        mock_client.jobs.watch_logs.return_value = iter(
+            [JobLogUpdate(logs="error\n", job=failed)]
+        )
+
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main,
+                [
+                    "eval",
+                    "run",
+                    "--config",
+                    str(cfg_path),
+                    "--watch",
+                ],
+            )
+        assert result.exit_code == 1
+
+    def test_run_with_wait_and_watch_mutually_exclusive(
+        self,
+        runner: CliRunner,
+        config_file: Path,
+        mock_client: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cfg = {
+            "name": "my-eval",
+            "model": {"url": "http://vllm:8000/v1", "name": "llama3"},
+            "benchmarks": [{"id": "mmlu", "provider_id": "lm_eval"}],
+        }
+        cfg_path = tmp_path / "eval.yaml"
+        cfg_path.write_text(yaml.safe_dump(cfg))
+
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main,
+                [
+                    "eval",
+                    "run",
+                    "--config",
+                    str(cfg_path),
+                    "--wait",
+                    "--watch",
+                ],
+            )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower()
 
     def test_run_with_param_flags(
         self, runner: CliRunner, config_file: Path, mock_client: MagicMock
@@ -924,6 +1032,7 @@ class TestEvalHelp:
         assert "--config" in result.output
         assert "--model-url" in result.output
         assert "--wait" in result.output
+        assert "--watch" in result.output
 
     def test_eval_status_help(self, runner: CliRunner) -> None:
         result = runner.invoke(main, ["eval", "status", "--help"])

--- a/tests/unit/test_job_logs.py
+++ b/tests/unit/test_job_logs.py
@@ -187,7 +187,10 @@ class TestAsyncJobLogs:
 
         with (
             patch.object(
-                resource, "get", side_effect=[running, completed], new_callable=AsyncMock
+                resource,
+                "get",
+                side_effect=[running, completed],
+                new_callable=AsyncMock,
             ) as mock_get,
             patch.object(
                 resource,

--- a/tests/unit/test_job_logs.py
+++ b/tests/unit/test_job_logs.py
@@ -66,14 +66,12 @@ class TestJobLogHelpers:
             JobLogOptions(
                 tail_lines=250,
                 timestamps=True,
-                previous=True,
                 since_seconds=30,
             )
         )
         assert params == {
             "tail_lines": "250",
             "timestamps": "true",
-            "previous": "true",
             "since_seconds": "30",
         }
 

--- a/tests/unit/test_job_logs.py
+++ b/tests/unit/test_job_logs.py
@@ -47,6 +47,7 @@ def _make_job(state: JobStatus) -> EvaluationJob:
     )
 
 
+@pytest.mark.unit
 class TestJobLogHelpers:
     def test_build_logs_path_job_level(self) -> None:
         assert build_logs_path("job-1") == "/evaluations/jobs/job-1/logs"
@@ -98,6 +99,7 @@ class TestJobLogHelpers:
         assert log_delta(seen, current) == expected
 
 
+@pytest.mark.unit
 class TestSyncJobLogs:
     def test_get_logs_calls_plain_text_endpoint(self) -> None:
         client = Mock()
@@ -160,6 +162,7 @@ class TestSyncJobLogs:
                 list(resource.watch_logs("job-1", poll_interval=0.01, timeout=1.0))
 
 
+@pytest.mark.unit
 class TestAsyncJobLogs:
     @pytest.mark.asyncio
     async def test_get_logs_calls_plain_text_endpoint(self) -> None:

--- a/tests/unit/test_job_logs.py
+++ b/tests/unit/test_job_logs.py
@@ -1,0 +1,213 @@
+"""Unit tests for evaluation job log client helpers and resources."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from evalhub.client.job_logs import (
+    JobLogOptions,
+    JobLogUpdate,
+    build_log_query_params,
+    build_logs_path,
+    log_delta,
+)
+from evalhub.client.resources.jobs import AsyncJobsResource, SyncJobsResource
+from evalhub.models.api import (
+    BenchmarkConfig,
+    BenchmarkStatus,
+    EvaluationJob,
+    EvaluationJobResource,
+    EvaluationJobStatus,
+    JobStatus,
+    ModelConfig,
+)
+
+NOW = datetime.now(UTC)
+
+
+def _make_job(state: JobStatus) -> EvaluationJob:
+    return EvaluationJob(
+        resource=EvaluationJobResource(id="job-1", created_at=NOW),
+        status=EvaluationJobStatus(
+            state=state,
+            benchmarks=[
+                BenchmarkStatus(
+                    provider_id="test",
+                    id="bench",
+                    benchmark_index=0,
+                    status=state,
+                )
+            ],
+        ),
+        name="test-job",
+        model=ModelConfig(url="http://vllm:8000/v1", name="llama3"),
+        benchmarks=[BenchmarkConfig(id="bench", provider_id="test")],
+    )
+
+
+class TestJobLogHelpers:
+    def test_build_logs_path_job_level(self) -> None:
+        assert build_logs_path("job-1") == "/evaluations/jobs/job-1/logs"
+
+    def test_build_logs_path_benchmark_level(self) -> None:
+        assert (
+            build_logs_path("job-1", benchmark_index=2)
+            == "/evaluations/jobs/job-1/benchmarks/2/logs"
+        )
+
+    def test_build_log_query_params_defaults(self) -> None:
+        assert build_log_query_params(JobLogOptions()) == {"tail_lines": "1000"}
+
+    def test_build_log_query_params_all_fields(self) -> None:
+        params = build_log_query_params(
+            JobLogOptions(
+                tail_lines=250,
+                timestamps=True,
+                previous=True,
+                since_seconds=30,
+            )
+        )
+        assert params == {
+            "tail_lines": "250",
+            "timestamps": "true",
+            "previous": "true",
+            "since_seconds": "30",
+        }
+
+    def test_job_log_options_validates_tail_lines(self) -> None:
+        with pytest.raises(ValueError, match="tail_lines"):
+            JobLogOptions(tail_lines=0)
+
+    def test_job_log_options_validates_since_seconds(self) -> None:
+        with pytest.raises(ValueError, match="since_seconds"):
+            JobLogOptions(since_seconds=0)
+
+    @pytest.mark.parametrize(
+        ("seen", "current", "expected"),
+        [
+            ("", "line-1\nline-2", "line-1\nline-2"),
+            ("line-1\n", "line-1\nline-2", "line-2"),
+            ("old", "new", "new"),
+            ("abc", "bcdef", "def"),
+            ("line-1", "", ""),
+        ],
+    )
+    def test_log_delta(self, seen: str, current: str, expected: str) -> None:
+        assert log_delta(seen, current) == expected
+
+
+class TestSyncJobLogs:
+    def test_get_logs_calls_plain_text_endpoint(self) -> None:
+        client = Mock()
+        response = Mock()
+        response.text = "INFO starting\n"
+        client._request_get.return_value = response
+        resource = SyncJobsResource(client)
+
+        logs = resource.get_logs(
+            "job-1",
+            benchmark_index=1,
+            options=JobLogOptions(tail_lines=200, timestamps=True),
+            tenant="tenant-a",
+        )
+
+        assert logs == "INFO starting\n"
+        client._request_get.assert_called_once_with(
+            "/evaluations/jobs/job-1/benchmarks/1/logs",
+            params={"tail_lines": "200", "timestamps": "true"},
+            tenant="tenant-a",
+        )
+
+    def test_watch_logs_streams_until_terminal(self) -> None:
+        running = _make_job(JobStatus.RUNNING)
+        completed = _make_job(JobStatus.COMPLETED)
+        client = Mock()
+        resource = SyncJobsResource(client)
+
+        with (
+            patch.object(resource, "get", side_effect=[running, completed]) as mock_get,
+            patch.object(
+                resource,
+                "get_logs",
+                side_effect=["INFO start\n", "INFO start\nINFO done\n"],
+            ) as mock_logs,
+            patch("evalhub.client.resources.jobs.time.sleep"),
+        ):
+            updates = list(
+                resource.watch_logs("job-1", poll_interval=0.01, timeout=5.0)
+            )
+
+        assert mock_get.call_count == 2
+        assert mock_logs.call_count == 2
+        assert len(updates) == 2
+        assert updates[0] == JobLogUpdate(logs="INFO start\n", job=running)
+        assert updates[1] == JobLogUpdate(logs="INFO done\n", job=completed)
+
+    def test_watch_logs_timeout(self) -> None:
+        running = _make_job(JobStatus.RUNNING)
+        client = Mock()
+        resource = SyncJobsResource(client)
+
+        with (
+            patch.object(resource, "get", return_value=running),
+            patch.object(resource, "get_logs", return_value=""),
+            patch("evalhub.client.resources.jobs.time.sleep"),
+            patch("evalhub.client.resources.jobs.time.time", side_effect=[0.0, 2.0]),
+        ):
+            with pytest.raises(TimeoutError, match="did not complete within"):
+                list(resource.watch_logs("job-1", poll_interval=0.01, timeout=1.0))
+
+
+class TestAsyncJobLogs:
+    @pytest.mark.asyncio
+    async def test_get_logs_calls_plain_text_endpoint(self) -> None:
+        client = AsyncMock()
+        response = Mock()
+        response.text = "INFO starting\n"
+        client._request_get.return_value = response
+        resource = AsyncJobsResource(client)
+
+        logs = await resource.get_logs("job-1")
+
+        assert logs == "INFO starting\n"
+        client._request_get.assert_awaited_once_with(
+            "/evaluations/jobs/job-1/logs",
+            params={"tail_lines": "1000"},
+            tenant=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_watch_logs_streams_until_terminal(self) -> None:
+        running = _make_job(JobStatus.RUNNING)
+        completed = _make_job(JobStatus.COMPLETED)
+        client = AsyncMock()
+        resource = AsyncJobsResource(client)
+
+        with (
+            patch.object(
+                resource, "get", side_effect=[running, completed], new_callable=AsyncMock
+            ) as mock_get,
+            patch.object(
+                resource,
+                "get_logs",
+                side_effect=["line-1\n", "line-1\nline-2\n"],
+                new_callable=AsyncMock,
+            ) as mock_logs,
+            patch(
+                "evalhub.client.resources.jobs.asyncio.sleep",
+                new_callable=AsyncMock,
+            ),
+        ):
+            updates: list[JobLogUpdate] = []
+            async for update in resource.watch_logs(
+                "job-1", poll_interval=0.01, timeout=5.0
+            ):
+                updates.append(update)
+
+        assert mock_get.await_count == 2
+        assert mock_logs.await_count == 2
+        assert updates[0].logs == "line-1\n"
+        assert updates[1].logs == "line-2\n"
+        assert updates[1].job.effective_state == JobStatus.COMPLETED


### PR DESCRIPTION
## What and why

EvalHub now exposes on-demand job log APIs on the server. This PR adds SDK support for fetching and tailing those logs, plus CLI and example tooling so users can follow workload output from job submission through completion.

The server returns log snapshots rather than SSE/WebSocket streams, so `watch_logs` polls log and status endpoints and deduplicates overlapping content until the job reaches a terminal state.

## Summary

### Client API

- Add `jobs.get_logs()` to fetch plain-text workload logs from `GET /api/v1/evaluations/jobs/{id}/logs` and the per-benchmark variant
- Add `jobs.watch_logs()` sync/async iterators that poll logs and job status until the job reaches a terminal state, yielding incremental `JobLogUpdate` objects with new log content and the current `EvaluationJob`
- Add shared helpers in `client/job_logs.py`: `JobLogOptions`, `JobLogUpdate`, path/query builders, and `log_delta()` with a KMP-based overlap algorithm for incremental deduplication
- Export `JobLogOptions` and `JobLogUpdate` from the top-level `evalhub` package and `evalhub.client`
- Reuse `is_terminal_job` / `TERMINAL_JOB_STATES` in `wait_for_completion` so terminal-state handling stays consistent with log watching
- `JobLogOptions` supports `tail_lines`, `timestamps`, and `since_seconds`

### CLI

- Add `--watch` to `eval run` and `collections run` to submit a job and stream logs until completion
- `--watch` shares `--timeout` and `--poll-interval` with `--wait`; the two flags are mutually exclusive
- Logs are written to stdout; submission and completion messages go to stderr
- Exit codes: `0` on success, `1` on failed job, `2` on timeout

### Example script

- Add `examples/watch_job_logs.py` for watching logs on an existing job ID
- Supports CLI profiles, env vars, explicit `--base-url`, Kubernetes service-account token files, and TLS options
- Includes structured HTTP error formatting and clean handling for timeouts, HTTP failures, and `KeyboardInterrupt`

### Documentation

- Update `README.md` with job log fetch/watch usage and CLI examples
- Add `examples/README.md` with runnable instructions for the watch script
- Update `CLAUDE.md` to document the new job resource methods

## Usage

### Client

```python
from evalhub import SyncEvalHubClient, JobLogOptions

with SyncEvalHubClient() as client:
    for update in client.jobs.watch_logs(
        "job-123",
        options=JobLogOptions(tail_lines=500),
        poll_interval=2.0,
    ):
        if update.logs:
            print(update.logs, end="")
    # final update.job.effective_state is terminal
```

### CLI

```bash
# Submit and stream logs until completion
evalhub eval run --config eval.yaml --watch

evalhub collections run rag-safety \
  --model-url http://vllm:8000/v1 \
  --model-name llama3 \
  --watch
```

### Example script

```bash
uv run python examples/watch_job_logs.py eval-abc123 --profile prod
```

## Type

- [x] feat
- [ ] fix
- [x] docs
- [x] refactor / chore
- [x] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

- [x] `uv run pytest tests/unit/test_job_logs.py -v`
- [x] `uv run pytest tests/unit/test_cli_eval.py tests/unit/test_cli_collections.py -k watch -v`
- [x] `make test`
- [x] `uv run mypy src/evalhub/client/job_logs.py src/evalhub/client/resources/jobs.py src/evalhub/cli/main.py`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added job log retrieval for job-level and benchmark-specific logs.
  * Added `watch_logs` for both sync and async clients to stream incremental log updates with configurable polling, tail size, timestamps, and optional timeout.
  * Exposed new job-log types in the client SDK to configure log query options and receive incremental updates.
* **Bug Fixes**
  * Improved log watching completion/termination handling to use consistent terminal-state logic.
* **Documentation**
  * Added an example script and README instructions for watching job logs.
* **Tests**
  * Added unit tests covering log query/path building, incremental delta computation, and sync/async log streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->