### PR TITLE
fix: comments/documentation for message origin

### DIFF
--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -593,8 +593,9 @@ class DefaultCallbacks(JobCallbacks):
         """Serialize a message for /events, stamping message_origin when unset.
 
         Adapter-driven ``report_status`` / ``report_results`` calls default to
-        ``adapter``. SDK-generated errors (e.g. MLflow save failure) should set
-        ``message_origin=sdk`` on the MessageInfo before calling report_status.
+        ``adapter``. Errors from the SDK itself (e.g. MLflow save failure)
+        should set ``message_origin=sdk`` on the MessageInfo before calling
+        report_status.
         """
         data = msg.model_dump(mode="json")
         if not data.get("message_origin"):
@@ -605,8 +606,8 @@ class DefaultCallbacks(JobCallbacks):
         """Report status update to evalhub or log it.
 
         Message fields (``error_message``, ``warning_message``) are stamped with
-        ``message_origin=adapter`` when unset. SDK-generated errors should set
-        ``message_origin=sdk`` explicitly before calling this method.
+        ``message_origin=adapter`` when unset. Errors from the SDK itself should
+        set ``message_origin=sdk`` explicitly before calling this method.
 
         Args:
             update: Status update to report

--- a/src/evalhub/adapter/callbacks.py
+++ b/src/evalhub/adapter/callbacks.py
@@ -592,10 +592,9 @@ class DefaultCallbacks(JobCallbacks):
     ) -> dict[str, Any]:
         """Serialize a message for /events, stamping message_origin when unset.
 
-        Adapter-driven ``report_status`` / ``report_results`` calls default to
-        ``adapter``. Errors from the SDK itself (e.g. MLflow save failure)
-        should set ``message_origin=sdk`` on the MessageInfo before calling
-        report_status.
+        Adapter-driven ``report_status`` calls default to ``adapter``. Errors
+        from the SDK itself (e.g. MLflow save failure) should set
+        ``message_origin=sdk`` on the MessageInfo before calling report_status.
         """
         data = msg.model_dump(mode="json")
         if not data.get("message_origin"):
@@ -695,9 +694,6 @@ class DefaultCallbacks(JobCallbacks):
         This sends the complete results including metrics to the evalhub service.
         If the provider did not supply an Environment Card, a best-effort card
         is auto-captured from the current runtime.
-
-        When message fields are present on the event payload they are stamped
-        with ``message_origin=adapter`` (same as ``report_status``).
 
         Args:
             results: Final job results to report

--- a/src/evalhub/adapter/models/job.py
+++ b/src/evalhub/adapter/models/job.py
@@ -34,7 +34,8 @@ class MessageInfo(BaseModel):
         default=None,
         description=(
             "Origin of the message. Set by the SDK when posting /events: "
-            "'adapter' for adapter-driven updates, 'sdk' for SDK-generated errors."
+            "'adapter' for a message from the adapter, 'sdk' for a message "
+            "from the SDK."
         ),
     )
 
@@ -51,7 +52,8 @@ class ErrorInfo(BaseModel):
         default=None,
         description=(
             "Origin of the error. Set by the SDK when posting /events: "
-            "'adapter' for adapter-driven updates, 'sdk' for SDK-generated errors."
+            "'adapter' for an error from the adapter, 'sdk' for an error "
+            "from the SDK."
         ),
     )
 

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -162,9 +162,10 @@ class EvaluationResult(BaseModel):
 class MessageOrigin(str, Enum):
     """Origin of a status, warning, or error message.
 
-    - ``adapter``: produced by adapter code via ``report_status`` /
-      ``report_results``.
-    - ``sdk``: produced by the EvalHub SDK itself (e.g. MLflow save failure).
+    - ``adapter``: error or message from the adapter (via ``report_status`` /
+      ``report_results``).
+    - ``sdk``: error or message from the EvalHub SDK itself (e.g. MLflow
+      save failure).
     - ``server`` / ``runtime``: used by the EvalHub service / job runtime.
     """
 

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -162,8 +162,7 @@ class EvaluationResult(BaseModel):
 class MessageOrigin(str, Enum):
     """Origin of a status, warning, or error message.
 
-    - ``adapter``: error or message from the adapter (via ``report_status`` /
-      ``report_results``).
+    - ``adapter``: error or message from the adapter (via ``report_status``).
     - ``sdk``: error or message from the EvalHub SDK itself (e.g. MLflow
       save failure).
     - ``server`` / ``runtime``: used by the EvalHub service / job runtime.


### PR DESCRIPTION
## What and why

Fix for comments/documentation for message origin

Closes #

## Type

- [ ] feat
- [ ] fix
- [X] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [ ] Tests added or updated
- [ ] Tested manually

## Breaking changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how message origins are identified as coming from the adapter or SDK.
  * Improved descriptions for status updates, results, and errors to make message sources easier to understand.
  * Added detail on how adapter and SDK-originated messages are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->