### PR TITLE
feat(cli): add config create, delete commands and auto-create on use

### DIFF
--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -231,6 +231,20 @@ def resolve_component_config_dir(
     return state_dir / profile_name
 
 
+def create_profile(data: dict[str, Any], profile: str) -> dict[str, Any]:
+    """Create an empty profile. Returns the updated data dict."""
+    data.setdefault("profiles", {})[profile] = {}
+    return data
+
+
+def delete_profile(data: dict[str, Any], profile: str) -> dict[str, Any]:
+    """Remove a profile and its file-key storage. Returns the updated data dict."""
+    data.get("profiles", {}).pop(profile, None)
+    for key in FILE_KEYS:
+        remove_file_key(key, profile)
+    return data
+
+
 def set_active_profile(data: dict[str, Any], profile: str) -> dict[str, Any]:
     """Switch the active profile."""
     data["active_profile"] = profile

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -1295,7 +1295,8 @@ def config(ctx: click.Context) -> None:
     supports multiple profiles. Use 'config set' to store values,
     'config get' to read them, 'config list' to see the full
     profile, 'config list --all' to list all profiles, and
-    'config use' to switch profiles.
+    'config use' to switch profiles, 'config create' to create
+    a new profile, and 'config delete' to remove one.
 
     \b
     File-based keys (e.g. mcp_config_file, server_config_file) store
@@ -1506,8 +1507,7 @@ def config_use(profile: str) -> None:
 
     \b
     Sets the given profile as the default for all subsequent commands.
-    The profile must already exist (create it by setting a value with
-    --profile).
+    If the profile does not exist yet, it is created as an empty profile.
 
     \b
     Examples:
@@ -1516,13 +1516,65 @@ def config_use(profile: str) -> None:
     """
     data = cfg.load_config()
     profiles = cfg.list_profiles(data)
-    if profile not in profiles:
-        click.echo(
-            f"Profile '{profile}' does not exist. Available profiles: "
-            f"{', '.join(profiles) or '(none)'}",
-            err=True,
-        )
-        raise SystemExit(1)
+    created = profile not in profiles
+    if created:
+        cfg.create_profile(data, profile)
     cfg.set_active_profile(data, profile)
     cfg.save_config(data)
-    click.echo(f"Active profile set to '{profile}'")
+    if created:
+        click.echo(f"Created profile '{profile}' and set it as active")
+    else:
+        click.echo(f"Active profile set to '{profile}'")
+
+
+@config.command("create")
+@click.argument("profile")
+def config_create(profile: str) -> None:
+    """Create a new empty configuration profile.
+
+    \b
+    Creates the profile without switching to it.
+    Use 'config use' to switch to it afterwards.
+
+    \b
+    Examples:
+      evalhub config create staging
+      evalhub config create prod
+    """
+    data = cfg.load_config()
+    profiles = cfg.list_profiles(data)
+    if profile in profiles:
+        raise click.ClickException(f"Profile '{profile}' already exists")
+    cfg.create_profile(data, profile)
+    cfg.save_config(data)
+    click.echo(f"Created profile '{profile}'")
+
+
+@config.command("delete")
+@click.argument("profile")
+def config_delete(profile: str) -> None:
+    """Delete a configuration profile.
+
+    \b
+    Removes the profile and any associated file-key data
+    (e.g. stored mcp_config_file, server_config_file).
+    The active profile cannot be deleted.
+
+    \b
+    Examples:
+      evalhub config delete staging
+      evalhub config delete prod
+    """
+    data = cfg.load_config()
+    profiles = cfg.list_profiles(data)
+    if profile not in profiles:
+        raise click.ClickException(f"Profile '{profile}' does not exist")
+    active = cfg.get_active_profile(data)
+    if profile == active:
+        raise click.ClickException(
+            f"Cannot delete the active profile '{profile}'. "
+            f"Switch to another profile first with 'config use'."
+        )
+    cfg.delete_profile(data, profile)
+    cfg.save_config(data)
+    click.echo(f"Deleted profile '{profile}'")

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -17,6 +17,8 @@ from evalhub.cli.config import (
     OPTIONAL_KEYS,
     REQUIRED_KEYS,
     SENSITIVE_KEYS,
+    create_profile,
+    delete_profile,
     get_active_profile,
     get_profile,
     get_value,
@@ -134,6 +136,23 @@ class TestProfileOperations:
             "profiles": {"prod": {"base_url": "https://prod.example.com"}},
         }
         assert get_profile(data, "prod") == {"base_url": "https://prod.example.com"}
+
+    def test_create_profile(self) -> None:
+        data: dict[str, Any] = {"active_profile": "default", "profiles": {}}
+        create_profile(data, "staging")
+        assert data["profiles"]["staging"] == {}
+
+    def test_delete_profile(self) -> None:
+        data: dict[str, Any] = {
+            "active_profile": "default",
+            "profiles": {
+                "default": {"base_url": "http://localhost"},
+                "staging": {"base_url": "http://staging"},
+            },
+        }
+        delete_profile(data, "staging")
+        assert "staging" not in data["profiles"]
+        assert "default" in data["profiles"]
 
     def test_set_value_creates_profile(self) -> None:
         data: dict[str, Any] = {"active_profile": "default", "profiles": {}}
@@ -381,12 +400,25 @@ class TestConfigUseCommand:
         data = load_config()
         assert data["active_profile"] == "prod"
 
-    def test_use_nonexistent_profile_errors(
+    def test_use_creates_nonexistent_profile(
         self, runner: CliRunner, config_file: Path
     ) -> None:
-        result = runner.invoke(main, ["config", "use", "nonexistent"])
-        assert result.exit_code != 0
-        assert "does not exist" in result.output
+        result = runner.invoke(main, ["config", "use", "newprofile"])
+        assert result.exit_code == 0
+        assert "Created profile 'newprofile'" in result.output
+        data = load_config()
+        assert data["active_profile"] == "newprofile"
+        assert data["profiles"]["newprofile"] == {}
+
+    def test_use_created_profile_shows_in_list_all(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        runner.invoke(main, ["config", "use", "newprofile"])
+        result = runner.invoke(main, ["config", "list", "--all"])
+        assert result.exit_code == 0
+        assert "Profile: newprofile *" in result.output
+        assert "(no configuration values)" in result.output
 
     def test_use_then_set_uses_new_profile(
         self, runner: CliRunner, config_file: Path
@@ -636,3 +668,82 @@ class TestConfigUnsetCommand:
         assert "profile 'prod'" in result.output
         data = load_config()
         assert "token" not in data["profiles"]["prod"]
+
+
+class TestConfigCreateCommand:
+    def test_create_new_profile(self, runner: CliRunner, config_file: Path) -> None:
+        result = runner.invoke(main, ["config", "create", "staging"])
+        assert result.exit_code == 0
+        assert "Created profile 'staging'" in result.output
+        data = load_config()
+        assert data["profiles"]["staging"] == {}
+
+    def test_create_does_not_switch_active(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        result = runner.invoke(main, ["config", "create", "staging"])
+        assert result.exit_code == 0
+        data = load_config()
+        assert data["active_profile"] == "default"
+
+    def test_create_existing_profile_errors(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        result = runner.invoke(main, ["config", "create", "default"])
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+    def test_create_shows_in_list_all(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        runner.invoke(main, ["config", "create", "staging"])
+        result = runner.invoke(main, ["config", "list", "--all"])
+        assert result.exit_code == 0
+        assert "Profile: staging" in result.output
+        assert "(no configuration values)" in result.output
+
+
+class TestConfigDeleteCommand:
+    def test_delete_profile(self, runner: CliRunner, config_file: Path) -> None:
+        runner.invoke(
+            main, ["--profile", "staging", "config", "set", "base_url", "http://s:8080"]
+        )
+        result = runner.invoke(main, ["config", "delete", "staging"])
+        assert result.exit_code == 0
+        assert "Deleted profile 'staging'" in result.output
+        data = load_config()
+        assert "staging" not in data["profiles"]
+
+    def test_delete_nonexistent_profile_errors(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        result = runner.invoke(main, ["config", "delete", "nonexistent"])
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+
+    def test_delete_active_profile_errors(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        result = runner.invoke(main, ["config", "delete", "default"])
+        assert result.exit_code != 0
+        assert "Cannot delete the active profile" in result.output
+
+    def test_delete_preserves_other_profiles(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://localhost:8080"])
+        runner.invoke(
+            main, ["--profile", "staging", "config", "set", "base_url", "http://s:8080"]
+        )
+        runner.invoke(
+            main, ["--profile", "prod", "config", "set", "base_url", "http://p:443"]
+        )
+        runner.invoke(main, ["config", "delete", "staging"])
+        data = load_config()
+        assert "staging" not in data["profiles"]
+        assert "default" in data["profiles"]
+        assert "prod" in data["profiles"]


### PR DESCRIPTION
## What and why

Allow profiles to be explicitly created and deleted via dedicated subcommands, and implicitly created when switching with config use.

- `evalhub config use test1` to implicitly create test1 if it does not exists and activate.
- `evalhub config create test1` to explicitly create , but does not activate
- `evalhub config delete test1` to delete a profile. cannot delete the active


Closes # NA

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually
<img width="705" height="610" alt="Screenshot 2026-08-11 at 4 47 42 PM" src="https://github.com/user-attachments/assets/61b96ed3-4adb-4cf5-9129-3e7b6c06cac9" />

## Breaking changes
No**

**There is a behavior change with `evalhub config use <profile>` ; This no longer fails , but implicitly create `<profile>` and activate, when it would failed earlier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added commands to create and delete CLI configuration profiles.
  - Switching to a nonexistent profile now creates it automatically.
  - Deleting a profile also removes its associated stored file-key settings.
  - Added safeguards against duplicate profiles and deleting nonexistent or active profiles.
  - Profile creation does not change the currently active profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->