### PR TITLE
feat(adapter): add additional_info field for supplementary evaluation metadata

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       run: uv sync --all-extras
     - name: Run tests with coverage
       run: |
-        uv run pytest --cov=src/evalhub --cov-report=term-missing --cov-report=xml
+        uv run pytest -m unit --cov=src/evalhub --cov-report=term-missing --cov-report=xml
 
   lint:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: uv run --extra dev pytest
+        entry: uv run --extra dev pytest -m unit
         language: system
         pass_filenames: false
         always_run: true

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ pre-commit:
 
 .PHONY: test
 test:
-	uv run pytest --color=yes -ra
+	uv run pytest -m unit --color=yes -ra
 
 .PHONY: test-e2e
 test-e2e:
 	uv run uv pip show eval-hub-server
-	uv run pytest --e2e --e2e-debug -s -x --color=yes -ra
+	uv run pytest -m e2e --e2e-debug -s -x --color=yes -ra
 
 .PHONY: ruff
 ruff:

--- a/README.md
+++ b/README.md
@@ -578,14 +578,13 @@ class LMEvalAdapter(FrameworkAdapter):
         self, results: JobResults
     ) -> dict[str, str | int | float | bool | None] | None:
         """Derive supplementary EvalCard fields from lm-eval output."""
-        eval_meta = results.evaluation_metadata or {}
         benchmark_id = results.benchmark_id
 
         # Resolved n-shot (after task YAML override of the CLI value)
-        n_shot = eval_meta.get("n_shot", {}).get(benchmark_id, 0)
+        n_shot = self._n_shot.get(benchmark_id, 0)
 
         # CoT detection — layered heuristic (no single reliable signal)
-        task_config = eval_meta.get("task_configs", {}).get(benchmark_id, {})
+        task_config = self._task_configs.get(benchmark_id, {})
         tags = task_config.get("tag", [])
         if isinstance(tags, str):
             tags = [tags]
@@ -623,15 +622,11 @@ class LMEvalAdapter(FrameworkAdapter):
 
         lmeval_results = simple_evaluate(...)
 
-        # Stash framework metadata needed by generate_additional_info()
-        return JobResults(
-            ...,
-            evaluation_metadata={
-                "framework": "lm-evaluation-harness",
-                "n_shot": lmeval_results.get("n-shot", {}),
-                "task_configs": lmeval_results.get("configs", {}),
-            },
-        )
+        # Store framework output on self for generate_additional_info()
+        self._n_shot = lmeval_results.get("n-shot", {})
+        self._task_configs = lmeval_results.get("configs", {})
+
+        return JobResults(...)
 ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ The SDK is organized into distinct, focused packages:
 4. **JobResults** - Evaluation results returned when job completes
 5. **EvalCardMetadata** - Standardized evaluation disclosure (Dhar et al., arXiv:2511.21695): modalities, languages, capability and safety evaluations
 6. **EnvironmentCardMetadata** - Operational context of an evaluation run: hardware, software, Kubernetes, model identity, and run provenance
-7. **Sidecar** - Container that handles service communication (provided by platform)
+7. **additional_info** - Supplementary scalar key-value pairs merged into the server-generated EvalCard (e.g. zero-shot/alt-prompting scores, dataset SHA)
+8. **Sidecar** - Container that handles service communication (provided by platform)
 
 ## Breaking Changes
 
@@ -497,6 +498,7 @@ class JobResults(BaseModel):
     oci_artifact: Optional[OCIArtifactResult] # OCI artifact info if persisted
     eval_card: Optional[EvalCardMetadata]     # EvalCard disclosure metadata
     env_card: Optional[EnvironmentCardMetadata] # Environment Card metadata
+    additional_info: Optional[Dict[str, Any]]  # Key-value pairs for EvalCard generation
 ```
 
 **EvalCard & Environment Card** - Evaluation documentation artifacts:
@@ -536,6 +538,102 @@ eval_card = EvalCardMetadata(
 # Attach to results before reporting
 results = JobResults(..., eval_card=eval_card, env_card=env_card)
 callbacks.report_results(results)
+```
+
+**additional_info** - EvalCard key-value metadata:
+
+`additional_info` is a flat `dict[str, str | int | float | bool | None]` of
+supplementary key-value pairs merged into the server-generated EvalCard. The
+server populates core EvalCard fields from job metadata automatically; use
+`additional_info` to supply additional fields such as `zero_shot`,
+`alt_prompting`, and `alt_prompting_description`.
+Values must be scalar types (`str`, `int`, `float`, `bool`, or `None`).
+It is serialized as a top-level `additional_info` key in the
+`benchmark_status_event` payload.
+
+Override `generate_additional_info()` on your `FrameworkAdapter` subclass to
+centralise the derivation logic, then call it from `run_benchmark_job()`
+before returning results. If a framework has no implementation the base
+class returns `None` and it becomes a no-op.
+
+The adapter is not opinionated about where the key-value pairs come from —
+they can be derived from user input or from the framework's evaluation
+output. It is up to the implementer to decide. For example, when deriving
+from lm-evaluation-harness results it could look like:
+
+```python
+from evalhub.adapter import (
+    FrameworkAdapter,
+    JobSpec,
+    JobCallbacks,
+    JobResults,
+)
+
+
+class LMEvalAdapter(FrameworkAdapter):
+
+    def generate_additional_info(
+        self, config: JobSpec, results: JobResults
+    ) -> dict[str, str | int | float | bool | None] | None:
+        """Derive supplementary EvalCard fields from lm-eval output."""
+        eval_meta = results.evaluation_metadata or {}
+        benchmark_id = config.benchmark_id
+
+        # Resolved n-shot (after task YAML override of the CLI value)
+        n_shot = eval_meta.get("n_shot", {}).get(benchmark_id, 0)
+
+        # CoT detection — layered heuristic (no single reliable signal)
+        task_config = eval_meta.get("task_configs", {}).get(benchmark_id, {})
+        tags = task_config.get("tag", [])
+        if isinstance(tags, str):
+            tags = [tags]
+        doc_to_text = str(task_config.get("doc_to_text", ""))
+
+        is_cot = (
+            "chain_of_thought" in tags
+            or "cot" in benchmark_id.lower().replace("-", "_").split("_")
+            or "think step by step" in doc_to_text.lower()
+        )
+
+        is_zero_shot = n_shot == 0 and not is_cot
+        score = results.overall_score
+
+        # Build prompting strategy description
+        alt_desc = None
+        if not is_zero_shot:
+            parts = []
+            if n_shot > 0:
+                parts.append(f"{n_shot}-Shot")
+            if is_cot:
+                parts.append("CoT")
+            alt_desc = " ".join(parts) if parts else None
+
+        return {
+            "zero_shot": score if is_zero_shot else None,
+            "alt_prompting": score if not is_zero_shot else None,
+            "alt_prompting_description": alt_desc,
+        }
+
+    def run_benchmark_job(
+        self, config: JobSpec, callbacks: JobCallbacks
+    ) -> JobResults:
+        from lm_eval import simple_evaluate
+
+        lmeval_results = simple_evaluate(...)
+
+        # Stash framework metadata needed by generate_additional_info()
+        job_results = JobResults(
+            ...,
+            evaluation_metadata={
+                "framework": "lm-evaluation-harness",
+                "n_shot": lmeval_results.get("n-shot", {}),
+                "task_configs": lmeval_results.get("configs", {}),
+            },
+        )
+        job_results.additional_info = self.generate_additional_info(
+            config, job_results
+        )
+        return job_results
 ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The SDK is organized into distinct, focused packages:
 4. **JobResults** - Evaluation results returned when job completes
 5. **EvalCardMetadata** - Standardized evaluation disclosure (Dhar et al., arXiv:2511.21695): modalities, languages, capability and safety evaluations
 6. **EnvironmentCardMetadata** - Operational context of an evaluation run: hardware, software, Kubernetes, model identity, and run provenance
-7. **additional_info** - Supplementary scalar key-value pairs merged into the server-generated EvalCard (e.g. zero-shot/alt-prompting scores, dataset SHA)
+7. **additional_info** - Supplementary scalar key-value pairs for evaluation information beyond metrics (e.g. zero-shot/alt-prompting scores, dataset SHA)
 8. **Sidecar** - Container that handles service communication (provided by platform)
 
 ## Breaking Changes
@@ -498,7 +498,7 @@ class JobResults(BaseModel):
     oci_artifact: Optional[OCIArtifactResult] # OCI artifact info if persisted
     eval_card: Optional[EvalCardMetadata]     # EvalCard disclosure metadata
     env_card: Optional[EnvironmentCardMetadata] # Environment Card metadata
-    additional_info: Optional[Dict[str, Any]]  # Key-value pairs for EvalCard generation
+    additional_info: Optional[Dict[str, Union[str, int, float, bool, None]]]  # Supplementary evaluation info beyond metrics
 ```
 
 **EvalCard & Environment Card** - Evaluation documentation artifacts:
@@ -540,21 +540,23 @@ results = JobResults(..., eval_card=eval_card, env_card=env_card)
 callbacks.report_results(results)
 ```
 
-**additional_info** - EvalCard key-value metadata:
+**additional_info** - supplementary evaluation metadata:
 
 `additional_info` is a flat `dict[str, str | int | float | bool | None]` of
-supplementary key-value pairs merged into the server-generated EvalCard. The
-server populates core EvalCard fields from job metadata automatically; use
-`additional_info` to supply additional fields such as `zero_shot`,
-`alt_prompting`, and `alt_prompting_description`.
+supplementary key-value pairs for evaluation information beyond metrics
+(e.g. prompting strategy, dataset provenance). Use `additional_info` to
+supply fields such as `zero_shot`, `alt_prompting`, and
+`alt_prompting_description`.
 Values must be scalar types (`str`, `int`, `float`, `bool`, or `None`).
 It is serialized as a top-level `additional_info` key in the
-`benchmark_status_event` payload.
+`benchmark_status_event` payload and is available to downstream consumers
+such as EvalCard generation.
 
 Override `generate_additional_info()` on your `FrameworkAdapter` subclass to
-centralise the derivation logic, then call it from `run_benchmark_job()`
-before returning results. If a framework has no implementation the base
-class returns `None` and it becomes a no-op.
+centralise the derivation logic. It is called automatically by
+`DefaultCallbacks.report_results()` when `results.additional_info` is not
+already set. If a framework has no implementation the base class returns
+`None` and it becomes a no-op.
 
 The adapter is not opinionated about where the key-value pairs come from —
 they can be derived from user input or from the framework's evaluation
@@ -573,11 +575,11 @@ from evalhub.adapter import (
 class LMEvalAdapter(FrameworkAdapter):
 
     def generate_additional_info(
-        self, config: JobSpec, results: JobResults
+        self, results: JobResults
     ) -> dict[str, str | int | float | bool | None] | None:
         """Derive supplementary EvalCard fields from lm-eval output."""
         eval_meta = results.evaluation_metadata or {}
-        benchmark_id = config.benchmark_id
+        benchmark_id = results.benchmark_id
 
         # Resolved n-shot (after task YAML override of the CLI value)
         n_shot = eval_meta.get("n_shot", {}).get(benchmark_id, 0)
@@ -622,7 +624,7 @@ class LMEvalAdapter(FrameworkAdapter):
         lmeval_results = simple_evaluate(...)
 
         # Stash framework metadata needed by generate_additional_info()
-        job_results = JobResults(
+        return JobResults(
             ...,
             evaluation_metadata={
                 "framework": "lm-evaluation-harness",
@@ -630,10 +632,6 @@ class LMEvalAdapter(FrameworkAdapter):
                 "task_configs": lmeval_results.get("configs", {}),
             },
         )
-        job_results.additional_info = self.generate_additional_info(
-            config, job_results
-        )
-        return job_results
 ```
 
 ## Deployment

--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -679,7 +679,12 @@ class DefaultCallbacks(JobCallbacks):
         # Resolve additional_info without mutating the caller's results object.
         additional_info = results.additional_info
         if additional_info is None and self.generate_additional_info_fn:
-            additional_info = self.generate_additional_info_fn(results)
+            try:
+                additional_info = self.generate_additional_info_fn(results)
+            except Exception:
+                logger.debug(
+                    "generate_additional_info_fn failed", exc_info=True
+                )
 
         # Resolve the Environment Card without mutating the caller's results object.
         # If the provider did not supply one, capture a best-effort card locally.

--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -682,9 +682,7 @@ class DefaultCallbacks(JobCallbacks):
             try:
                 additional_info = self.generate_additional_info_fn(results)
             except Exception:
-                logger.debug(
-                    "generate_additional_info_fn failed", exc_info=True
-                )
+                logger.debug("generate_additional_info_fn failed", exc_info=True)
 
         # Resolve the Environment Card without mutating the caller's results object.
         # If the provider did not supply one, capture a best-effort card locally.

--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -339,6 +340,10 @@ class DefaultCallbacks(JobCallbacks):
         oci_insecure: bool = False,
         oci_proxy_host: str | None = None,
         mlflow_backend: MlflowBackend = MlflowBackend.ODH,
+        generate_additional_info_fn: (
+            Callable[[JobResults], dict[str, str | int | float | bool | None] | None]
+            | None
+        ) = None,
     ):
         """Initialize default callbacks.
 
@@ -367,6 +372,10 @@ class DefaultCallbacks(JobCallbacks):
                            MlflowBackend.UPSTREAM for the official mlflow library.
                            Can also be set via EVALHUB_MLFLOW_BACKEND env var when
                            constructing via from_adapter().
+            generate_additional_info_fn: Optional callable that derives supplementary
+                           evaluation key-value pairs from JobResults. Called by
+                           report_results() when results.additional_info is not
+                           already set. Automatically wired via from_adapter().
         """
         self.job_id = job_id
         self.benchmark_id = benchmark_id
@@ -408,6 +417,8 @@ class DefaultCallbacks(JobCallbacks):
 
         # MLflow integration (single-method API via callbacks.mlflow.save)
         self.mlflow = _MlflowOps(backend=mlflow_backend, callbacks=self)
+
+        self.generate_additional_info_fn = generate_additional_info_fn
 
         # Try to import httpx for sidecar communication
         self._httpx_available = False
@@ -665,6 +676,11 @@ class DefaultCallbacks(JobCallbacks):
         Args:
             results: Final job results to report
         """
+        # Resolve additional_info without mutating the caller's results object.
+        additional_info = results.additional_info
+        if additional_info is None and self.generate_additional_info_fn:
+            additional_info = self.generate_additional_info_fn(results)
+
         # Resolve the Environment Card without mutating the caller's results object.
         # If the provider did not supply one, capture a best-effort card locally.
         env_card = results.env_card
@@ -718,8 +734,8 @@ class DefaultCallbacks(JobCallbacks):
                 if artifacts:
                     status_event["artifacts"] = artifacts
 
-                if results.additional_info is not None:
-                    status_event["additional_info"] = results.additional_info
+                if additional_info is not None:
+                    status_event["additional_info"] = additional_info
 
                 data = {"benchmark_status_event": status_event}
                 logger.debug("Events report_results body: %s", data)
@@ -777,4 +793,10 @@ class DefaultCallbacks(JobCallbacks):
                 else None
             ),
             mlflow_backend=adapter.settings.mlflow_backend,
+            generate_additional_info_fn=(
+                adapter.generate_additional_info
+                if type(adapter).generate_additional_info
+                is not FrameworkAdapter.generate_additional_info
+                else None
+            ),
         )

--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -718,6 +718,9 @@ class DefaultCallbacks(JobCallbacks):
                 if artifacts:
                     status_event["artifacts"] = artifacts
 
+                if results.additional_info is not None:
+                    status_event["additional_info"] = results.additional_info
+
                 data = {"benchmark_status_event": status_event}
                 logger.debug("Events report_results body: %s", data)
 

--- a/src/evalhub/adapter/models/adapter.py
+++ b/src/evalhub/adapter/models/adapter.py
@@ -39,6 +39,8 @@ class FrameworkAdapter(ABC):
 
     Framework adapters should:
     - Implement run_benchmark_job() to execute the benchmark
+    - Optionally override generate_additional_info() to supply supplementary EvalCard fields;
+      call it from run_benchmark_job() and attach to results before returning
     - Use the config parameter for job configuration (passed as adapter.job_spec in production)
     - Access self.settings for runtime configuration (service_url, registry, etc.)
     - Use callbacks.report_status() to report progress
@@ -57,7 +59,11 @@ class FrameworkAdapter(ABC):
                 # Run evaluation
                 results = evaluate(config.model, ...)
 
-                return JobResults(...)
+                job_results = JobResults(...)
+                job_results.additional_info = self.generate_additional_info(
+                    config, job_results
+                )
+                return job_results
 
         # Production usage (auto-detects /meta/job.json in k8s)
         adapter = MyAdapter()
@@ -69,13 +75,9 @@ class FrameworkAdapter(ABC):
         # export EVALHUB_JOB_SPEC_PATH=/path/to/job.json
         adapter = MyAdapter()
 
-        # Run the job
-        callbacks = DefaultCallbacks(
-            job_id=adapter.job_spec.id,
-            sidecar_url=adapter.job_spec.callback_url,
-            ...
-        )
+        callbacks = DefaultCallbacks.from_adapter(adapter)
         results = adapter.run_benchmark_job(adapter.job_spec, callbacks)
+        callbacks.report_results(results)
         ```
     """
 
@@ -228,6 +230,26 @@ class FrameworkAdapter(ABC):
                 f"got: {s.job_spec_path}"
             )
         return job_spec.parent.parent
+
+    def generate_additional_info(
+        self, config: JobSpec, results: JobResults
+    ) -> dict[str, str | int | float | bool | None] | None:
+        """Generate supplementary key-value pairs for EvalCard generation.
+
+        The server populates EvalCard fields from job metadata automatically;
+        override this to supply additional fields (e.g. ``zero_shot``,
+        ``alt_prompting``, ``dataset_sha``) that are merged into the
+        generated EvalCard. The default returns ``None``.
+        Values must be scalar types (str, int, float, bool, or None).
+
+        Args:
+            config: The job specification (dataset info, benchmark params, etc.)
+            results: The completed evaluation results (metrics, scores, etc.)
+
+        Returns:
+            Dict of scalar key-value pairs, or None to skip.
+        """
+        return None
 
     @abstractmethod
     def run_benchmark_job(self, config: JobSpec, callbacks: JobCallbacks) -> JobResults:

--- a/src/evalhub/adapter/models/adapter.py
+++ b/src/evalhub/adapter/models/adapter.py
@@ -39,8 +39,9 @@ class FrameworkAdapter(ABC):
 
     Framework adapters should:
     - Implement run_benchmark_job() to execute the benchmark
-    - Optionally override generate_additional_info() to supply supplementary EvalCard fields;
-      call it from run_benchmark_job() and attach to results before returning
+    - Optionally override generate_additional_info() to supply supplementary
+      evaluation metadata beyond metrics; called automatically by
+      DefaultCallbacks.report_results()
     - Use the config parameter for job configuration (passed as adapter.job_spec in production)
     - Access self.settings for runtime configuration (service_url, registry, etc.)
     - Use callbacks.report_status() to report progress
@@ -59,11 +60,7 @@ class FrameworkAdapter(ABC):
                 # Run evaluation
                 results = evaluate(config.model, ...)
 
-                job_results = JobResults(...)
-                job_results.additional_info = self.generate_additional_info(
-                    config, job_results
-                )
-                return job_results
+                return JobResults(...)
 
         # Production usage (auto-detects /meta/job.json in k8s)
         adapter = MyAdapter()
@@ -232,19 +229,23 @@ class FrameworkAdapter(ABC):
         return job_spec.parent.parent
 
     def generate_additional_info(
-        self, config: JobSpec, results: JobResults
+        self, results: JobResults
     ) -> dict[str, str | int | float | bool | None] | None:
-        """Generate supplementary key-value pairs for EvalCard generation.
+        """Generate supplementary key-value pairs for the evaluation.
 
-        The server populates EvalCard fields from job metadata automatically;
-        override this to supply additional fields (e.g. ``zero_shot``,
-        ``alt_prompting``, ``dataset_sha``) that are merged into the
-        generated EvalCard. The default returns ``None``.
+        Override this to supply additional evaluation information beyond
+        metrics (e.g. ``zero_shot``, ``alt_prompting``, ``dataset_sha``).
+        These are included in the ``benchmark_status_event`` payload and
+        are available to downstream consumers such as EvalCard generation.
+        The default returns ``None``.
         Values must be scalar types (str, int, float, bool, or None).
 
+        Called automatically by ``DefaultCallbacks.report_results()`` when
+        ``results.additional_info`` is not already set.
+
         Args:
-            config: The job specification (dataset info, benchmark params, etc.)
-            results: The completed evaluation results (metrics, scores, etc.)
+            results: The completed evaluation results (metrics, scores, etc.).
+                     Use ``results.benchmark_id`` for benchmark-specific logic.
 
         Returns:
             Dict of scalar key-value pairs, or None to skip.

--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -314,10 +314,10 @@ class JobResults(BaseModel):
 
     additional_info: dict[str, str | int | float | bool | None] | None = Field(
         default=None,
-        description="Supplementary scalar key-value pairs merged into the "
-        "server-generated EvalCard. The server populates core EvalCard fields "
-        "from job metadata; these supply additional fields. "
-        "Serialized into status_event['additional_info'].",
+        description="Supplementary scalar key-value pairs for evaluation "
+        "information beyond metrics (e.g. prompting strategy, dataset SHA). "
+        "Serialized into status_event['additional_info'] and available to "
+        "downstream consumers such as EvalCard generation.",
     )
 
 

--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ...models.api import (
     EvaluationResult,
@@ -263,6 +263,8 @@ class JobResults(BaseModel):
 
     This is returned synchronously when the job completes.
     """
+
+    model_config = ConfigDict(validate_assignment=True)
 
     # Core results
     id: str = Field(..., description="Job identifier")

--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -310,6 +310,14 @@ class JobResults(BaseModel):
         description="Environment Card metadata. Serialized into artifacts['evalhub.env_card'].",
     )
 
+    additional_info: dict[str, str | int | float | bool | None] | None = Field(
+        default=None,
+        description="Supplementary scalar key-value pairs merged into the "
+        "server-generated EvalCard. The server populates core EvalCard fields "
+        "from job metadata; these supply additional fields. "
+        "Serialized into status_event['additional_info'].",
+    )
+
 
 class JobCallbacks(ABC):
     """Abstract interface for job callbacks.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,57 +1,13 @@
 """Pytest configuration for eval-hub-sdk tests."""
 
-import logging
 from typing import Any
-
-import pytest
 
 
 def pytest_addoption(parser: Any) -> None:
     """Add custom command line options."""
-    parser.addoption(
-        "--e2e",
-        action="store_true",
-        default=False,
-        help="Run only E2E tests",
-    )
     parser.addoption(
         "--e2e-debug",
         action="store_true",
         default=False,
         help="Enable DEBUG logging for E2E test fixtures",
     )
-
-
-def pytest_configure(config: Any) -> None:
-    """Register custom markers and configure logging."""
-    config.addinivalue_line(
-        "markers", "e2e: mark test as end-to-end test (run with --e2e flag)"
-    )
-    if config.getoption("--e2e-debug", default=False):
-        e2e_logger = logging.getLogger("tests.e2e.conftest")
-        e2e_logger.setLevel(logging.DEBUG)
-        handler = logging.StreamHandler()
-        handler.setLevel(logging.DEBUG)
-        handler.setFormatter(logging.Formatter("%(name)s %(levelname)s: %(message)s"))
-        e2e_logger.addHandler(handler)
-
-
-def pytest_collection_modifyitems(config: Any, items: list[Any]) -> None:
-    e2e_flag = config.getoption("--e2e")
-
-    skip_e2e = pytest.mark.skip(reason="E2E tests require --e2e flag")
-    skip_non_e2e = pytest.mark.skip(
-        reason="Non-E2E tests are skipped when --e2e flag is used"
-    )
-
-    for item in items:
-        is_e2e = "e2e" in item.keywords
-
-        if e2e_flag:
-            # When --e2e flag is provided, skip non-e2e tests
-            if not is_e2e:
-                item.add_marker(skip_non_e2e)
-        else:
-            # When --e2e flag is NOT provided, skip e2e tests
-            if is_e2e:
-                item.add_marker(skip_e2e)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,11 +8,23 @@ import tempfile
 import time
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
 
 logger = logging.getLogger(__name__)
+
+
+def pytest_configure(config: Any) -> None:
+    """Configure logging for E2E tests."""
+    if config.getoption("--e2e-debug", default=False):
+        e2e_logger = logging.getLogger("tests.e2e.conftest")
+        e2e_logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(logging.Formatter("%(name)s %(levelname)s: %(message)s"))
+        e2e_logger.addHandler(handler)
 
 
 def _kill_process_on_port(port: int) -> bool:

--- a/tests/e2e/test_persist_with_mock_persister.py
+++ b/tests/e2e/test_persist_with_mock_persister.py
@@ -18,6 +18,8 @@ from evalhub.adapter.callbacks import DefaultCallbacks
 from evalhub.adapter.models import JobStatusUpdate, OCIArtifactResult, OCIArtifactSpec
 from evalhub.models.api import OCICoordinates
 
+pytestmark = pytest.mark.e2e
+
 
 @pytest.fixture
 def mock_job_spec_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:

--- a/tests/unit/test_adapter_models.py
+++ b/tests/unit/test_adapter_models.py
@@ -26,6 +26,8 @@ from evalhub.adapter import (
 )
 from pydantic import ValidationError
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture
 def mock_job_spec_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:

--- a/tests/unit/test_adapter_models.py
+++ b/tests/unit/test_adapter_models.py
@@ -1013,3 +1013,50 @@ class TestJobResultsWithCards:
 
         assert results.eval_card is None
         assert results.env_card is None
+        assert results.additional_info is None
+
+    def test_additional_info_accepts_scalar_values(self) -> None:
+        info: dict[str, str | int | float | bool | None] = {
+            "dataset_sha": "sha256:abc",
+            "zero_shot": "0.85",
+            "custom_metric": 42,
+            "score": 0.95,
+            "passed": True,
+            "notes": None,
+        }
+        results = JobResults(
+            id="j",
+            benchmark_id="b",
+            benchmark_index=0,
+            model_name="m",
+            results=[],
+            num_examples_evaluated=0,
+            duration_seconds=0.0,
+            additional_info=info,
+        )
+        assert results.additional_info == info
+
+    def test_additional_info_rejects_non_scalar_values(self) -> None:
+        with pytest.raises(ValueError, match="additional_info"):
+            JobResults(
+                id="j",
+                benchmark_id="b",
+                benchmark_index=0,
+                model_name="m",
+                results=[],
+                num_examples_evaluated=0,
+                duration_seconds=0.0,
+                additional_info={"nested": {"a": 1}},  # type: ignore[dict-item]
+            )
+
+        with pytest.raises(ValueError, match="additional_info"):
+            JobResults(
+                id="j",
+                benchmark_id="b",
+                benchmark_index=0,
+                model_name="m",
+                results=[],
+                num_examples_evaluated=0,
+                duration_seconds=0.0,
+                additional_info={"tags": ["a", "b"]},  # type: ignore[dict-item]
+            )

--- a/tests/unit/test_adapter_models.py
+++ b/tests/unit/test_adapter_models.py
@@ -24,6 +24,7 @@ from evalhub.adapter import (
     OCIArtifactSpec,
     SafetyEvalEntry,
 )
+from pydantic import ValidationError
 
 
 @pytest.fixture
@@ -530,6 +531,21 @@ class TestJobResults:
 
         assert results.completed_at is not None
         assert isinstance(results.completed_at, datetime)
+
+    def test_additional_info_rejects_invalid_values_on_assignment(self) -> None:
+        """Test that assigning non-scalar values to additional_info is rejected."""
+        results = JobResults(
+            id="test-job-001",
+            benchmark_id="mmlu",
+            benchmark_index=0,
+            model_name="model",
+            results=[],
+            num_examples_evaluated=100,
+            duration_seconds=60.0,
+        )
+
+        with pytest.raises(ValidationError):
+            results.additional_info = {"nested": {"not": "allowed"}}  # type: ignore[dict-item]
 
 
 class TestJobCallbacks:

--- a/tests/unit/test_adapter_settings.py
+++ b/tests/unit/test_adapter_settings.py
@@ -7,6 +7,8 @@ import pytest
 from evalhub.adapter.config import get_job_spec_path
 from evalhub.adapter.settings import AdapterSettings
 
+pytestmark = pytest.mark.unit
+
 
 class TestAdapterSettingsModeNormalization:
     """Tests for case-insensitive EVALHUB_MODE handling."""

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -13,6 +13,8 @@ from evalhub.adapter.models.job import (
 )
 from evalhub.models.api import EvaluationResult, JobStatus, ModelConfig
 
+pytestmark = pytest.mark.unit
+
 
 def _results(mlflow_run_id: str | None = None) -> JobResults:
     return JobResults(
@@ -154,7 +156,6 @@ def test_mlflow_save_returns_run_id_from_upstream_path() -> None:
     m.assert_called_once()
 
 
-@pytest.mark.unit
 def test_mlflow_save_posts_failed_event_on_mlflow_error() -> None:
     callbacks, mock_http = _make_callbacks()
 

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -368,3 +368,53 @@ def test_report_results_always_includes_provider_id() -> None:
     event = body["benchmark_status_event"]
     assert "provider_id" in event
     assert event["provider_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# additional_info payload tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_results_includes_additional_info_when_set() -> None:
+    callbacks, mock_http = _make_callbacks()
+    results = _results()
+    results.additional_info = {
+        "dataset_sha": "abc123",
+        "zero_shot": "0.85",
+    }
+    callbacks.report_results(results)
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert event["additional_info"] == {
+        "dataset_sha": "abc123",
+        "zero_shot": "0.85",
+    }
+
+
+def test_report_results_omits_additional_info_when_not_set() -> None:
+    callbacks, mock_http = _make_callbacks()
+    callbacks.report_results(_results())
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert "additional_info" not in event
+
+
+def test_report_results_additional_info_passes_arbitrary_keys() -> None:
+    callbacks, mock_http = _make_callbacks()
+    results = _results()
+    results.additional_info = {
+        "alt_prompting": "0.91",
+        "alt_prompting_description": "5-Shot CoT",
+        "custom_key": 42,
+    }
+    callbacks.report_results(results)
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert event["additional_info"] == {
+        "alt_prompting": "0.91",
+        "alt_prompting_description": "5-Shot CoT",
+        "custom_key": 42,
+    }

--- a/tests/unit/test_cli_client.py
+++ b/tests/unit/test_cli_client.py
@@ -21,6 +21,8 @@ from evalhub.cli.config import (
 from evalhub.cli.main import main
 from evalhub.client import ClientError, JobNotFoundError
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 def config_file(tmp_path: Path) -> Iterator[Path]:

--- a/tests/unit/test_cli_collections.py
+++ b/tests/unit/test_cli_collections.py
@@ -19,6 +19,8 @@ from evalhub.models.api import (
     Resource,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _make_benchmark_ref(
     id: str = "mmlu",

--- a/tests/unit/test_cli_completion.py
+++ b/tests/unit/test_cli_completion.py
@@ -8,6 +8,8 @@ from click.testing import CliRunner
 from evalhub.cli.completion import PowerShellComplete
 from evalhub.cli.main import main
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 def runner() -> CliRunner:

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -33,6 +33,8 @@ from evalhub.cli.config import (
 )
 from evalhub.cli.main import main
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 def config_file(tmp_path: Path) -> Iterator[Path]:

--- a/tests/unit/test_cli_eval.py
+++ b/tests/unit/test_cli_eval.py
@@ -25,6 +25,8 @@ from evalhub.models.api import (
     ModelConfig,
 )
 
+pytestmark = pytest.mark.unit
+
 NOW = datetime(2026, 3, 23, 12, 0, 0, tzinfo=UTC)
 
 

--- a/tests/unit/test_cli_formatter.py
+++ b/tests/unit/test_cli_formatter.py
@@ -6,6 +6,7 @@ import io
 import json
 import re
 
+import pytest
 import yaml
 from evalhub.cli.formatter import (
     FORMATS,
@@ -13,6 +14,8 @@ from evalhub.cli.formatter import (
     format_option,
     output,
 )
+
+pytestmark = pytest.mark.unit
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 

--- a/tests/unit/test_cli_mcp.py
+++ b/tests/unit/test_cli_mcp.py
@@ -15,6 +15,8 @@ from click.testing import CliRunner
 from evalhub.cli.main import main
 from evalhub.cli.mcp_cmd import GENERATED_CONFIG, _fetch_server_info
 
+pytestmark = pytest.mark.unit
+
 
 @pytest.fixture()
 def config_file(tmp_path: Path) -> Iterator[Path]:

--- a/tests/unit/test_cli_providers.py
+++ b/tests/unit/test_cli_providers.py
@@ -21,6 +21,8 @@ from evalhub.models.api import (
     Resource,
 )
 
+pytestmark = pytest.mark.unit
+
 
 def _make_provider(
     id: str = "lm_eval",

--- a/tests/unit/test_evalhub_client.py
+++ b/tests/unit/test_evalhub_client.py
@@ -46,6 +46,8 @@ from evalhub.models.api import (
     ScoreRange,
 )
 
+pytestmark = pytest.mark.unit
+
 # Environment variable to enable real server testing
 EVALHUB_TEST_BASE_URL = os.environ.get("EVALHUB_TEST_BASE_URL")
 

--- a/tests/unit/test_mlflow_metric_key.py
+++ b/tests/unit/test_mlflow_metric_key.py
@@ -1,6 +1,9 @@
 """MLflow metric key sanitization for REST API rules."""
 
+import pytest
 from evalhub.adapter.mlflow import sanitize_metric_key_for_api
+
+pytestmark = pytest.mark.unit
 
 
 def test_sanitize_lm_eval_style_comma() -> None:

--- a/tests/unit/test_mlflow_traces.py
+++ b/tests/unit/test_mlflow_traces.py
@@ -11,6 +11,8 @@ from evalhub.adapter.mlflow import (
     _parse_trace,
 )
 
+pytestmark = pytest.mark.unit
+
 # -- TracesNamespace.is_source_configured -----------------------------------
 
 

--- a/tests/unit/test_models_api.py
+++ b/tests/unit/test_models_api.py
@@ -31,6 +31,8 @@ from evalhub.models.api import (
 )
 from pydantic import ValidationError
 
+pytestmark = pytest.mark.unit
+
 
 class TestModelConfig:
     """Test cases for ModelConfig model."""

--- a/tests/unit/test_oci_models.py
+++ b/tests/unit/test_oci_models.py
@@ -8,6 +8,8 @@ from evalhub.models.api import (
 )
 from pydantic import ValidationError
 
+pytestmark = pytest.mark.unit
+
 
 class TestOCICoordinates:
     """Tests for OCICoordinates model."""

--- a/tests/unit/test_oci_persister.py
+++ b/tests/unit/test_oci_persister.py
@@ -10,6 +10,8 @@ from evalhub.adapter.oci import OCIArtifactContext, OCIArtifactPersister
 from evalhub.adapter.oci.persister import default_tag_hasher
 from evalhub.models.api import OCICoordinates
 
+pytestmark = pytest.mark.unit
+
 
 class TestOCIArtifactPersisterInit:
     """Tests for OCIArtifactPersister initialization."""

--- a/tests/unit/test_retry_logic.py
+++ b/tests/unit/test_retry_logic.py
@@ -13,6 +13,8 @@ from evalhub.client.base import (
     _calculate_retry_delay,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestRetryDelayCalculation:
     """Test retry delay calculation with exponential backoff."""


### PR DESCRIPTION


## What and why


Add a flat scalar key-value dict to JobResults for attaching supplementary metadata (dataset SHA, zero-shot/alt-prompting scores, etc.) to the benchmark completion event. Includes generate_additional_info() hook on FrameworkAdapter, serialization in DefaultCallbacks.report_results(), and validation to reject non-scalar values.

This information will be consumed by Evalcard generation at the server end

Closes # https://redhat.atlassian.net/browse/RHOAIENG-72755

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README to document an optional `additional_info` channel for benchmark status events, including allowed scalar types and an adapter guidance example.
* **New Features**
  * `JobResults` can now carry optional `additional_info`, which is surfaced in the benchmark status event payload.
  * Adapters can provide `additional_info` via a `generate_additional_info()` hook, automatically used by callbacks when not already set.
* **Tests**
  * Added/extended unit tests for `additional_info` validation and correct inclusion/omission in status event payloads.
* **Chores**
  * Updated review guidance for test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->