### PR TITLE
feat(cli): add config profiles command and config list --all flag

### DIFF
--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -99,6 +99,14 @@ def get_active_profile(data: dict[str, Any]) -> str:
     return active
 
 
+def list_profiles(data: dict[str, Any]) -> dict[str, Any]:
+    """Return the profiles mapping, safely handling corrupt data."""
+    profiles = data.get("profiles", {})
+    if not isinstance(profiles, dict):
+        return {}
+    return profiles
+
+
 def get_profile(data: dict[str, Any], profile: str | None = None) -> dict[str, Any]:
     """Return the settings dict for a profile (empty dict if it doesn't exist yet)."""
     name = profile or get_active_profile(data)

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -104,7 +104,11 @@ def list_profiles(data: dict[str, Any]) -> dict[str, Any]:
     profiles = data.get("profiles", {})
     if not isinstance(profiles, dict):
         return {}
-    return profiles
+    return {
+        name: prof
+        for name, prof in profiles.items()
+        if isinstance(name, str) and isinstance(prof, dict)
+    }
 
 
 def get_profile(data: dict[str, Any], profile: str | None = None) -> dict[str, Any]:

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -1294,7 +1294,8 @@ def config(ctx: click.Context) -> None:
     Configuration is stored in ~/.config/evalhub/config.yaml and
     supports multiple profiles. Use 'config set' to store values,
     'config get' to read them, 'config list' to see the full
-    profile, and 'config use' to switch profiles.
+    profile, 'config profiles' to list all profiles, and
+    'config use' to switch profiles.
 
     \b
     File-based keys (e.g. mcp_config_file, server_config_file) store
@@ -1443,32 +1444,81 @@ def config_get(ctx: click.Context, key: str, unmask: bool, unfold: bool) -> None
         click.echo(value)
 
 
-@config.command("list")
-@click.pass_context
-def config_list(ctx: click.Context) -> None:
-    """List all configuration values in the active profile.
-
-    \b
-    Shows all key-value pairs and flags any missing required keys.
-
-    \b
-    Examples:
-      evalhub config list
-      evalhub --profile prod config list
-    """
-    profile = ctx.obj.get("profile")
-    data = cfg.load_config()
-    profile_name = profile or cfg.get_active_profile(data)
-    prof = cfg.get_profile(data, profile=profile)
-    click.echo(f"Profile: {profile_name}")
+def _render_profile(
+    name: str,
+    prof: dict[str, object],
+    data: dict[str, object],
+    *,
+    marker: str = "",
+) -> None:
+    """Print a single profile's header, values, and missing-key warning."""
+    click.echo(f"Profile: {name}{marker}")
     if not prof:
         click.echo("  (no configuration values)")
     else:
         for k, v in cfg.mask_mapping(prof).items():
             click.echo(f"  {k}: {v}")
-    missing = cfg.missing_required_keys(data, profile=profile)
+    missing = cfg.missing_required_keys(data, profile=name)
     if missing:
         click.echo(f"\n  Missing required keys: {', '.join(missing)}")
+
+
+@config.command("list")
+@click.option("--all", "show_all", is_flag=True, help="Show all profiles.")
+@click.pass_context
+def config_list(ctx: click.Context, *, show_all: bool = False) -> None:
+    """List configuration values in the active profile.
+
+    \b
+    Shows all key-value pairs and flags any missing required keys.
+    Use --all to show every profile at once.
+
+    \b
+    Examples:
+      evalhub config list
+      evalhub config list --all
+      evalhub --profile prod config list
+    """
+    data = cfg.load_config()
+    active = cfg.get_active_profile(data)
+
+    if show_all:
+        profiles = cfg.list_profiles(data)
+        if not profiles:
+            click.echo("No profiles configured.")
+            return
+        for i, (name, prof) in enumerate(profiles.items()):
+            if i:
+                click.echo()
+            marker = " *" if name == active else ""
+            _render_profile(name, prof, data, marker=marker)
+    else:
+        profile = ctx.obj.get("profile")
+        profile_name = profile or active
+        prof = cfg.get_profile(data, profile=profile)
+        _render_profile(profile_name, prof, data)
+
+
+@config.command("profiles")
+def config_profiles() -> None:
+    """List all available configuration profiles.
+
+    \b
+    Shows every profile name, marking the active one with an asterisk (*).
+
+    \b
+    Examples:
+      evalhub config profiles
+    """
+    data = cfg.load_config()
+    active = cfg.get_active_profile(data)
+    profiles = cfg.list_profiles(data)
+    if not profiles:
+        click.echo("No profiles configured.")
+        return
+    for name in profiles:
+        marker = " *" if name == active else ""
+        click.echo(f"  {name}{marker}")
 
 
 @config.command("use")
@@ -1487,7 +1537,7 @@ def config_use(profile: str) -> None:
       evalhub config use staging
     """
     data = cfg.load_config()
-    profiles = data.get("profiles", {})
+    profiles = cfg.list_profiles(data)
     if profile not in profiles:
         click.echo(
             f"Profile '{profile}' does not exist. Available profiles: "

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -1294,7 +1294,7 @@ def config(ctx: click.Context) -> None:
     Configuration is stored in ~/.config/evalhub/config.yaml and
     supports multiple profiles. Use 'config set' to store values,
     'config get' to read them, 'config list' to see the full
-    profile, 'config profiles' to list all profiles, and
+    profile, 'config list --all' to list all profiles, and
     'config use' to switch profiles.
 
     \b
@@ -1497,28 +1497,6 @@ def config_list(ctx: click.Context, *, show_all: bool = False) -> None:
         profile_name = profile or active
         prof = cfg.get_profile(data, profile=profile)
         _render_profile(profile_name, prof, data)
-
-
-@config.command("profiles")
-def config_profiles() -> None:
-    """List all available configuration profiles.
-
-    \b
-    Shows every profile name, marking the active one with an asterisk (*).
-
-    \b
-    Examples:
-      evalhub config profiles
-    """
-    data = cfg.load_config()
-    active = cfg.get_active_profile(data)
-    profiles = cfg.list_profiles(data)
-    if not profiles:
-        click.echo("No profiles configured.")
-        return
-    for name in profiles:
-        marker = " *" if name == active else ""
-        click.echo(f"  {name}{marker}")
 
 
 @config.command("use")

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -304,6 +304,117 @@ class TestConfigListCommand:
         assert "Missing required keys" not in result.output
 
 
+class TestConfigListAllCommand:
+    def test_list_all_no_profiles(self, runner: CliRunner, config_file: Path) -> None:
+        result = runner.invoke(main, ["config", "list", "--all"])
+        assert result.exit_code == 0
+        assert "No profiles configured." in result.output
+
+    def test_list_all_shows_every_profile(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        runner.invoke(main, ["config", "set", "token", "default-token-val"])
+        runner.invoke(
+            main, ["--profile", "prod", "config", "set", "base_url", "https://prod:443"]
+        )
+        runner.invoke(
+            main, ["--profile", "prod", "config", "set", "token", "prod-token-val"]
+        )
+        result = runner.invoke(main, ["config", "list", "--all"])
+        assert result.exit_code == 0
+        assert "Profile: default *" in result.output
+        assert "Profile: prod" in result.output
+        assert "base_url: http://localhost:8080" in result.output
+        assert "base_url: https://prod:443" in result.output
+
+    def test_list_all_masks_tokens(self, runner: CliRunner, config_file: Path) -> None:
+        runner.invoke(main, ["config", "set", "token", "secret-default-token"])
+        runner.invoke(
+            main, ["--profile", "prod", "config", "set", "token", "secret-prod-token"]
+        )
+        result = runner.invoke(main, ["config", "list", "--all"])
+        assert result.exit_code == 0
+        assert "secret-default-token" not in result.output
+        assert "secret-prod-token" not in result.output
+        assert "token: sec***en" in result.output
+
+    def test_list_all_marks_active_profile(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        runner.invoke(
+            main, ["--profile", "prod", "config", "set", "base_url", "https://prod:443"]
+        )
+        runner.invoke(main, ["config", "use", "prod"])
+        result = runner.invoke(main, ["config", "list", "--all"])
+        assert result.exit_code == 0
+        assert "Profile: prod *" in result.output
+        assert "Profile: default\n" in result.output
+
+    def test_list_all_shows_missing_keys(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        runner.invoke(main, ["config", "set", "token", "tok12345"])
+        runner.invoke(main, ["config", "set", "tenant", "ns"])
+        runner.invoke(
+            main, ["--profile", "prod", "config", "set", "base_url", "https://prod:443"]
+        )
+        result = runner.invoke(main, ["config", "list", "--all"])
+        assert result.exit_code == 0
+        # default is complete
+        assert "Missing required keys" in result.output  # prod is incomplete
+
+
+class TestConfigProfilesCommand:
+    def test_profiles_empty(self, runner: CliRunner, config_file: Path) -> None:
+        result = runner.invoke(main, ["config", "profiles"])
+        assert result.exit_code == 0
+        assert "No profiles configured." in result.output
+
+    def test_profiles_single(self, runner: CliRunner, config_file: Path) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        result = runner.invoke(main, ["config", "profiles"])
+        assert result.exit_code == 0
+        assert "default *" in result.output
+
+    def test_profiles_multiple_marks_active(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        runner.invoke(
+            main, ["--profile", "prod", "config", "set", "base_url", "https://prod:443"]
+        )
+        runner.invoke(
+            main,
+            ["--profile", "staging", "config", "set", "base_url", "https://stg:443"],
+        )
+        result = runner.invoke(main, ["config", "profiles"])
+        assert result.exit_code == 0
+        assert "default *" in result.output
+        assert "prod" in result.output
+        assert "staging" in result.output
+        # Only the active profile should have the asterisk
+        lines = result.output.strip().splitlines()
+        starred = [line for line in lines if "*" in line]
+        assert len(starred) == 1
+
+    def test_profiles_after_switch(self, runner: CliRunner, config_file: Path) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        runner.invoke(
+            main, ["--profile", "prod", "config", "set", "base_url", "https://prod:443"]
+        )
+        runner.invoke(main, ["config", "use", "prod"])
+        result = runner.invoke(main, ["config", "profiles"])
+        assert result.exit_code == 0
+        assert "prod *" in result.output
+        # default should NOT have the asterisk
+        lines = result.output.strip().splitlines()
+        default_line = [line for line in lines if "default" in line][0]
+        assert "*" not in default_line
+
+
 class TestConfigUseCommand:
     def test_use_switches_active_profile(
         self, runner: CliRunner, config_file: Path

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -367,54 +367,6 @@ class TestConfigListAllCommand:
         assert "Missing required keys" in result.output  # prod is incomplete
 
 
-class TestConfigProfilesCommand:
-    def test_profiles_empty(self, runner: CliRunner, config_file: Path) -> None:
-        result = runner.invoke(main, ["config", "profiles"])
-        assert result.exit_code == 0
-        assert "No profiles configured." in result.output
-
-    def test_profiles_single(self, runner: CliRunner, config_file: Path) -> None:
-        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
-        result = runner.invoke(main, ["config", "profiles"])
-        assert result.exit_code == 0
-        assert "default *" in result.output
-
-    def test_profiles_multiple_marks_active(
-        self, runner: CliRunner, config_file: Path
-    ) -> None:
-        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
-        runner.invoke(
-            main, ["--profile", "prod", "config", "set", "base_url", "https://prod:443"]
-        )
-        runner.invoke(
-            main,
-            ["--profile", "staging", "config", "set", "base_url", "https://stg:443"],
-        )
-        result = runner.invoke(main, ["config", "profiles"])
-        assert result.exit_code == 0
-        assert "default *" in result.output
-        assert "prod" in result.output
-        assert "staging" in result.output
-        # Only the active profile should have the asterisk
-        lines = result.output.strip().splitlines()
-        starred = [line for line in lines if "*" in line]
-        assert len(starred) == 1
-
-    def test_profiles_after_switch(self, runner: CliRunner, config_file: Path) -> None:
-        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
-        runner.invoke(
-            main, ["--profile", "prod", "config", "set", "base_url", "https://prod:443"]
-        )
-        runner.invoke(main, ["config", "use", "prod"])
-        result = runner.invoke(main, ["config", "profiles"])
-        assert result.exit_code == 0
-        assert "prod *" in result.output
-        # default should NOT have the asterisk
-        lines = result.output.strip().splitlines()
-        default_line = [line for line in lines if "default" in line][0]
-        assert "*" not in default_line
-
-
 class TestConfigUseCommand:
     def test_use_switches_active_profile(
         self, runner: CliRunner, config_file: Path


### PR DESCRIPTION

## What and why

Add two new ways to discover and inspect configuration profiles:

- ~`evalhub config profiles` lists all profile names, marking the active one with an asterisk (*).~ (Not implemented. config list --all , will suffice)
- `evalhub config list --all` shows every profile's key-value pairs (with tokens masked) and flags missing required keys per profile.

Also extracts a `list_profiles()` helper in the config module for defensive profile enumeration, and a `_render_profile()` helper to avoid duplicating the profile display logic between single and multi-profile code paths.

Closes # https://redhat.atlassian.net/browse/RHOAIENG-80926

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

Output example:
```
╰─➤  evalhub config --help
Usage: evalhub config [OPTIONS] COMMAND [ARGS]...

  View and update CLI configuration.

  Configuration is stored in ~/.config/evalhub/config.yaml and
  supports multiple profiles. Use 'config set' to store values,
  'config get' to read them, 'config list' to see the full
  profile, and 'config use' to switch profiles.

  File-based keys (e.g. mcp_config_file, server_config_file) store
  a path to a YAML file. Use 'config get <key> --unfold' to view
  the file contents.

  Examples:
    evalhub config set base_url http://localhost:8080
    evalhub config set mcp_config_file mcp-config.yaml
    evalhub config set server_config_file myserver-config.yaml
    evalhub config get mcp_config_file --unfold
    evalhub config list
    evalhub config use prod

Options:
  -h, --help  Show this message and exit.

Commands:
  get    Get a configuration value from the active profile.
  list   List all configuration values in the active profile.
  set    Set a configuration value in the active profile.
  unset  Remove a configuration key from the active profile.
  use    Switch the active configuration profile.


Fix:

╰─➤  evalhub config profiles
  default
  local-mcp
  gbn
  dev1
  gbndev *
  postgres


╰─➤  evalhub config list --all
Profile: default
  base_url: http://localhost:8080
  server_config_file: /Users/gnaulak/.config/evalhub/server/default/config.yaml

  Missing required keys: token, tenant

Profile: local-mcp
  base_url: http://localhost:8080

  Missing required keys: token, tenant

Profile: gbn
  base_url: https://evalhub-evalhub-test.apps.rosa.gbn-dev.vqoo.p3.openshiftapps.com
  token: sha***8M
  tenant: dataplane

Profile: dev1
  base_url: http://localhost:8080
  mcp_config_file: /Users/gnaulak/.config/evalhub/mcp/dev1/config.yaml

  Missing required keys: token, tenant

Profile: gbndev *
  base_url: https://evalhub-evalhub-test.apps.rosa.gbn-dev.vqoo.p3.openshiftapps.com
  tenant: dataplane
  token: eyJ***YU

Profile: postgres
  base_url: http://localhost:8080
  server_config_file: /Users/gnaulak/.config/evalhub/server/postgres/config.yaml

  Missing required keys: token, tenant

```


## Breaking changes

No
<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `config list --all` to display all configured profiles and identify the active profile.
  - Improved profile details with masked tokens, empty-profile handling, and warnings for missing required settings.
  - Enhanced configuration profile switching with consistent profile discovery and handling.

- **Tests**
  - Added coverage for listing all profiles, active-profile indicators, empty configurations, token masking, and validation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->