### PR TITLE
feat(cli): display server version and commit in server status

### DIFF
--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import ssl
 import time
 import urllib.request
 from pathlib import Path
+from typing import Any
 
 import click
 import yaml
@@ -48,7 +50,8 @@ def _read_server_config(config_dir: Path) -> tuple[int, bool]:
         ) from exc
 
 
-def _health_check(port: int, *, tls: bool = False) -> bool:
+def _fetch_health_info(port: int, *, tls: bool = False) -> dict[str, Any] | None:
+    """Fetch the full JSON response from the health endpoint."""
     scheme = "https" if tls else "http"
     url = f"{scheme}://localhost:{port}/api/v1/health"
     req = urllib.request.Request(url, method="GET")
@@ -59,9 +62,15 @@ def _health_check(port: int, *, tls: bool = False) -> bool:
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
         with urllib.request.urlopen(req, timeout=2, context=ctx) as resp:
-            return bool(resp.status == 200)
+            if resp.status == 200:
+                return json.loads(resp.read().decode())  # type: ignore[no-any-return]
     except Exception:
-        return False
+        pass
+    return None
+
+
+def _health_check(port: int, *, tls: bool = False) -> bool:
+    return _fetch_health_info(port, tls=tls) is not None
 
 
 def _wait_for_healthy(port: int, timeout: float, *, tls: bool = False) -> bool:
@@ -192,9 +201,9 @@ def server_status(ctx: click.Context) -> None:
     scheme = "https" if tls else "http"
 
     pid = live_pid(PID_FILE)
-    healthy = _health_check(port, tls=tls)
+    info = _fetch_health_info(port, tls=tls)
 
-    if not healthy and pid is None:
+    if not info and pid is None:
         click.echo("Server is not running.")
         return
 
@@ -203,7 +212,12 @@ def server_status(ctx: click.Context) -> None:
     else:
         click.echo("Server is running.")
 
-    click.echo(f"  Health: {'healthy' if healthy else 'not responding'}")
+    click.echo(f"  Health: {'healthy' if info else 'not responding'}")
+    if info:
+        if info.get("build"):
+            click.echo(f"  Version: {info['build']}")
+        if info.get("git_hash"):
+            click.echo(f"  Commit:  {info['git_hash']}")
     click.echo(f"  URL:    {scheme}://localhost:{port}")
     if pid is not None:
         click.echo(f"  Logs:   {LOG_FILE}")

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -63,7 +63,10 @@ def _fetch_health_info(port: int, *, tls: bool = False) -> dict[str, Any] | None
             ctx.verify_mode = ssl.CERT_NONE
         with urllib.request.urlopen(req, timeout=2, context=ctx) as resp:
             if resp.status == 200:
-                return json.loads(resp.read().decode())  # type: ignore[no-any-return]
+                data = json.loads(resp.read().decode())
+                if isinstance(data, dict):
+                    return data
+
     except Exception:
         pass
     return None

--- a/tests/unit/test_cli_server.py
+++ b/tests/unit/test_cli_server.py
@@ -459,7 +459,7 @@ def test_server_status_not_running(
 
     with patch("evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"), patch(
         "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
-    ), patch("evalhub.cli.server_cmd._health_check", return_value=False):
+    ), patch("evalhub.cli.server_cmd._fetch_health_info", return_value=None):
         result = runner.invoke(main, ["server", "status"])
 
     assert result.exit_code == 0, result.output
@@ -476,17 +476,21 @@ def test_server_status_running_healthy(
     pid_file.write_text("12345")
     _setup_server_config(tmp_path, config_file)
 
+    health_info = {"status": "healthy", "build": "0.4.4", "git_hash": "f758919"}
+
     with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
         "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
     ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
         "evalhub.cli._process.is_process_alive", return_value=True
-    ), patch("evalhub.cli.server_cmd._health_check", return_value=True):
+    ), patch("evalhub.cli.server_cmd._fetch_health_info", return_value=health_info):
         result = runner.invoke(main, ["server", "status"])
 
     assert result.exit_code == 0, result.output
     assert "running" in result.output
     assert "12345" in result.output
     assert "healthy" in result.output
+    assert "Version: 0.4.4" in result.output
+    assert "Commit:  f758919" in result.output
     assert "http://localhost:8080" in result.output
     assert "Logs:" in result.output
 
@@ -500,14 +504,18 @@ def test_server_status_healthy_no_pid(
     _seed_profile(config_file)
     _setup_server_config(tmp_path, config_file)
 
+    health_info = {"status": "healthy", "build": "1.0.0"}
+
     with patch("evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"), patch(
         "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
-    ), patch("evalhub.cli.server_cmd._health_check", return_value=True):
+    ), patch("evalhub.cli.server_cmd._fetch_health_info", return_value=health_info):
         result = runner.invoke(main, ["server", "status"])
 
     assert result.exit_code == 0, result.output
     assert "running" in result.output
     assert "healthy" in result.output
+    assert "Version: 1.0.0" in result.output
+    assert "Commit:" not in result.output
     assert "http://localhost:8080" in result.output
     assert "PID" not in result.output
     assert "Logs:" not in result.output
@@ -523,17 +531,21 @@ def test_server_status_tls_uses_https_scheme(
     pid_file.write_text("12345")
     _setup_server_config(tmp_path, config_file, tls=True)
 
+    health_info = {"status": "healthy"}
+
     with patch("evalhub.cli.server_cmd.PID_FILE", pid_file), patch(
         "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
     ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
         "evalhub.cli._process.is_process_alive", return_value=True
-    ), patch("evalhub.cli.server_cmd._health_check", return_value=True) as mock_hc:
+    ), patch(
+        "evalhub.cli.server_cmd._fetch_health_info", return_value=health_info
+    ) as mock_fhi:
         result = runner.invoke(main, ["server", "status"])
 
     assert result.exit_code == 0, result.output
     assert "https://localhost:8080" in result.output
     assert "http://localhost:8080" not in result.output
-    mock_hc.assert_called_once_with(8080, tls=True)
+    mock_fhi.assert_called_once_with(8080, tls=True)
 
 
 def test_server_status_running_unhealthy(
@@ -550,12 +562,14 @@ def test_server_status_running_unhealthy(
         "evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path
     ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"), patch(
         "evalhub.cli._process.is_process_alive", return_value=True
-    ), patch("evalhub.cli.server_cmd._health_check", return_value=False):
+    ), patch("evalhub.cli.server_cmd._fetch_health_info", return_value=None):
         result = runner.invoke(main, ["server", "status"])
 
     assert result.exit_code == 0, result.output
     assert "running" in result.output
     assert "not responding" in result.output
+    assert "Version:" not in result.output
+    assert "Commit:" not in result.output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION


## What and why
Parse the JSON response from the /api/v1/health endpoint to extract build version and git hash, and display them in `evalhub server status` output, matching the pattern used by `evalhub mcp status`.

```
## before
╰─➤  evalhub server status
Server is running (PID 43808).
  Health: healthy
  URL:    http://localhost:8080
  Logs:   /Users/gnaulak/.config/evalhub/server/server.log

## after

╰─➤  evalhub server status
Server is running (PID 63444).
  Health: healthy
  Version: 0.4.4
  Commit:  f758919
  URL:    http://localhost:8080
  Logs:   /Users/gnaulak/.config/evalhub/server/server.log
```


Closes # NA

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes

No
<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `server status` output with health information.
  * Displays the server version and commit identifier when available.
  * Supports health status checks over TLS.

* **Bug Fixes**
  * Improved health-check handling for unavailable or unhealthy servers.
  * Shared health retrieval behavior now provides more consistent status results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->