### PR TITLE
feat(models): add additional_info field to BenchmarkResult for GET job response

### DIFF
--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -239,6 +239,11 @@ class BenchmarkResult(BaseModel):
         default=None, description="MLFlow run ID if tracking enabled"
     )
     logs_path: str | None = Field(default=None, description="Path to evaluation logs")
+    additional_info: dict[str, Any] | None = Field(
+        default=None,
+        description="Supplementary key-value pairs for evaluation "
+        "information beyond metrics (e.g. prompting strategy, dataset SHA).",
+    )
 
 
 class EvaluationJobResults(BaseModel):

--- a/tests/unit/test_models_api.py
+++ b/tests/unit/test_models_api.py
@@ -690,9 +690,7 @@ class TestBenchmarkResult:
             "generation_parameters": {"temperature": 0},
             "zero_shot": 0.8,
         }
-        result = BenchmarkResult(
-            id="mmlu", provider_id="lm_eval", additional_info=info
-        )
+        result = BenchmarkResult(id="mmlu", provider_id="lm_eval", additional_info=info)
         assert result.additional_info == info
 
     def test_additional_info_roundtrip(self) -> None:

--- a/tests/unit/test_models_api.py
+++ b/tests/unit/test_models_api.py
@@ -7,6 +7,7 @@ import pytest
 from evalhub.models.api import (
     BenchmarkConfig,
     BenchmarkInfo,
+    BenchmarkResult,
     BenchmarksList,
     CollectionList,
     CollectionRef,
@@ -15,6 +16,7 @@ from evalhub.models.api import (
     EvaluationExports,
     EvaluationExportsOCI,
     EvaluationJob,
+    EvaluationJobResults,
     EvaluationResponse,
     EvaluationResult,
     EvaluationStatus,
@@ -667,6 +669,67 @@ class TestExperimentConfig:
         assert restored.name == "roundtrip"
         assert len(restored.tags) == 2
         assert restored.tags[0].key == "k1"
+
+
+class TestBenchmarkResult:
+    """Test cases for BenchmarkResult model."""
+
+    def test_additional_info_default_none(self) -> None:
+        result = BenchmarkResult(id="mmlu", provider_id="lm_eval")
+        assert result.additional_info is None
+
+    def test_additional_info_with_nested_values(self) -> None:
+        info: dict[str, Any] = {
+            "dataset": [
+                {
+                    "hf_repo": "openai/gsm8k",
+                    "hf_subset": "main",
+                    "sha": "740312add88f",
+                }
+            ],
+            "generation_parameters": {"temperature": 0},
+            "zero_shot": 0.8,
+        }
+        result = BenchmarkResult(
+            id="mmlu", provider_id="lm_eval", additional_info=info
+        )
+        assert result.additional_info == info
+
+    def test_additional_info_roundtrip(self) -> None:
+        info: dict[str, Any] = {
+            "prompting_strategy": "chain-of-thought",
+            "dataset_sha": "abc123",
+        }
+        result = BenchmarkResult(
+            id="mmlu",
+            provider_id="lm_eval",
+            metrics={"accuracy": 0.85},
+            additional_info=info,
+        )
+        data = result.model_dump(mode="json")
+        assert data["additional_info"] == info
+        restored = BenchmarkResult.model_validate(data)
+        assert restored.additional_info == info
+
+    def test_additional_info_excluded_when_none(self) -> None:
+        result = BenchmarkResult(id="mmlu", provider_id="lm_eval")
+        data = result.model_dump(mode="json", exclude_none=True)
+        assert "additional_info" not in data
+
+    def test_additional_info_in_job_results(self) -> None:
+        info: dict[str, Any] = {"zero_shot": 0.8}
+        results = EvaluationJobResults(
+            benchmarks=[
+                BenchmarkResult(
+                    id="mmlu",
+                    provider_id="lm_eval",
+                    metrics={"accuracy": 0.85},
+                    additional_info=info,
+                ),
+            ],
+        )
+        data = results.model_dump(mode="json")
+        assert data["benchmarks"][0]["additional_info"] == info
 
 
 class TestEvaluationResult:


### PR DESCRIPTION


## What and why

Support supplementary key-value metadata (e.g. prompting strategy, dataset SHA, generation parameters) returned by the server in job results, surfaced via `evalhub eval status <job-id> --format json/yaml`.

Closes # https://redhat.atlassian.net/browse/RHOAIENG-72755

example:
╰─➤  evalhub eval status 24d49fa3-c9f4-47e6-8ed3-aa8026796255 --format=json

sample output
```json
[
  {
    "resource": {
      "id": "24d49fa3-c9f4-47e6-8ed3-aa8026796255",
      "tenant": null,
      "created_at": "2026-07-21T10:21:53Z",
      "updated_at": "2026-07-21T10:22:13Z",
      "mlflow_experiment_id": null,
      "message": null
    },
    "status": {
      "state": "completed",
      "message": {
        "message": "Evaluation job is completed",
        "message_code": "evaluation_job_updated"
      },
      "benchmarks": [
        {
          "id": "math",
          "provider_id": "9b5c7c98-75f5-4453-9e8b-96ed65864d65",
          "benchmark_index": 0,
          "status": "completed",
          "phase": null,
          "error_message": null,
          "started_at": null,
          "completed_at": "2026-07-21T10:22:13.445204Z"
        }
      ]
    },
    "results": {
      "benchmarks": [
        {
          "id": "math",
          "provider_id": "9b5c7c98-75f5-4453-9e8b-96ed65864d65",
          "benchmark_index": 0,
          "metrics": {
            "all.extractive_match": 0,
            "all.maj@n:n=4&strip_strings=True&normalize_pred=<function math_normalizer at 0x135897420>&normalize_gold=<function math_normalizer at 0x135897420>": 0,
            "gsm8k.extractive_match": 0,
            "math:_average.maj@n:n=4&strip_strings=True&normalize_pred=<function math_normalizer at 0x135897420>&normalize_gold=<function math_normalizer at 0x135897420>": 0,
            "math:algebra.maj@n:n=4&strip_strings=True&normalize_pred=<function math_normalizer at 0x135897420>&normalize_gold=<function math_normalizer at 0x135897420>": 0,
            "math:counting_and_probability.maj@n:n=4&strip_strings=True&normalize_pred=<function math_normalizer at 0x135897420>&normalize_gold=<function math_normalizer at 0x135897420>": 0
          },
          "artifacts": {
            "evalhub.env_card": {
              "aggregate_results": {},
              "autograder_bias": {},
              "capture_completeness": 0.15,
              "confidence_intervals": {},
              "cpu_model": "arm",
              "custom": {},
              "k8s_pod_labels": {},
              "k8s_resource_limits": {},
              "key_packages": {
                "mlflow": "3.14.0",
                "torch": "2.13.0",
                "transformers": "5.13.1"
              },
              "os_info": "macOS-26.5.2-arm64-arm-64bit",
              "per_task_results": {},
              "python_version": "3.12.12",
              "scorer_ids": []
            }
          },
          "mlflow_run_id": null,
          "logs_path": null,
          "additional_info": {
            "alt_prompting": 0,
            "alt_prompting_description": "3-Shot",
            "dataset": [
              {
                "hf_repo": "DigitalLearningGmbH/MATH-lighteval",
                "hf_subset": "counting_and_probability",
                "sha": "0530c78699ea5e8eb5530600900e1f328b48acad"
              },
              {
                "hf_repo": "DigitalLearningGmbH/MATH-lighteval",
                "hf_subset": "algebra",
                "sha": "0530c78699ea5e8eb5530600900e1f328b48acad"
              },
              {
                "hf_repo": "openai/gsm8k",
                "hf_subset": "main",
                "sha": "740312add88f781978c0658806c59bc2815b9866"
              }
            ],
            "generation_parameters": {
              "max_new_tokens": 512,
              "stop_tokens": [
                "\n",
                "###"
              ],
              "temperature": 0.1
            }
          }
        }
      ],
      "mlflow_experiment_url": null
    },
    "name": "math-job",
    "description": null,
    "tags": [],
    "model": {
      "url": "http://localhost:11434/v1",
      "name": "llama3.2:3b-instruct-q4_K_M",
      "auth": null
    },
    "benchmarks": [
      {
        "id": "math",
        "provider_id": "9b5c7c98-75f5-4453-9e8b-96ed65864d65",
        "parameters": {
          "num_examples": 5,
          "num_few_shot": 3,
          "parameters": {
            "concurrent_requests": 7,
            "generation_parameters": {
              "max_new_tokens": 512,
              "stop_tokens": [
                "\n",
                "###"
              ],
              "temperature": 0.1
            },
            "system_prompt": "You are a helpful math tutor."
          }
        },
        "test_data_ref": null
      }
    ],
    "collection": null,
    "experiment": null,
    "exports": null,
    "queue": null
  }
]
```

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [x] Tested manually

## Breaking changes
No
<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional supplementary metadata to evaluation job results to store extra evaluation context (for example, prompting strategy and dataset identifiers).
  - Preserves nested structured values and carries the metadata through when included within larger evaluation responses.
  - When no supplementary metadata is provided, the field is omitted from serialized output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->