### PR TITLE
fix: sanitize error messages with hostnames/URLs

### DIFF
--- a/src/evalhub/adapter/__init__.py
+++ b/src/evalhub/adapter/__init__.py
@@ -94,6 +94,7 @@ from .models import (
 )
 from .oci import OCIArtifactPersister
 from .settings import AdapterSettings
+from .status_messages import sanitize_consumer_message, sanitize_status_update
 
 # Legacy API is available but deprecated
 # from evalhub.adapter.legacy import ...
@@ -120,6 +121,9 @@ __all__ = [
     "OCIArtifactPersister",
     # Callback implementation
     "DefaultCallbacks",
+    # Status message sanitization
+    "sanitize_consumer_message",
+    "sanitize_status_update",
     # Configuration utilities
     "get_job_spec_path",
     "AdapterSettings",

--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -23,6 +23,7 @@ from .models import (
 )
 from .oci import DEFAULT_OCI_PROXY_HOST, OCIArtifactPersister
 from .oci.persister import OCIArtifactContext
+from .status_messages import sanitize_status_update
 
 _MLFLOW_SAVE_FAILED = MessageInfo(
     message="Failed to save evaluation results to MLflow.",
@@ -575,9 +576,15 @@ class DefaultCallbacks(JobCallbacks):
     def report_status(self, update: JobStatusUpdate) -> None:
         """Report status update to evalhub or log it.
 
+        Error and warning messages are sanitized before they are sent to the
+        sidecar so consumer-facing payloads do not include URLs or hostnames.
+        The full original message is logged before any shortening.
+
         Args:
             update: Status update to report
         """
+        update = sanitize_status_update(update)
+
         # If evalhub available, send status update
         if self.sidecar_url and self._httpx_available and self._http_client:
             try:

--- a/src/evalhub/adapter/status_messages.py
+++ b/src/evalhub/adapter/status_messages.py
@@ -10,24 +10,24 @@ from __future__ import annotations
 
 import logging
 import re
+from typing import TypeVar
 from urllib.parse import urlparse
 
-from .models.job import JobStatusUpdate, MessageInfo
+from .models.job import ErrorInfo, JobStatusUpdate, MessageInfo
+
+_TMessage = TypeVar("_TMessage", MessageInfo, ErrorInfo)
 
 logger = logging.getLogger(__name__)
 
 # Matches adapter errors like:
 # "Model endpoint returned HTTP 404: 404 Client Error: Not Found for url: http://..."
 # Capture group 1 is the consumer-safe prefix (through the HTTP status code).
-_ENDPOINT_HTTP_DETAIL = re.compile(
-    r"(?i)^(.+\bendpoint returned HTTP \d+)\s*:\s*\S"
-)
+_ENDPOINT_HTTP_DETAIL = re.compile(r"(?i)^(.+\bendpoint returned HTTP \d+)\s*:\s*\S")
 
 # Absolute URLs — replaced with path (+ query/fragment) so the message stays useful.
 # Optional leading preposition is dropped when the URL has no useful path.
 _PREP_URL = re.compile(
-    r"(?i)(?:(?P<prep>\s+(?:at|from|to|on|via))\s+)?"
-    r"(?P<url>https?://[^\s\"'<>]+)"
+    r"(?i)(?:(?P<prep>\s+(?:at|from|to|on|via))\s+)?" r"(?P<url>https?://[^\s\"'<>]+)"
 )
 
 # Bare hostnames that commonly leak from sidecar / in-cluster errors (no scheme).
@@ -47,6 +47,10 @@ _TRAILING_PREP = re.compile(r"(?i)\s+\b(?:at|from|to|on|via)\b\s*$")
 
 _MULTI_SPACE = re.compile(r"[ \t]{2,}")
 _SPACE_BEFORE_PUNCT = re.compile(r"\s+([,.;:])")
+
+# When URL/hostname stripping leaves nothing useful, return this instead of
+# the original message (which would re-leak the sensitive detail).
+_EMPTY_SANITIZED_FALLBACK = "An error occurred"
 
 
 def _url_path(url: str) -> str:
@@ -94,7 +98,8 @@ def sanitize_consumer_message(message: str) -> str:
 
     The full original message is logged at INFO before any shortening.
     Messages that do not contain URL/hostname detail are returned unchanged
-    (and are not logged by this helper).
+    (and are not logged by this helper). When stripping removes the entire
+    message, a safe non-empty fallback is returned instead of the original.
     """
     if not message:
         return message
@@ -117,18 +122,18 @@ def sanitize_consumer_message(message: str) -> str:
     cleaned = _SPACE_BEFORE_PUNCT.sub(r"\1", cleaned)
     cleaned = cleaned.strip(" \t,;:")
 
-    if cleaned and cleaned != message:
+    if cleaned != message:
         logger.info(
             "Sanitized status message for consumer "
             "(full message logged before shortening): %s",
             message,
         )
-        return cleaned
+        return cleaned or _EMPTY_SANITIZED_FALLBACK
 
     return message
 
 
-def _sanitize_message_info(info: MessageInfo | None) -> MessageInfo | None:
+def _sanitize_message_info(info: _TMessage | None) -> _TMessage | None:
     if info is None:
         return None
     sanitized = sanitize_consumer_message(info.message)
@@ -139,17 +144,20 @@ def _sanitize_message_info(info: MessageInfo | None) -> MessageInfo | None:
 
 def sanitize_status_update(update: JobStatusUpdate) -> JobStatusUpdate:
     """Return a copy of ``update`` with consumer-safe error/warning messages."""
+    error = _sanitize_message_info(update.error)
     error_message = _sanitize_message_info(update.error_message)
     warning_message = _sanitize_message_info(update.warning_message)
 
     if (
-        error_message is update.error_message
+        error is update.error
+        and error_message is update.error_message
         and warning_message is update.warning_message
     ):
         return update
 
     return update.model_copy(
         update={
+            "error": error,
             "error_message": error_message,
             "warning_message": warning_message,
         }

--- a/src/evalhub/adapter/status_messages.py
+++ b/src/evalhub/adapter/status_messages.py
@@ -1,0 +1,156 @@
+"""Sanitize consumer-facing status error/warning messages.
+
+Adapters often surface raw exceptions from model endpoints, MLflow, OCI, or
+eval-hub itself. Those strings can include URLs or hostnames that should not be
+persisted or shown to API consumers. This module shortens such messages while
+leaving enough context to be useful (for example HTTP status codes).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from urllib.parse import urlparse
+
+from .models.job import JobStatusUpdate, MessageInfo
+
+logger = logging.getLogger(__name__)
+
+# Matches adapter errors like:
+# "Model endpoint returned HTTP 404: 404 Client Error: Not Found for url: http://..."
+# Capture group 1 is the consumer-safe prefix (through the HTTP status code).
+_ENDPOINT_HTTP_DETAIL = re.compile(
+    r"(?i)^(.+\bendpoint returned HTTP \d+)\s*:\s*\S"
+)
+
+# Absolute URLs — replaced with path (+ query/fragment) so the message stays useful.
+# Optional leading preposition is dropped when the URL has no useful path.
+_PREP_URL = re.compile(
+    r"(?i)(?:(?P<prep>\s+(?:at|from|to|on|via))\s+)?"
+    r"(?P<url>https?://[^\s\"'<>]+)"
+)
+
+# Bare hostnames that commonly leak from sidecar / in-cluster errors (no scheme).
+# Intentionally narrow to avoid stripping filenames like ``report.json``.
+# Optional leading preposition is dropped when there is no path to keep.
+_PREP_HOSTNAME = re.compile(
+    r"(?i)(?:(?P<prep>\s+(?:at|from|to|on|via))\s+)?"
+    r"\b(?:"
+    r"localhost(?::\d+)?"
+    r"|127\.0\.0\.1(?::\d+)?"
+    r"|(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+svc\.cluster\.local(?::\d+)?"
+    r")(?P<path>/[^\s\"'<>]*)?"
+)
+
+# Safety net for a dangling preposition left at the end of the message.
+_TRAILING_PREP = re.compile(r"(?i)\s+\b(?:at|from|to|on|via)\b\s*$")
+
+_MULTI_SPACE = re.compile(r"[ \t]{2,}")
+_SPACE_BEFORE_PUNCT = re.compile(r"\s+([,.;:])")
+
+
+def _url_path(url: str) -> str:
+    """Return path (+ query/fragment) for ``url``, or ``\"\"`` if none is useful."""
+    parsed = urlparse(url)
+    path = parsed.path or ""
+    if path in ("", "/") and not parsed.query and not parsed.fragment:
+        return ""
+    if not path.startswith("/"):
+        path = f"/{path}"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    if parsed.fragment:
+        path = f"{path}#{parsed.fragment}"
+    return path
+
+
+def _prep_url_to_path(match: re.Match[str]) -> str:
+    """Replace an absolute URL with its path; drop a leading prep if nothing remains."""
+    path = _url_path(match.group("url"))
+    if not path:
+        return ""
+    prep = match.group("prep") or ""
+    return f"{prep} {path}" if prep else path
+
+
+def _prep_hostname_to_path(match: re.Match[str]) -> str:
+    """Drop a bare hostname, keeping path and a leading prep only when a path remains."""
+    path = match.group("path") or ""
+    if not path:
+        return ""
+    prep = match.group("prep") or ""
+    return f"{prep} {path}" if prep else path
+
+
+def sanitize_consumer_message(message: str) -> str:
+    """Return a consumer-safe message with URLs/hostnames removed when present.
+
+    Prefer truncating well-known ``endpoint returned HTTP <code>: <detail>``
+    errors to the status-code prefix (same behavior as eval-hub persistence).
+    Otherwise replace absolute URLs with their path (e.g.
+    ``https://host/api/v1/jobs`` → ``/api/v1/jobs``), strip bare hostnames while
+    keeping any path, and drop dangling prepositions like ``at`` /
+    ``from`` when the host/URL is removed entirely.
+
+    The full original message is logged at INFO before any shortening.
+    Messages that do not contain URL/hostname detail are returned unchanged
+    (and are not logged by this helper).
+    """
+    if not message:
+        return message
+
+    match = _ENDPOINT_HTTP_DETAIL.match(message)
+    if match:
+        shortened = match.group(1).strip()
+        if shortened != message:
+            logger.info(
+                "Sanitized status message for consumer "
+                "(full message logged before shortening): %s",
+                message,
+            )
+        return shortened
+
+    cleaned = _PREP_URL.sub(_prep_url_to_path, message)
+    cleaned = _PREP_HOSTNAME.sub(_prep_hostname_to_path, cleaned)
+    cleaned = _TRAILING_PREP.sub("", cleaned)
+    cleaned = _MULTI_SPACE.sub(" ", cleaned)
+    cleaned = _SPACE_BEFORE_PUNCT.sub(r"\1", cleaned)
+    cleaned = cleaned.strip(" \t,;:")
+
+    if cleaned and cleaned != message:
+        logger.info(
+            "Sanitized status message for consumer "
+            "(full message logged before shortening): %s",
+            message,
+        )
+        return cleaned
+
+    return message
+
+
+def _sanitize_message_info(info: MessageInfo | None) -> MessageInfo | None:
+    if info is None:
+        return None
+    sanitized = sanitize_consumer_message(info.message)
+    if sanitized == info.message:
+        return info
+    return info.model_copy(update={"message": sanitized})
+
+
+def sanitize_status_update(update: JobStatusUpdate) -> JobStatusUpdate:
+    """Return a copy of ``update`` with consumer-safe error/warning messages."""
+    error_message = _sanitize_message_info(update.error_message)
+    warning_message = _sanitize_message_info(update.warning_message)
+
+    if (
+        error_message is update.error_message
+        and warning_message is update.warning_message
+    ):
+        return update
+
+    return update.model_copy(
+        update={
+            "error_message": error_message,
+            "warning_message": warning_message,
+        }
+    )

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -266,6 +266,52 @@ def test_report_status_sends_error_message() -> None:
     assert event["error_message"] == {"message": "boom", "message_code": "kaboom"}
 
 
+def test_report_status_sanitizes_error_message_urls() -> None:
+    from evalhub.adapter.models.job import JobStatusUpdate, MessageInfo
+    from evalhub.models.api import JobStatus
+
+    callbacks, mock_http = _make_callbacks()
+    full = (
+        "Model endpoint returned HTTP 404: 404 Client Error: Not Found for url: "
+        "http://localhost:8080/v1/completions"
+    )
+    callbacks.report_status(
+        JobStatusUpdate(
+            status=JobStatus.FAILED,
+            error_message=MessageInfo(
+                message=full,
+                message_code="evaluation_error",
+            ),
+        )
+    )
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert event["error_message"]["message"] == "Model endpoint returned HTTP 404"
+    assert "localhost" not in event["error_message"]["message"]
+
+
+def test_report_status_sanitizes_warning_message_urls() -> None:
+    from evalhub.adapter.models.job import JobStatusUpdate, MessageInfo
+    from evalhub.models.api import JobStatus
+
+    callbacks, mock_http = _make_callbacks()
+    callbacks.report_status(
+        JobStatusUpdate(
+            status=JobStatus.RUNNING,
+            warning_message=MessageInfo(
+                message="Artifact upload warning for url: https://quay.io/v2/",
+                message_code="oci_warning",
+            ),
+        )
+    )
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert event["warning_message"]["message"] == "Artifact upload warning for url: /v2/"
+    assert "quay.io" not in event["warning_message"]["message"]
+
+
 def test_report_status_sends_warning_message() -> None:
     from evalhub.adapter.models.job import JobStatusUpdate, MessageInfo
     from evalhub.models.api import JobStatus

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -308,7 +308,9 @@ def test_report_status_sanitizes_warning_message_urls() -> None:
 
     body = mock_http.post.call_args.kwargs["json"]
     event = body["benchmark_status_event"]
-    assert event["warning_message"]["message"] == "Artifact upload warning for url: /v2/"
+    assert (
+        event["warning_message"]["message"] == "Artifact upload warning for url: /v2/"
+    )
     assert "quay.io" not in event["warning_message"]["message"]
 
 

--- a/tests/unit/test_status_messages.py
+++ b/tests/unit/test_status_messages.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 
 import pytest
-from evalhub.adapter.models.job import JobStatusUpdate, MessageInfo
+from evalhub.adapter.models.job import ErrorInfo, JobStatusUpdate, MessageInfo
 from evalhub.adapter.status_messages import (
     sanitize_consumer_message,
     sanitize_status_update,
@@ -68,6 +68,9 @@ from evalhub.models.api import JobStatus
             "Failed writing report.json to results dir",
             "Failed writing report.json to results dir",
         ),
+        ("http://localhost:8080", "An error occurred"),
+        ("localhost:8080", "An error occurred"),
+        ("https://example.com/", "An error occurred"),
     ],
 )
 def test_sanitize_consumer_message(message: str, want: str) -> None:
@@ -95,6 +98,17 @@ def test_sanitize_consumer_message_does_not_log_when_unchanged(
         assert sanitize_consumer_message(message) == message
 
     assert "Sanitized status message" not in caplog.text
+
+
+def test_sanitize_consumer_message_logs_when_fallback_used(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    full = "http://localhost:8080"
+    with caplog.at_level(logging.INFO, logger="evalhub.adapter.status_messages"):
+        assert sanitize_consumer_message(full) == "An error occurred"
+
+    assert full in caplog.text
+    assert "Sanitized status message" in caplog.text
 
 
 def test_sanitize_status_update_sanitizes_error_and_warning() -> None:
@@ -135,3 +149,39 @@ def test_sanitize_status_update_noop_when_clean() -> None:
     )
 
     assert sanitize_status_update(update) is update
+
+
+def test_sanitize_status_update_sanitizes_deprecated_error() -> None:
+    with pytest.warns(DeprecationWarning):
+        update = JobStatusUpdate(
+            status=JobStatus.FAILED,
+            error=ErrorInfo(
+                message=(
+                    "Model endpoint returned HTTP 404: 404 Client Error: Not Found "
+                    "for url: http://localhost:8080/v1/completions"
+                ),
+                message_code="evaluation_error",
+            ),
+        )
+        sanitized = sanitize_status_update(update)
+
+    assert sanitized is not update
+    assert sanitized.error is not None
+    assert sanitized.error.message == "Model endpoint returned HTTP 404"
+    assert sanitized.error.message_code == "evaluation_error"
+    assert sanitized.resolved_error is sanitized.error
+    assert update.error is not None
+    assert "localhost:8080" in update.error.message
+
+
+def test_sanitize_status_update_preserves_clean_deprecated_error() -> None:
+    with pytest.warns(DeprecationWarning):
+        update = JobStatusUpdate(
+            status=JobStatus.FAILED,
+            error=ErrorInfo(
+                message="evaluation failed",
+                message_code="evaluation_error",
+            ),
+        )
+        assert sanitize_status_update(update) is update
+        assert update.resolved_error is update.error

--- a/tests/unit/test_status_messages.py
+++ b/tests/unit/test_status_messages.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 
 import pytest
-
 from evalhub.adapter.models.job import JobStatusUpdate, MessageInfo
 from evalhub.adapter.status_messages import (
     sanitize_consumer_message,

--- a/tests/unit/test_status_messages.py
+++ b/tests/unit/test_status_messages.py
@@ -1,0 +1,138 @@
+"""Tests for consumer-facing status message sanitization."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from evalhub.adapter.models.job import JobStatusUpdate, MessageInfo
+from evalhub.adapter.status_messages import (
+    sanitize_consumer_message,
+    sanitize_status_update,
+)
+from evalhub.models.api import JobStatus
+
+
+@pytest.mark.parametrize(
+    ("message", "want"),
+    [
+        (
+            "Model endpoint returned HTTP 404: 404 Client Error: Not Found for url: "
+            "http://localhost:8080/v1/completions",
+            "Model endpoint returned HTTP 404",
+        ),
+        (
+            "MLflow endpoint returned HTTP 502: 502 Server Error: Bad Gateway for url: "
+            "http://localhost:8080/api/2.0/mlflow/runs/create",
+            "MLflow endpoint returned HTTP 502",
+        ),
+        (
+            "OCI endpoint returned HTTP 401: unauthorized for url: "
+            "https://quay.io/v2/evalhub/results/blobs/upload/",
+            "OCI endpoint returned HTTP 401",
+        ),
+        (
+            "Model endpoint returned HTTP 404",
+            "Model endpoint returned HTTP 404",
+        ),
+        (
+            "Connection failed: timeout talking to sidecar",
+            "Connection failed: timeout talking to sidecar",
+        ),
+        ("", ""),
+        (
+            "Upload failed for url: http://registry.svc.cluster.local:5000/v2/",
+            "Upload failed for url: /v2/",
+        ),
+        (
+            "Could not reach https://evalhub.example.com/api/v1/jobs",
+            "Could not reach /api/v1/jobs",
+        ),
+        (
+            "Could not reach https://evalhub.example.com/api/v1/jobs?limit=10",
+            "Could not reach /api/v1/jobs?limit=10",
+        ),
+        (
+            "Sidecar unavailable at localhost:8080",
+            "Sidecar unavailable",
+        ),
+        (
+            "Sidecar unavailable at https://localhost:8080",
+            "Sidecar unavailable",
+        ),
+        (
+            "Request failed at localhost:8080/v1/completions",
+            "Request failed at /v1/completions",
+        ),
+        (
+            "Failed writing report.json to results dir",
+            "Failed writing report.json to results dir",
+        ),
+    ],
+)
+def test_sanitize_consumer_message(message: str, want: str) -> None:
+    assert sanitize_consumer_message(message) == want
+
+
+def test_sanitize_consumer_message_logs_full_message_before_shortening(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    full = (
+        "Model endpoint returned HTTP 500: upstream boom for url: "
+        "http://localhost:8080/v1/completions"
+    )
+    with caplog.at_level(logging.INFO, logger="evalhub.adapter.status_messages"):
+        assert sanitize_consumer_message(full) == "Model endpoint returned HTTP 500"
+
+    assert full in caplog.text
+
+
+def test_sanitize_consumer_message_does_not_log_when_unchanged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    message = "Model endpoint returned HTTP 404"
+    with caplog.at_level(logging.INFO, logger="evalhub.adapter.status_messages"):
+        assert sanitize_consumer_message(message) == message
+
+    assert "Sanitized status message" not in caplog.text
+
+
+def test_sanitize_status_update_sanitizes_error_and_warning() -> None:
+    update = JobStatusUpdate(
+        status=JobStatus.FAILED,
+        error_message=MessageInfo(
+            message=(
+                "Model endpoint returned HTTP 404: 404 Client Error: Not Found "
+                "for url: http://localhost:8080/v1/completions"
+            ),
+            message_code="evaluation_error",
+        ),
+        warning_message=MessageInfo(
+            message="Slow response from https://judge.example.com/v1",
+            message_code="slow_response",
+        ),
+    )
+
+    sanitized = sanitize_status_update(update)
+
+    assert sanitized is not update
+    assert sanitized.error_message is not None
+    assert sanitized.error_message.message == "Model endpoint returned HTTP 404"
+    assert sanitized.error_message.message_code == "evaluation_error"
+    assert sanitized.warning_message is not None
+    assert sanitized.warning_message.message == "Slow response from /v1"
+    assert update.error_message is not None
+    assert "localhost:8080" in update.error_message.message
+
+
+def test_sanitize_status_update_noop_when_clean() -> None:
+    update = JobStatusUpdate(
+        status=JobStatus.FAILED,
+        error_message=MessageInfo(
+            message="evaluation failed",
+            message_code="evaluation_error",
+        ),
+    )
+
+    assert sanitize_status_update(update) is update


### PR DESCRIPTION
## What and why

Adapter goes through the sidecar proxy (running on localhost:8080 on another container on the same pod) to reach the model, MLFLow, OCI and evalhub service. When it receives an error from any of these services, it includes a localhost URL in the error message sent back to evalhub. This PR handles some of these error messages and trims them to exclude hostnames.

Closes:
https://redhat.atlassian.net/browse/RHOAIENG-76561
https://redhat.atlassian.net/browse/RHOAIENG-76229

## Type

- [ ] feat
- [X] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [X] Tests added or updated
- [ ] Tested manually

## Breaking changes

NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added status-message sanitization helpers to the adapter SDK.
  - Error and warning messages now remove or shorten URLs and hostnames before status updates are sent.
  - Relevant HTTP status and failure details are preserved while unnecessary connection details are removed.

- **Bug Fixes**
  - Prevented consumer-facing status updates from exposing full endpoint or host information.

- **Tests**
  - Added coverage for message sanitization, logging behavior, and callback status payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->