### PR TITLE
fix(models): make Collection description optional to match server

### DIFF
--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -821,7 +821,7 @@ class Collection(BaseModel):
 
     resource: Resource = Field(..., description="Resource metadata")
     name: str = Field(..., description="Collection name")
-    description: str = Field(..., description="Collection description")
+    description: str = Field(default="", description="Collection description")
     category: str = Field(..., description="Collection category")
     tags: list[str] = Field(default_factory=list, description="Collection tags")
     custom: dict[str, Any] = Field(default_factory=dict, description="Custom metadata")

--- a/tests/unit/test_models_api.py
+++ b/tests/unit/test_models_api.py
@@ -1024,6 +1024,36 @@ class TestListModelsServerCompatibility:
         assert len(collection_list.items) == 1
         assert collection_list.items[0].resource.id == "healthcare_v1"
 
+    def test_collection_list_without_description(self) -> None:
+        """Test CollectionList parses when server omits description."""
+        server_response = {
+            "items": [
+                {
+                    "resource": {
+                        "id": "c566c23d-8f79-4643-9d61-a6392e810184",
+                        "tenant": "dataplane",
+                        "created_at": "2026-07-28T15:25:38Z",
+                        "updated_at": "2026-07-28T15:25:38Z",
+                    },
+                    "name": "my-safety-suite",
+                    "category": "safety",
+                    "benchmarks": [
+                        {
+                            "id": "truthfulqa_mc1",
+                            "provider_id": "lm_evaluation_harness",
+                        },
+                        {"id": "owasp_llm_top_10", "provider_id": "garak"},
+                    ],
+                }
+            ],
+            "total_count": 1,
+        }
+
+        collection_list = CollectionList.model_validate(server_response)
+        assert collection_list.total_count == 1
+        assert len(collection_list.items) == 1
+        assert collection_list.items[0].description == ""
+
     def test_jobs_list_with_server_fields(self) -> None:
         """Test JobsList parses server response format."""
         # Go API returns 'items' and 'total_count' with nested structure


### PR DESCRIPTION


## What and why

Fix for `evalhub collection list` crashing with custom collection missing "description".
The server may omit the description field when listing collections. Default to an empty string so CollectionList.model_validate does not raise a ValidationError for responses without a description.


Closes # https://redhat.atlassian.net/browse/RHOAIENG-79594

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

<img width="729" height="279" alt="Screenshot 2026-07-29 at 11 21 35 AM" src="https://github.com/user-attachments/assets/64f5a856-63f1-45d5-918d-f26e9f67c70c" />
<img width="847" height="773" alt="Screenshot 2026-07-29 at 11 21 03 AM" src="https://github.com/user-attachments/assets/f3c9ebbe-fd20-416a-939a-9acd3be53b12" />


## Breaking changes
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection data can now be processed when the description is omitted.
  * Missing descriptions are automatically shown as blank instead of causing validation errors.

* **Tests**
  * Added coverage to verify collection responses without descriptions are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->