### PR TITLE
feat(adapter): support local-mode model auth via env var fallbacks

### DIFF
--- a/src/evalhub/adapter/auth.py
+++ b/src/evalhub/adapter/auth.py
@@ -1,11 +1,16 @@
 """Helpers for resolving model auth from environment."""
 
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 _MODEL_AUTH_DIR = Path("/var/run/secrets/model")
+
+_ENV_LOCAL_MODEL_API_KEY = "EVALHUB_LOCAL_MODEL_API_KEY"
+_ENV_LOCAL_MODEL_CA_CERT_PATH = "EVALHUB_LOCAL_MODEL_CA_CERT_PATH"
+_ENV_LOCAL_MODEL_HF_TOKEN = "EVALHUB_LOCAL_MODEL_HF_TOKEN"
 
 
 def read_model_auth_key(key_name: str) -> str | None:
@@ -24,22 +29,47 @@ def read_model_auth_key(key_name: str) -> str | None:
     return value or None
 
 
+def _read_model_auth_path(key_name: str) -> str | None:
+    """Return the path to a mounted model auth key file, if it exists."""
+    cleaned = key_name.strip()
+    if not cleaned:
+        return None
+    path = _MODEL_AUTH_DIR / cleaned
+    if not path.is_file():
+        return None
+    return str(path)
+
+
 @dataclass
 class ModelCredentials:
-    """Resolved model credentials from the pod environment.
+    """Resolved model credentials.
 
-    api_key holds the ref token (e.g. 'api-key:ref') that the sidecar
-    proxy resolves to the real credential. CA cert and SA token injection
-    are handled transparently by the sidecar — not the adapter.
+    In K8s mode, api_key holds the ref token (e.g. 'api-key:ref') that
+    the sidecar proxy resolves to the real credential. In local mode,
+    api_key holds the real credential read from EVALHUB_LOCAL_MODEL_API_KEY.
+
+    ca_cert_path is the filesystem path to the CA certificate PEM used
+    for TLS verification against the model endpoint.
+
+    hf_token is the HuggingFace token for gated dataset/tokenizer access.
     """
 
     api_key: str | None = field(default=None, repr=False)
+    ca_cert_path: str | None = field(default=None)
+    hf_token: str | None = field(default=None, repr=False)
 
 
 def resolve_model_credentials() -> ModelCredentials:
     """Resolve model authentication from the pod environment.
 
-    Reads the api-key ref token from the mounted model auth secret.
-    CA cert and SA token injection are handled by the sidecar proxy.
+    Uses a fallback pattern: K8s-mounted secret files take precedence,
+    EVALHUB_LOCAL_MODEL_* env vars are the local-mode fallback.
     """
-    return ModelCredentials(api_key=read_model_auth_key("api-key"))
+    return ModelCredentials(
+        api_key=read_model_auth_key("api-key")
+        or os.environ.get(_ENV_LOCAL_MODEL_API_KEY),
+        ca_cert_path=_read_model_auth_path("ca_cert")
+        or os.environ.get(_ENV_LOCAL_MODEL_CA_CERT_PATH),
+        hf_token=read_model_auth_key("hf-token")
+        or os.environ.get(_ENV_LOCAL_MODEL_HF_TOKEN),
+    )

--- a/tests/unit/test_adapter_auth.py
+++ b/tests/unit/test_adapter_auth.py
@@ -1,0 +1,188 @@
+"""Unit tests for adapter auth: read_model_auth_key and resolve_model_credentials."""
+
+from pathlib import Path
+
+import pytest
+from evalhub.adapter.auth import (
+    ModelCredentials,
+    read_model_auth_key,
+    resolve_model_credentials,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def model_auth_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect _MODEL_AUTH_DIR to a temp directory."""
+    auth_dir = tmp_path / "model"
+    auth_dir.mkdir()
+    monkeypatch.setattr("evalhub.adapter.auth._MODEL_AUTH_DIR", auth_dir)
+    return auth_dir
+
+
+# ---------------------------------------------------------------------------
+# read_model_auth_key
+# ---------------------------------------------------------------------------
+
+
+class TestReadModelAuthKey:
+    """Tests for read_model_auth_key()."""
+
+    def test_reads_value_from_file(self, model_auth_dir: Path) -> None:
+        """Returns the trimmed content of the key file."""
+        (model_auth_dir / "api-key").write_text("my-secret-key\n")
+        assert read_model_auth_key("api-key") == "my-secret-key"
+
+    def test_returns_none_when_file_missing(self, model_auth_dir: Path) -> None:
+        """Returns None when the key file does not exist."""
+        assert read_model_auth_key("api-key") is None
+
+    def test_returns_none_for_empty_file(self, model_auth_dir: Path) -> None:
+        """Returns None when the key file is empty or whitespace-only."""
+        (model_auth_dir / "api-key").write_text("   \n")
+        assert read_model_auth_key("api-key") is None
+
+    def test_returns_none_for_empty_key_name(self, model_auth_dir: Path) -> None:
+        """Returns None when the key name is empty or whitespace."""
+        assert read_model_auth_key("") is None
+        assert read_model_auth_key("   ") is None
+
+    def test_strips_key_name(self, model_auth_dir: Path) -> None:
+        """Strips whitespace from the key name before lookup."""
+        (model_auth_dir / "hf-token").write_text("tok123")
+        assert read_model_auth_key("  hf-token  ") == "tok123"
+
+    def test_returns_none_on_read_error(
+        self, model_auth_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Returns None and logs a warning on read errors."""
+        key_file = model_auth_dir / "api-key"
+        key_file.write_text("value")
+        monkeypatch.setattr(
+            "pathlib.Path.read_text",
+            lambda *_a, **_kw: (_ for _ in ()).throw(OSError("disk error")),
+        )
+        assert read_model_auth_key("api-key") is None
+
+
+# ---------------------------------------------------------------------------
+# ModelCredentials
+# ---------------------------------------------------------------------------
+
+
+class TestModelCredentials:
+    """Tests for the ModelCredentials dataclass."""
+
+    def test_defaults_to_none(self) -> None:
+        """All fields default to None."""
+        creds = ModelCredentials()
+        assert creds.api_key is None
+        assert creds.ca_cert_path is None
+        assert creds.hf_token is None
+
+    def test_fields_set(self) -> None:
+        """Fields can be set via constructor."""
+        creds = ModelCredentials(
+            api_key="key", ca_cert_path="/certs/ca.pem", hf_token="hf-123"
+        )
+        assert creds.api_key == "key"
+        assert creds.ca_cert_path == "/certs/ca.pem"
+        assert creds.hf_token == "hf-123"
+
+    def test_api_key_and_hf_token_hidden_in_repr(self) -> None:
+        """api_key and hf_token are excluded from repr for security."""
+        creds = ModelCredentials(api_key="secret", hf_token="also-secret")
+        r = repr(creds)
+        assert "secret" not in r
+        assert "also-secret" not in r
+
+
+# ---------------------------------------------------------------------------
+# resolve_model_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestResolveModelCredentials:
+    """Tests for resolve_model_credentials()."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_local_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Remove all EVALHUB_LOCAL_MODEL_* env vars for test isolation."""
+        monkeypatch.delenv("EVALHUB_LOCAL_MODEL_API_KEY", raising=False)
+        monkeypatch.delenv("EVALHUB_LOCAL_MODEL_CA_CERT_PATH", raising=False)
+        monkeypatch.delenv("EVALHUB_LOCAL_MODEL_HF_TOKEN", raising=False)
+
+    def test_reads_from_files_k8s_style(
+        self,
+        model_auth_dir: Path,
+    ) -> None:
+        """Reads api-key, ca_cert, and hf-token from mounted secret files."""
+        (model_auth_dir / "api-key").write_text("api-key:ref")
+        (model_auth_dir / "ca_cert").write_text("-----BEGIN CERTIFICATE-----\n...")
+        (model_auth_dir / "hf-token").write_text("hf-abc")
+
+        creds = resolve_model_credentials()
+
+        assert creds.api_key == "api-key:ref"
+        assert creds.ca_cert_path == str(model_auth_dir / "ca_cert")
+        assert creds.hf_token == "hf-abc"
+
+    def test_falls_back_to_env_vars(
+        self, model_auth_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Uses EVALHUB_LOCAL_MODEL_* env vars when files are absent."""
+        monkeypatch.setenv("EVALHUB_LOCAL_MODEL_API_KEY", "real-api-key")
+        monkeypatch.setenv("EVALHUB_LOCAL_MODEL_CA_CERT_PATH", "/local/ca.pem")
+        monkeypatch.setenv("EVALHUB_LOCAL_MODEL_HF_TOKEN", "hf-local")
+
+        creds = resolve_model_credentials()
+
+        assert creds.api_key == "real-api-key"
+        assert creds.ca_cert_path == "/local/ca.pem"
+        assert creds.hf_token == "hf-local"
+
+    def test_file_takes_precedence_over_env(
+        self, model_auth_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """K8s-mounted files take precedence over env vars."""
+        (model_auth_dir / "api-key").write_text("from-file")
+        (model_auth_dir / "ca_cert").write_text("cert-content")
+        (model_auth_dir / "hf-token").write_text("hf-from-file")
+        monkeypatch.setenv("EVALHUB_LOCAL_MODEL_API_KEY", "from-env")
+        monkeypatch.setenv("EVALHUB_LOCAL_MODEL_CA_CERT_PATH", "/env/ca.pem")
+        monkeypatch.setenv("EVALHUB_LOCAL_MODEL_HF_TOKEN", "hf-from-env")
+
+        creds = resolve_model_credentials()
+
+        assert creds.api_key == "from-file"
+        assert creds.ca_cert_path == str(model_auth_dir / "ca_cert")
+        assert creds.hf_token == "hf-from-file"
+
+    def test_returns_none_when_nothing_configured(
+        self,
+        model_auth_dir: Path,
+    ) -> None:
+        """Returns all-None credentials when no files or env vars exist."""
+        creds = resolve_model_credentials()
+
+        assert creds.api_key is None
+        assert creds.ca_cert_path is None
+        assert creds.hf_token is None
+
+    def test_partial_configuration(
+        self, model_auth_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Supports partial configuration (e.g. api_key from env, no cert)."""
+        monkeypatch.setenv("EVALHUB_LOCAL_MODEL_API_KEY", "only-key")
+
+        creds = resolve_model_credentials()
+
+        assert creds.api_key == "only-key"
+        assert creds.ca_cert_path is None
+        assert creds.hf_token is None


### PR DESCRIPTION


## What and why

Local mode need a way to enable `api-key` (beside hf-token and ca_cert) for those model_url which are TLS enabled. There is no sidecar in local mode.

`resolve_model_credentials()` now falls back to 
- EVALHUB_LOCAL_MODEL_API_KEY
- EVALHUB_LOCAL_MODEL_CA_CERT_PATH
- EVALHUB_LOCAL_MODEL_HF_TOKEN
env vars when K8s-mounted secret files are absent, enabling remote TLS model endpoints in local mode without a sidecar proxy.

The objective here is to enable the equivalent of k8s secret  e.g.
```bash
oc create secret generic vllm-sim2-withcert-secret -n "${NAMESPACE}" \
  --from-literal=api-key="test-***" \
  --from-literal=hf-token="my-hf-token" \
  --from-file=ca_cert=certificates/vllm_sim2_ca_bundle.pem
```
To be able to run the same adapter implementation Local mode `main.py`

Closes # https://redhat.atlassian.net/browse/RHOAIENG-65193

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

<img width="1085" height="674" alt="Screenshot 2026-08-03 at 3 13 00 PM" src="https://github.com/user-attachments/assets/a194f0a8-ade7-4537-8736-296edd46e9a1" />

<img width="992" height="648" alt="Screenshot 2026-08-03 at 3 15 09 PM" src="https://github.com/user-attachments/assets/4689e78c-b71c-4b3b-bd00-d4992e1fe58d" />
<img width="963" height="513" alt="Screenshot 2026-08-03 at 3 15 19 PM" src="https://github.com/user-attachments/assets/e84fed8a-e1f6-499d-9f47-a9cbdaebd2cd" />

## Breaking changes
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring API keys, CA certificates, and Hugging Face tokens through environment variables in local mode.
  * Added support for Kubernetes-mounted credential files, with file-based settings taking precedence over environment variables.
  * Improved credential handling for partial configurations and certificate paths.

* **Bug Fixes**
  * Improved validation and handling of missing, invalid, or unreadable credential configuration.
  * Enhanced protection against exposing sensitive credential values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->