### PR TITLE
chore(adapter): relax additional_info to accept any JSON-serializable value

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The SDK is organized into distinct, focused packages:
 4. **JobResults** - Evaluation results returned when job completes
 5. **EvalCardMetadata** - Standardized evaluation disclosure (Dhar et al., arXiv:2511.21695): modalities, languages, capability and safety evaluations
 6. **EnvironmentCardMetadata** - Operational context of an evaluation run: hardware, software, Kubernetes, model identity, and run provenance
-7. **additional_info** - Supplementary scalar key-value pairs for evaluation information beyond metrics (e.g. zero-shot/alt-prompting scores, dataset SHA)
+7. **additional_info** - Supplementary key-value pairs for evaluation information beyond metrics (e.g. dataset provenance, zero-shot/alt-prompting scores)
 8. **Sidecar** - Container that handles service communication (provided by platform)
 
 ## Breaking Changes
@@ -529,7 +529,7 @@ class JobResults(BaseModel):
     oci_artifact: Optional[OCIArtifactResult] # OCI artifact info if persisted
     eval_card: Optional[EvalCardMetadata]     # EvalCard disclosure metadata
     env_card: Optional[EnvironmentCardMetadata] # Environment Card metadata
-    additional_info: Optional[Dict[str, Union[str, int, float, bool, None]]]  # Supplementary evaluation info beyond metrics
+    additional_info: Optional[Dict[str, Any]]  # Supplementary evaluation info beyond metrics
 ```
 
 **EvalCard & Environment Card** - Evaluation documentation artifacts:
@@ -573,12 +573,11 @@ callbacks.report_results(results)
 
 **additional_info** - supplementary evaluation metadata:
 
-`additional_info` is a flat `dict[str, str | int | float | bool | None]` of
-supplementary key-value pairs for evaluation information beyond metrics
-(e.g. prompting strategy, dataset provenance). Use `additional_info` to
-supply fields such as `zero_shot`, `alt_prompting`, and
-`alt_prompting_description`.
-Values must be scalar types (`str`, `int`, `float`, `bool`, or `None`).
+`additional_info` is a `dict[str, Any]` of supplementary key-value pairs for
+evaluation information beyond metrics. Values can be any JSON-serializable
+type, including nested objects and lists. Use `additional_info` to supply
+fields such as `dataset` (list of dataset provenance records), `zero_shot`,
+`alt_prompting`, and `alt_prompting_description`.
 It is serialized as a top-level `additional_info` key in the
 `benchmark_status_event` payload and is available to downstream consumers
 such as EvalCard generation.
@@ -607,7 +606,7 @@ class LMEvalAdapter(FrameworkAdapter):
 
     def generate_additional_info(
         self, results: JobResults
-    ) -> dict[str, str | int | float | bool | None] | None:
+    ) -> dict[str, Any] | None:
         """Derive supplementary EvalCard fields from lm-eval output."""
         benchmark_id = results.benchmark_id
 

--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -341,8 +341,7 @@ class DefaultCallbacks(JobCallbacks):
         oci_proxy_host: str | None = None,
         mlflow_backend: MlflowBackend = MlflowBackend.ODH,
         generate_additional_info_fn: (
-            Callable[[JobResults], dict[str, str | int | float | bool | None] | None]
-            | None
+            Callable[[JobResults], dict[str, Any] | None] | None
         ) = None,
     ):
         """Initialize default callbacks.

--- a/src/evalhub/adapter/models/adapter.py
+++ b/src/evalhub/adapter/models/adapter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from evalhub.adapter.config import EvalHubMode
 
@@ -228,9 +228,7 @@ class FrameworkAdapter(ABC):
             )
         return job_spec.parent.parent
 
-    def generate_additional_info(
-        self, results: JobResults
-    ) -> dict[str, str | int | float | bool | None] | None:
+    def generate_additional_info(self, results: JobResults) -> dict[str, Any] | None:
         """Generate supplementary key-value pairs for the evaluation.
 
         Override this to supply additional evaluation information beyond
@@ -238,7 +236,7 @@ class FrameworkAdapter(ABC):
         These are included in the ``benchmark_status_event`` payload and
         are available to downstream consumers such as EvalCard generation.
         The default returns ``None``.
-        Values must be scalar types (str, int, float, bool, or None).
+        Values may be any JSON-serializable type.
 
         Called automatically by ``DefaultCallbacks.report_results()`` when
         ``results.additional_info`` is not already set.
@@ -248,7 +246,7 @@ class FrameworkAdapter(ABC):
                      Use ``results.benchmark_id`` for benchmark-specific logic.
 
         Returns:
-            Dict of scalar key-value pairs, or None to skip.
+            Dict of key-value pairs, or None to skip.
         """
         return None
 

--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -312,10 +312,11 @@ class JobResults(BaseModel):
         description="Environment Card metadata. Serialized into artifacts['evalhub.env_card'].",
     )
 
-    additional_info: dict[str, str | int | float | bool | None] | None = Field(
+    additional_info: dict[str, Any] | None = Field(
         default=None,
-        description="Supplementary scalar key-value pairs for evaluation "
+        description="Supplementary key-value pairs for evaluation "
         "information beyond metrics (e.g. prompting strategy, dataset SHA). "
+        "Accepts any JSON-serializable values. "
         "Serialized into status_event['additional_info'] and available to "
         "downstream consumers such as EvalCard generation.",
     )

--- a/tests/unit/test_adapter_models.py
+++ b/tests/unit/test_adapter_models.py
@@ -3,6 +3,7 @@
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 from evalhub.adapter import (
@@ -24,7 +25,6 @@ from evalhub.adapter import (
     OCIArtifactSpec,
     SafetyEvalEntry,
 )
-from pydantic import ValidationError
 
 pytestmark = pytest.mark.unit
 
@@ -534,8 +534,8 @@ class TestJobResults:
         assert results.completed_at is not None
         assert isinstance(results.completed_at, datetime)
 
-    def test_additional_info_rejects_invalid_values_on_assignment(self) -> None:
-        """Test that assigning non-scalar values to additional_info is rejected."""
+    def test_additional_info_accepts_nested_values_on_assignment(self) -> None:
+        """Test that assigning nested values to additional_info is accepted."""
         results = JobResults(
             id="test-job-001",
             benchmark_id="mmlu",
@@ -546,8 +546,8 @@ class TestJobResults:
             duration_seconds=60.0,
         )
 
-        with pytest.raises(ValidationError):
-            results.additional_info = {"nested": {"not": "allowed"}}  # type: ignore[dict-item]
+        results.additional_info = {"nested": {"is": "allowed"}}
+        assert results.additional_info == {"nested": {"is": "allowed"}}
 
 
 class TestJobCallbacks:
@@ -1034,7 +1034,7 @@ class TestJobResultsWithCards:
         assert results.additional_info is None
 
     def test_additional_info_accepts_scalar_values(self) -> None:
-        info: dict[str, str | int | float | bool | None] = {
+        info: dict[str, Any] = {
             "dataset_sha": "sha256:abc",
             "zero_shot": "0.85",
             "custom_metric": 42,
@@ -1054,27 +1054,20 @@ class TestJobResultsWithCards:
         )
         assert results.additional_info == info
 
-    def test_additional_info_rejects_non_scalar_values(self) -> None:
-        with pytest.raises(ValueError, match="additional_info"):
-            JobResults(
-                id="j",
-                benchmark_id="b",
-                benchmark_index=0,
-                model_name="m",
-                results=[],
-                num_examples_evaluated=0,
-                duration_seconds=0.0,
-                additional_info={"nested": {"a": 1}},  # type: ignore[dict-item]
-            )
-
-        with pytest.raises(ValueError, match="additional_info"):
-            JobResults(
-                id="j",
-                benchmark_id="b",
-                benchmark_index=0,
-                model_name="m",
-                results=[],
-                num_examples_evaluated=0,
-                duration_seconds=0.0,
-                additional_info={"tags": ["a", "b"]},  # type: ignore[dict-item]
-            )
+    def test_additional_info_accepts_nested_values(self) -> None:
+        info: dict[str, Any] = {
+            "nested": {"a": 1, "b": [2, 3]},
+            "tags": ["a", "b"],
+            "scalar": "still works",
+        }
+        results = JobResults(
+            id="j",
+            benchmark_id="b",
+            benchmark_index=0,
+            model_name="m",
+            results=[],
+            num_examples_evaluated=0,
+            duration_seconds=0.0,
+            additional_info=info,
+        )
+        assert results.additional_info == info

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -419,3 +419,20 @@ def test_report_results_additional_info_passes_arbitrary_keys() -> None:
         "alt_prompting_description": "5-Shot CoT",
         "custom_key": 42,
     }
+
+
+def test_report_results_additional_info_passes_nested_values() -> None:
+    callbacks, mock_http = _make_callbacks()
+    results = _results()
+    results.additional_info = {
+        "config": {"shots": 5, "cot": True},
+        "tags": ["a", "b"],
+    }
+    callbacks.report_results(results)
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert event["additional_info"] == {
+        "config": {"shots": 5, "cot": True},
+        "tags": ["a", "b"],
+    }


### PR DESCRIPTION


## What and why


The Go server accepts `map[string]any` for additional_info, but the SDK restricted values to scalars only. Relax the type from `dict[str, str | int | float | bool | None]` to `dict[str, Any]` to support nested objects and lists (e.g. dataset provenance records).

Closes # https://redhat.atlassian.net/browse/RHOAIENG-72755

## Type

- [ ] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

```
make tests
make tests-e2e
```
## Breaking changes

No
<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `additional_info` now supports nested objects, lists, and other JSON-serializable values.
  * Additional metadata with nested structures is included in benchmark status results.

* **Documentation**
  * Updated documentation and examples to reflect the broader `additional_info` format.

* **Tests**
  * Added coverage for storing and reporting nested metadata successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->