### PR TITLE
feat: populate message_origin

### DIFF
--- a/src/evalhub/adapter/__init__.py
+++ b/src/evalhub/adapter/__init__.py
@@ -88,6 +88,7 @@ from .models import (
     JobSpec,
     JobStatusUpdate,
     MessageInfo,
+    MessageOrigin,
     OCIArtifactResult,
     OCIArtifactSpec,
     SafetyEvalEntry,
@@ -114,6 +115,7 @@ __all__ = [
     "JobPhase",
     "ErrorInfo",
     "MessageInfo",
+    "MessageOrigin",
     # OCI models
     "OCIArtifactSpec",
     "OCIArtifactResult",

--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -9,11 +9,12 @@ from typing import Any
 
 from evalhub.adapter.models.adapter import FrameworkAdapter
 
-from ..models.api import JobStatus
+from ..models.api import JobStatus, MessageOrigin
 from .config import EvalHubMode, MlflowBackend
 from .mlflow import MlflowArtifact
 from .models import (
     EnvironmentCardMetadata,
+    ErrorInfo,
     JobCallbacks,
     JobResults,
     JobSpec,
@@ -28,6 +29,7 @@ from .oci.persister import OCIArtifactContext
 _MLFLOW_SAVE_FAILED = MessageInfo(
     message="Failed to save evaluation results to MLflow.",
     message_code="mlflow_save_failed",
+    message_origin=MessageOrigin.SDK,
 )
 
 logger = logging.getLogger(__name__)
@@ -582,8 +584,29 @@ class DefaultCallbacks(JobCallbacks):
             "status": status,
         }
 
+    @staticmethod
+    def _message_payload(
+        msg: MessageInfo | ErrorInfo,
+        *,
+        default_origin: MessageOrigin = MessageOrigin.ADAPTER,
+    ) -> dict[str, Any]:
+        """Serialize a message for /events, stamping message_origin when unset.
+
+        Adapter-driven ``report_status`` / ``report_results`` calls default to
+        ``adapter``. SDK-generated errors (e.g. MLflow save failure) should set
+        ``message_origin=sdk`` on the MessageInfo before calling report_status.
+        """
+        data = msg.model_dump(mode="json")
+        if not data.get("message_origin"):
+            data["message_origin"] = default_origin.value
+        return data
+
     def report_status(self, update: JobStatusUpdate) -> None:
         """Report status update to evalhub or log it.
+
+        Message fields (``error_message``, ``warning_message``) are stamped with
+        ``message_origin=adapter`` when unset. SDK-generated errors should set
+        ``message_origin=sdk`` explicitly before calling this method.
 
         Args:
             update: Status update to report
@@ -599,13 +622,13 @@ class DefaultCallbacks(JobCallbacks):
                     status_event["phase"] = update.phase.value
 
                 if update.resolved_error:
-                    status_event["error_message"] = update.resolved_error.model_dump(
-                        mode="json"
+                    status_event["error_message"] = self._message_payload(
+                        update.resolved_error
                     )
 
                 if update.warning_message:
-                    status_event["warning_message"] = update.warning_message.model_dump(
-                        mode="json"
+                    status_event["warning_message"] = self._message_payload(
+                        update.warning_message
                     )
 
                 data = {"benchmark_status_event": status_event}
@@ -671,6 +694,9 @@ class DefaultCallbacks(JobCallbacks):
         This sends the complete results including metrics to the evalhub service.
         If the provider did not supply an Environment Card, a best-effort card
         is auto-captured from the current runtime.
+
+        When message fields are present on the event payload they are stamped
+        with ``message_origin=adapter`` (same as ``report_status``).
 
         Args:
             results: Final job results to report

--- a/src/evalhub/adapter/models/__init__.py
+++ b/src/evalhub/adapter/models/__init__.py
@@ -1,5 +1,6 @@
 """Adapter models for the simplified BYOF SDK."""
 
+from ...models.api import MessageOrigin
 from .adapter import FrameworkAdapter
 from .cards import (
     CapabilityEvalEntry,
@@ -35,6 +36,7 @@ __all__ = [
     "JobPhase",
     "ErrorInfo",
     "MessageInfo",
+    "MessageOrigin",
     # OCI models
     "OCIArtifactSpec",
     "OCIArtifactResult",

--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -15,6 +15,7 @@ from ...models.api import (
     EvaluationResult,
     JobPhase,
     JobStatus,
+    MessageOrigin,
     ModelConfig,
     OCICoordinates,
 )
@@ -29,6 +30,13 @@ class MessageInfo(BaseModel):
 
     message: str = Field(..., description="Message text")
     message_code: str = Field(..., description="Message code identifier")
+    message_origin: MessageOrigin | None = Field(
+        default=None,
+        description=(
+            "Origin of the message. Set by the SDK when posting /events: "
+            "'adapter' for adapter-driven updates, 'sdk' for SDK-generated errors."
+        ),
+    )
 
 
 class ErrorInfo(BaseModel):
@@ -39,6 +47,13 @@ class ErrorInfo(BaseModel):
 
     message: str = Field(..., description="Error message")
     message_code: str = Field(..., description="Error code identifier")
+    message_origin: MessageOrigin | None = Field(
+        default=None,
+        description=(
+            "Origin of the error. Set by the SDK when posting /events: "
+            "'adapter' for adapter-driven updates, 'sdk' for SDK-generated errors."
+        ),
+    )
 
 
 class JobSpec(BaseModel):

--- a/src/evalhub/models/__init__.py
+++ b/src/evalhub/models/__init__.py
@@ -35,6 +35,8 @@ from .api import (
     JobsList,
     JobStatus,
     JobSubmissionRequest,
+    MessageInfo,
+    MessageOrigin,
     ModelAuth,
     ModelConfig,
     OCIConnectionConfig,
@@ -56,6 +58,8 @@ __all__ = [
     # Job & Evaluation models
     "JobPhase",
     "JobStatus",
+    "MessageInfo",
+    "MessageOrigin",
     "EvaluationExports",
     "EvaluationExportsOCI",
     "EvaluationStatus",

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -159,11 +159,30 @@ class EvaluationResult(BaseModel):
     )
 
 
+class MessageOrigin(str, Enum):
+    """Origin of a status, warning, or error message.
+
+    - ``adapter``: produced by adapter code via ``report_status`` /
+      ``report_results``.
+    - ``sdk``: produced by the EvalHub SDK itself (e.g. MLflow save failure).
+    - ``server`` / ``runtime``: used by the EvalHub service / job runtime.
+    """
+
+    ADAPTER = "adapter"
+    SDK = "sdk"
+    SERVER = "server"
+    RUNTIME = "runtime"
+
+
 class MessageInfo(BaseModel):
     """Message information with code."""
 
     message: str = Field(..., description="Message text")
     message_code: str = Field(..., description="Message code")
+    message_origin: MessageOrigin | None = Field(
+        default=None,
+        description="Origin of the message (adapter, sdk, server, or runtime)",
+    )
 
 
 class EvaluationJobResource(BaseModel):

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -317,7 +317,6 @@ def test_report_status_preserves_explicit_message_origin() -> None:
     assert event["error_message"]["message_origin"] == "sdk"
 
 
-
 def test_report_status_always_includes_provider_id() -> None:
     from evalhub.adapter.models.job import JobStatusUpdate
     from evalhub.models.api import JobStatus

--- a/tests/unit/test_callbacks_events.py
+++ b/tests/unit/test_callbacks_events.py
@@ -174,6 +174,7 @@ def test_mlflow_save_posts_failed_event_on_mlflow_error() -> None:
         == "Failed to save evaluation results to MLflow."
     )
     assert body["error_message"]["message_code"] == "mlflow_save_failed"
+    assert body["error_message"]["message_origin"] == "sdk"
     assert "mlflow offline" not in body["error_message"]["message"]
     assert "warning_message" not in body
 
@@ -264,7 +265,11 @@ def test_report_status_sends_error_message() -> None:
 
     body = mock_http.post.call_args.kwargs["json"]
     event = body["benchmark_status_event"]
-    assert event["error_message"] == {"message": "boom", "message_code": "kaboom"}
+    assert event["error_message"] == {
+        "message": "boom",
+        "message_code": "kaboom",
+        "message_origin": "adapter",
+    }
 
 
 def test_report_status_sends_warning_message() -> None:
@@ -287,7 +292,30 @@ def test_report_status_sends_warning_message() -> None:
     assert event["warning_message"] == {
         "message": "slow",
         "message_code": "slow_response",
+        "message_origin": "adapter",
     }
+
+
+def test_report_status_preserves_explicit_message_origin() -> None:
+    from evalhub.adapter.models.job import JobStatusUpdate, MessageInfo
+    from evalhub.models.api import JobStatus, MessageOrigin
+
+    callbacks, mock_http = _make_callbacks()
+    callbacks.report_status(
+        JobStatusUpdate(
+            status=JobStatus.FAILED,
+            error_message=MessageInfo(
+                message="sdk boom",
+                message_code="sdk_err",
+                message_origin=MessageOrigin.SDK,
+            ),
+        )
+    )
+
+    body = mock_http.post.call_args.kwargs["json"]
+    event = body["benchmark_status_event"]
+    assert event["error_message"]["message_origin"] == "sdk"
+
 
 
 def test_report_status_always_includes_provider_id() -> None:


### PR DESCRIPTION
## What and why

message_origin helps identify which component raised an error/warning.

Closes https://redhat.atlassian.net/browse/RHOAIENG-76259

## Type

- [X] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [X] Tested manually

#### Test
message_origin (at the benchmark level) is set as `adapter` when the runtime fails to access the model
<img width="846" height="769" alt="image" src="https://github.com/user-attachments/assets/e193ee6c-2962-48fb-9cff-75a3c9c1bb6d" />

<details>
<summary>GET job response showing `"message_origin": "adapter"` at the benchmark level</summary>

```
{
  "resource": {
    "id": "9fbea541-3636-48cd-a3f4-f881501d01e4",
    "tenant": "sagar",
    "created_at": "2026-07-21T18:41:10.506736Z",
    "updated_at": "2026-07-21T18:41:30.237426Z",
    "owner": "system:serviceaccount:sagar:evalhub-service"
  },
  "status": {
    "state": "failed",
    "message": {
      "message": "Evaluation job is failed. \nBenchmark arc_easy failed with message: Model endpoint returned HTTP 404: 404 Client Error: Not Found for url: https://vllm-llama-apikey-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v2/v1/completions\n",
      "message_code": "evaluation_job_updated",
      "message_origin": "server"
    },
    "benchmarks": [
      {
        "provider_id": "lm_evaluation_harness",
        "id": "arc_easy",
        "benchmark_index": 0,
        "status": "failed",
        "error_message": {
          "message": "Model endpoint returned HTTP 404: 404 Client Error: Not Found for url: https://vllm-llama-apikey-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v2/v1/completions",
          "message_code": "model_endpoint_not_found",
          "message_origin": "adapter"
        }
      }
    ]
  },
  "results": {
    "benchmarks": [
      {
        "id": "arc_easy",
        "provider_id": "lm_evaluation_harness",
        "benchmark_index": 0
      }
    ]
  },
  "name": "Eval-1",
  "model": {
    "url": "https://vllm-llama-apikey-prabhu.apps.rosa.prabhu-comhub.xqmp.p3.openshiftapps.com/v2",
    "name": "meta-llama/Llama-3.2-1B-Instruct",
    "auth": {
      "secret_ref": "vllm-llama-secret"
    }
  },
  "pass_criteria": {
    "threshold": 0.7
  },
  "benchmarks": [
    {
      "id": "arc_easy",
      "provider_id": "lm_evaluation_harness",
      "weight": 0.6,
      "primary_score": {
        "metric": "accuracy"
      },
      "pass_criteria": {
        "threshold": 0.3
      },
      "parameters": {
        "num_examples": 1,
        "tokenizer": "google/flan-t5-small"
      }
    }
  ],
  "exports": {
    "oci": {
      "coordinates": {
        "oci_host": "https://quay.io",
        "oci_repository": "rh-ee-nbs/nbs-dev"
      },
      "k8s": {
        "connection": "oci-credentials"
      }
    }
  }
}
```
</details>

## Breaking changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message-origin metadata to status, warning, and error events.
  * Messages can now identify whether they came from the adapter, SDK, server, or runtime.
  * Existing message origins are preserved when provided.

* **Bug Fixes**
  * Standardized origin labeling for SDK and adapter-generated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->