### PR TITLE
fix(models): add primary_score and pass_criteria to BenchmarkConfig

### DIFF
--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -399,7 +399,7 @@ class TestDataRef(BaseModel):
     )
 
     @model_validator(mode="after")
-    def check_exactly_one_source(self) -> "TestDataRef":
+    def check_exactly_one_source(self) -> TestDataRef:
         sources = [s for s in (self.s3, self.pvc, self.git) if s is not None]
         if len(sources) > 1:
             raise ValueError(
@@ -429,10 +429,10 @@ class BenchmarkConfig(BaseModel):
     parameters: dict[str, Any] = Field(
         default_factory=dict, description="Benchmark-specific parameters"
     )
-    primary_score: "PrimaryScore | None" = Field(
+    primary_score: PrimaryScore | None = Field(
         default=None, description="Override the benchmark's primary score metric"
     )
-    pass_criteria: "PassCriteria | None" = Field(
+    pass_criteria: PassCriteria | None = Field(
         default=None, description="Override pass/fail threshold for this benchmark"
     )
     test_data_ref: TestDataRef | None = Field(
@@ -565,7 +565,7 @@ class JobSubmissionRequest(BaseModel):
     )
 
     @model_validator(mode="after")
-    def check_benchmarks_or_collection(self) -> "JobSubmissionRequest":
+    def check_benchmarks_or_collection(self) -> JobSubmissionRequest:
         if self.benchmarks and self.collection:
             raise ValueError("Cannot specify both 'benchmarks' and 'collection'")
         if not self.benchmarks and not self.collection:

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -1,5 +1,7 @@
 """Core API models for the EvalHub SDK common interface."""
 
+from __future__ import annotations
+
 from datetime import datetime
 from enum import Enum
 from typing import Any, cast
@@ -426,6 +428,12 @@ class BenchmarkConfig(BaseModel):
     provider_id: str = Field(..., description="Provider identifier")
     parameters: dict[str, Any] = Field(
         default_factory=dict, description="Benchmark-specific parameters"
+    )
+    primary_score: "PrimaryScore | None" = Field(
+        default=None, description="Override the benchmark's primary score metric"
+    )
+    pass_criteria: "PassCriteria | None" = Field(
+        default=None, description="Override pass/fail threshold for this benchmark"
     )
     test_data_ref: TestDataRef | None = Field(
         default=None, description="Reference to custom external test data"

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -372,7 +372,7 @@ class GitTestDataRef(BaseModel):
     )
 
     @model_validator(mode="after")
-    def check_url_scheme(self) -> "GitTestDataRef":
+    def check_url_scheme(self) -> GitTestDataRef:
         parsed_url = urlsplit(self.url)
         if parsed_url.scheme not in ("http", "https") or not parsed_url.hostname:
             raise ValueError("git url must use http or https scheme and include a host")

--- a/tests/unit/test_models_api.py
+++ b/tests/unit/test_models_api.py
@@ -30,6 +30,8 @@ from evalhub.models.api import (
     ModelConfig,
     OCIConnectionConfig,
     OCICoordinates,
+    PassCriteria,
+    PrimaryScore,
     ProviderList,
     PVCTestDataRef,
     QueueConfig,
@@ -349,6 +351,85 @@ class TestEffectiveState:
             ],
         )
         assert job.effective_state == JobStatus.PENDING
+
+
+class TestBenchmarkConfig:
+    """Test cases for BenchmarkConfig model — primary_score and pass_criteria overrides."""
+
+    def test_defaults_are_none(self) -> None:
+        cfg = BenchmarkConfig(id="hellaswag", provider_id="lighteval")
+        assert cfg.primary_score is None
+        assert cfg.pass_criteria is None
+
+    def test_primary_score_accepted(self) -> None:
+        cfg = BenchmarkConfig(
+            id="hellaswag",
+            provider_id="lighteval",
+            primary_score=PrimaryScore(metric="hellaswag.em"),
+        )
+        assert cfg.primary_score is not None
+        assert cfg.primary_score.metric == "hellaswag.em"
+        assert cfg.primary_score.lower_is_better is False
+
+    def test_pass_criteria_accepted(self) -> None:
+        cfg = BenchmarkConfig(
+            id="hellaswag",
+            provider_id="lighteval",
+            pass_criteria=PassCriteria(threshold=0.99),
+        )
+        assert cfg.pass_criteria is not None
+        assert cfg.pass_criteria.threshold == 0.99
+
+    def test_both_fields_serialized(self) -> None:
+        """primary_score and pass_criteria must appear in model_dump output so the
+        server receives the per-benchmark threshold override."""
+        cfg = BenchmarkConfig(
+            id="hellaswag",
+            provider_id="lighteval",
+            primary_score=PrimaryScore(metric="hellaswag.em"),
+            pass_criteria=PassCriteria(threshold=0.99),
+        )
+        data = cfg.model_dump(exclude_none=True)
+        assert data["primary_score"] == {"metric": "hellaswag.em", "lower_is_better": False}
+        assert data["pass_criteria"] == {"threshold": 0.99}
+
+    def test_fields_omitted_when_none(self) -> None:
+        cfg = BenchmarkConfig(id="hellaswag", provider_id="lighteval")
+        data = cfg.model_dump(exclude_none=True)
+        assert "primary_score" not in data
+        assert "pass_criteria" not in data
+
+    def test_roundtrip_via_job_submission_request(self) -> None:
+        """Regression test: per-benchmark overrides must survive YAML→model→dump→server."""
+        import yaml
+
+        raw = yaml.safe_load("""
+name: violations-demo
+model:
+  url: http://vllm:8000/v1
+  name: my-model
+benchmarks:
+  - id: hellaswag
+    provider_id: lighteval
+    primary_score:
+      metric: hellaswag.em
+    pass_criteria:
+      threshold: 0.99
+    parameters:
+      num_examples: 10
+""")
+        req = JobSubmissionRequest(**raw)
+        assert req.benchmarks is not None
+        b = req.benchmarks[0]
+        assert b.primary_score is not None
+        assert b.primary_score.metric == "hellaswag.em"
+        assert b.pass_criteria is not None
+        assert b.pass_criteria.threshold == 0.99
+        # Verify the fields survive serialisation (what the CLI sends to the server)
+        payload = req.model_dump(exclude_none=True)
+        bench_payload = payload["benchmarks"][0]
+        assert bench_payload["primary_score"]["metric"] == "hellaswag.em"
+        assert bench_payload["pass_criteria"]["threshold"] == 0.99
 
 
 class TestCollectionRef:

--- a/tests/unit/test_models_api.py
+++ b/tests/unit/test_models_api.py
@@ -390,7 +390,10 @@ class TestBenchmarkConfig:
             pass_criteria=PassCriteria(threshold=0.99),
         )
         data = cfg.model_dump(exclude_none=True)
-        assert data["primary_score"] == {"metric": "hellaswag.em", "lower_is_better": False}
+        assert data["primary_score"] == {
+            "metric": "hellaswag.em",
+            "lower_is_better": False,
+        }
         assert data["pass_criteria"] == {"threshold": 0.99}
 
     def test_fields_omitted_when_none(self) -> None:
@@ -403,7 +406,8 @@ class TestBenchmarkConfig:
         """Regression test: per-benchmark overrides must survive YAML→model→dump→server."""
         import yaml
 
-        raw = yaml.safe_load("""
+        raw = yaml.safe_load(
+            """
 name: violations-demo
 model:
   url: http://vllm:8000/v1
@@ -417,7 +421,8 @@ benchmarks:
       threshold: 0.99
     parameters:
       num_examples: 10
-""")
+"""
+        )
         req = JobSubmissionRequest(**raw)
         assert req.benchmarks is not None
         b = req.benchmarks[0]


### PR DESCRIPTION
## What and why

CLI's `BenchmarkConfig` was missing `primary_score` and `pass_criteria` fields. When a job YAML specified per-benchmark overrides for these (e.g. a custom score metric or a stricter pass threshold), Pydantic silently dropped them before the request reached the server. The server then fell back to the provider's default threshold, so threshold-based signals (the `ThresholdViolated` phase label and `EvaluationThresholdViolated` Kubernetes event) never fired, even when the measured score was well below the user-specified threshold.

Closes https://redhat.atlassian.net/browse/RHOAIENG-82840

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [ ] Tested manually

Added `TestBenchmarkConfig` in `tests/unit/test_models_api.py` covering:
- fields default to `None` and are excluded from `model_dump(exclude_none=True)`
- `primary_score` and `pass_criteria` are accepted and serialised correctly
- regression test: a full YAML job config round-trips through `JobSubmissionRequest` with both overrides preserved in the serialised payload

## Breaking changes

`BenchmarkConfig` gains two new optional fields (`primary_score`, `pass_criteria`).
Both default to `None`, existing code that constructs or validates `BenchmarkConfig` without these fields is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Benchmark configurations can now optionally define a primary score and pass criteria.
  * These settings are preserved when configurations are loaded from YAML and included in job submissions.
  * Optional settings are omitted from serialized output when not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->