### PR TITLE
feat(adapter): support local-mode model auth resolution

### DIFF
--- a/src/evalhub/adapter/auth.py
+++ b/src/evalhub/adapter/auth.py
@@ -3,8 +3,8 @@
 In Kubernetes the auth files live under a well-known mount
 (``/var/run/secrets/model``).  In local mode, when ``job_spec.model.auth``
 is present, the directory is derived from its ``secret_ref`` field which
-points to a user-provided filesystem path that may contain ``api-key``,
-``hf-token``, and ``ca_cert`` files.
+must be a ``file:///`` URL pointing to a directory that may contain
+``api-key``, ``hf-token``, and ``ca_cert`` files.
 
 The job spec is discovered automatically from ``EVALHUB_JOB_SPEC_PATH``
 (or the mode-dependent default) — callers do not need to pass it in.
@@ -13,6 +13,7 @@ The job spec is discovered automatically from ``EVALHUB_JOB_SPEC_PATH``
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import urlparse
 
 from .config import EvalHubMode, get_job_spec_path
 from .models.job import JobSpec
@@ -20,6 +21,17 @@ from .settings import AdapterSettings
 
 logger = logging.getLogger(__name__)
 _MODEL_AUTH_DIR = Path("/var/run/secrets/model")
+
+
+def _parse_file_url(url: str) -> Path:
+    parsed = urlparse(url)
+    if parsed.scheme != "file" or parsed.path == "":
+        raise ValueError(f"secret_ref must be a file:/// URL in local mode, got: {url}")
+    if parsed.netloc:
+        raise ValueError(
+            f"Malformed file URL (use file:///path, not file://path): {url}"
+        )
+    return Path(parsed.path)
 
 
 def _resolve_auth_dir() -> Path:
@@ -31,9 +43,12 @@ def _resolve_auth_dir() -> Path:
 
     settings = AdapterSettings.from_env()
     if settings.mode == EvalHubMode.LOCAL and job_spec.model.auth is not None:
-        ref = Path(job_spec.model.auth.secret_ref)
-        if ref.is_dir():
-            return ref
+        ref = _parse_file_url(job_spec.model.auth.secret_ref)
+        if not ref.is_dir():
+            raise ValueError(
+                f"secret_ref does not point to an existing directory: {ref}"
+            )
+        return ref
     return _MODEL_AUTH_DIR
 
 

--- a/src/evalhub/adapter/auth.py
+++ b/src/evalhub/adapter/auth.py
@@ -38,6 +38,8 @@ def _resolve_auth_dir() -> Path:
 
 
 def _read_key_from_dir(auth_dir: Path, key_name: str) -> str | None:
+    if not key_name or "/" in key_name or "\\" in key_name or key_name in (".", ".."):
+        return None
     path = auth_dir / key_name
     if not path.is_file():
         return None

--- a/src/evalhub/adapter/auth.py
+++ b/src/evalhub/adapter/auth.py
@@ -1,45 +1,95 @@
-"""Helpers for resolving model auth from environment."""
+"""Helpers for resolving model auth from environment.
+
+In Kubernetes the auth files live under a well-known mount
+(``/var/run/secrets/model``).  In local mode, when ``job_spec.model.auth``
+is present, the directory is derived from its ``secret_ref`` field which
+points to a user-provided filesystem path that may contain ``api-key``,
+``hf-token``, and ``ca_cert`` files.
+
+The job spec is discovered automatically from ``EVALHUB_JOB_SPEC_PATH``
+(or the mode-dependent default) — callers do not need to pass it in.
+"""
 
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from .config import EvalHubMode, get_job_spec_path
+from .models.job import JobSpec
+from .settings import AdapterSettings
+
 logger = logging.getLogger(__name__)
 _MODEL_AUTH_DIR = Path("/var/run/secrets/model")
 
 
-def read_model_auth_key(key_name: str) -> str | None:
-    """Read a specific key from the mounted model auth secret."""
-    cleaned = key_name.strip()
-    if not cleaned:
-        return None
-    path = _MODEL_AUTH_DIR / cleaned
+def _resolve_auth_dir() -> Path:
+    try:
+        job_spec = JobSpec.from_file(get_job_spec_path())
+    except (FileNotFoundError, ValueError) as exc:
+        logger.debug("Job spec not available: %s", exc)
+        return _MODEL_AUTH_DIR
+
+    settings = AdapterSettings.from_env()
+    if settings.mode == EvalHubMode.LOCAL and job_spec.model.auth is not None:
+        ref = Path(job_spec.model.auth.secret_ref)
+        if ref.is_dir():
+            return ref
+    return _MODEL_AUTH_DIR
+
+
+def _read_key_from_dir(auth_dir: Path, key_name: str) -> str | None:
+    path = auth_dir / key_name
     if not path.is_file():
         return None
     try:
         value = path.read_text(encoding="utf-8").strip()
-    except (OSError, UnicodeDecodeError, ValueError) as exc:
-        logger.warning("Failed to read model auth key %s", cleaned, exc_info=exc)
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("Failed to read model auth key %s", key_name, exc_info=exc)
         return None
     return value or None
 
 
+def read_model_auth_key(key_name: str) -> str | None:
+    """Read a specific key from the model auth secret directory.
+
+    The auth directory is resolved automatically from the job spec
+    (via ``EVALHUB_JOB_SPEC_PATH``) in local mode, or from the default
+    Kubernetes mount path.
+    """
+    cleaned = key_name.strip()
+    if not cleaned:
+        return None
+    return _read_key_from_dir(_resolve_auth_dir(), cleaned)
+
+
 @dataclass
 class ModelCredentials:
-    """Resolved model credentials from the pod environment.
+    """Resolved model credentials.
 
-    api_key holds the ref token (e.g. 'api-key:ref') that the sidecar
-    proxy resolves to the real credential. CA cert and SA token injection
-    are handled transparently by the sidecar — not the adapter.
+    In Kubernetes ``api_key`` holds a ref token (e.g. ``"api-key:ref"``)
+    resolved by the sidecar proxy.  In local mode ``api_key`` is the
+    actual credential — the adapter sets the ``Authorization`` header
+    directly.
+
+    ``hf_token`` is the Hugging Face token from the ``hf-token`` file.
+    ``ca_cert_path`` points to the ``ca_cert`` file when present.
     """
 
     api_key: str | None = field(default=None, repr=False)
+    hf_token: str | None = field(default=None, repr=False)
+    ca_cert_path: Path | None = field(default=None)
 
 
 def resolve_model_credentials() -> ModelCredentials:
-    """Resolve model authentication from the pod environment.
+    """Resolve model authentication from the auth secret directory.
 
-    Reads the api-key ref token from the mounted model auth secret.
-    CA cert and SA token injection are handled by the sidecar proxy.
+    Reads ``api-key``, ``hf-token``, and checks for ``ca_cert``.
+    The auth directory is resolved automatically from the job spec.
     """
-    return ModelCredentials(api_key=read_model_auth_key("api-key"))
+    auth_dir = _resolve_auth_dir()
+    ca_cert = auth_dir / "ca_cert"
+    return ModelCredentials(
+        api_key=_read_key_from_dir(auth_dir, "api-key"),
+        hf_token=_read_key_from_dir(auth_dir, "hf-token"),
+        ca_cert_path=ca_cert if ca_cert.is_file() else None,
+    )

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -65,7 +65,11 @@ class ModelAuth(BaseModel):
     """Authentication configuration for the model endpoint."""
 
     secret_ref: str = Field(
-        ..., description="Kubernetes Secret name containing model credentials"
+        ...,
+        description=(
+            "Kubernetes Secret name (k8s mode) or file:/// URL pointing to a "
+            "local directory containing credential files (local mode)"
+        ),
     )
 
     @field_validator("secret_ref")

--- a/tests/unit/test_adapter_auth.py
+++ b/tests/unit/test_adapter_auth.py
@@ -171,6 +171,33 @@ class TestReadModelAuthKey:
 
         assert read_model_auth_key("api-key") == "key-with-whitespace"
 
+    @pytest.mark.parametrize(
+        "key_name",
+        [
+            "/etc/passwd",
+            "../secret",
+            "../../etc/shadow",
+            "subdir/file",
+            "a\\b",
+            ".",
+            "..",
+        ],
+    )
+    def test_rejects_path_traversal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        key_name: str,
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert read_model_auth_key(key_name) is None
+
     def test_backward_compat_no_env_var(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_adapter_auth.py
+++ b/tests/unit/test_adapter_auth.py
@@ -25,6 +25,10 @@ _MINIMAL_JOB_SPEC_FIELDS: dict[str, Any] = {
 }
 
 
+def _file_url(path: Path) -> str:
+    return path.as_uri()
+
+
 def _make_job_spec(secret_ref: str) -> JobSpec:
     return JobSpec(
         model=ModelConfig(
@@ -71,7 +75,7 @@ class TestResolveAuthDir:
         monkeypatch.setenv("EVALHUB_MODE", "k8s")
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
@@ -83,7 +87,7 @@ class TestResolveAuthDir:
         monkeypatch.setenv("EVALHUB_MODE", "local")
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
@@ -99,15 +103,42 @@ class TestResolveAuthDir:
 
         assert _resolve_auth_dir() == Path("/var/run/secrets/model")
 
-    def test_local_mode_nonexistent_dir_returns_default(
+    def test_local_mode_nonexistent_dir_raises(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.setenv("EVALHUB_MODE", "local")
-        spec = _make_job_spec(str(tmp_path / "does-not-exist"))
+        spec = _make_job_spec(_file_url(tmp_path / "does-not-exist"))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
-        assert _resolve_auth_dir() == Path("/var/run/secrets/model")
+        with pytest.raises(ValueError, match="existing directory"):
+            _resolve_auth_dir()
+
+    def test_local_mode_plain_path_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        with pytest.raises(ValueError, match="must be a file:/// URL"):
+            _resolve_auth_dir()
+
+    def test_local_mode_malformed_file_url_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        spec = _make_job_spec(f"file://{auth_dir.name}/{auth_dir}")
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        with pytest.raises(ValueError, match="file:///path, not file://path"):
+            _resolve_auth_dir()
 
 
 # ---------------------------------------------------------------------------
@@ -123,7 +154,7 @@ class TestReadModelAuthKey:
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
         (auth_dir / "api-key").write_text("my-secret-key\n")
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
@@ -135,7 +166,7 @@ class TestReadModelAuthKey:
         monkeypatch.setenv("EVALHUB_MODE", "local")
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
@@ -152,7 +183,7 @@ class TestReadModelAuthKey:
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
         (auth_dir / "api-key").write_text("")
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
@@ -165,7 +196,7 @@ class TestReadModelAuthKey:
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
         (auth_dir / "api-key").write_text("  key-with-whitespace  \n")
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
@@ -192,7 +223,7 @@ class TestReadModelAuthKey:
         monkeypatch.setenv("EVALHUB_MODE", "local")
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
@@ -221,7 +252,7 @@ class TestResolveModelCredentials:
         (auth_dir / "api-key").write_text("real-api-key")
         (auth_dir / "hf-token").write_text("hf-abc123")
         (auth_dir / "ca_cert").write_text("-----BEGIN CERTIFICATE-----")
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
@@ -238,7 +269,7 @@ class TestResolveModelCredentials:
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
         (auth_dir / "api-key").write_text("only-api-key")
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 
@@ -255,7 +286,7 @@ class TestResolveModelCredentials:
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
         (auth_dir / "ca_cert").mkdir()
-        spec = _make_job_spec(str(auth_dir))
+        spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
 

--- a/tests/unit/test_adapter_auth.py
+++ b/tests/unit/test_adapter_auth.py
@@ -1,0 +1,269 @@
+"""Unit tests for adapter model auth resolution."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from evalhub.adapter.auth import (
+    ModelCredentials,
+    _resolve_auth_dir,
+    read_model_auth_key,
+    resolve_model_credentials,
+)
+from evalhub.adapter.models.job import JobSpec
+from evalhub.models.api import ModelAuth, ModelConfig
+
+pytestmark = pytest.mark.unit
+
+_MINIMAL_JOB_SPEC_FIELDS: dict[str, Any] = {
+    "id": "job-1",
+    "provider_id": "prov-1",
+    "benchmark_id": "bench-1",
+    "benchmark_index": 0,
+    "parameters": {},
+    "callback_url": "http://localhost:8080",
+}
+
+
+def _make_job_spec(secret_ref: str) -> JobSpec:
+    return JobSpec(
+        model=ModelConfig(
+            url="http://model:8000/v1",
+            name="test-model",
+            auth=ModelAuth(secret_ref=secret_ref),
+        ),
+        **_MINIMAL_JOB_SPEC_FIELDS,
+    )
+
+
+def _make_job_spec_no_auth() -> JobSpec:
+    return JobSpec(
+        model=ModelConfig(
+            url="http://model:8000/v1",
+            name="test-model",
+        ),
+        **_MINIMAL_JOB_SPEC_FIELDS,
+    )
+
+
+def _write_job_json(tmp_path: Path, spec: JobSpec) -> Path:
+    """Write a job.json file and return the path."""
+    job_json = tmp_path / "job.json"
+    job_json.write_text(spec.model_dump_json(), encoding="utf-8")
+    return job_json
+
+
+# ---------------------------------------------------------------------------
+# _resolve_auth_dir
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAuthDir:
+    def test_no_job_spec_file_returns_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(tmp_path / "missing.json"))
+        assert _resolve_auth_dir() == Path("/var/run/secrets/model")
+
+    def test_k8s_mode_returns_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "k8s")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert _resolve_auth_dir() == Path("/var/run/secrets/model")
+
+    def test_local_mode_uses_secret_ref(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert _resolve_auth_dir() == auth_dir
+
+    def test_local_mode_no_auth_returns_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        spec = _make_job_spec_no_auth()
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert _resolve_auth_dir() == Path("/var/run/secrets/model")
+
+    def test_local_mode_nonexistent_dir_returns_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        spec = _make_job_spec(str(tmp_path / "does-not-exist"))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert _resolve_auth_dir() == Path("/var/run/secrets/model")
+
+
+# ---------------------------------------------------------------------------
+# read_model_auth_key
+# ---------------------------------------------------------------------------
+
+
+class TestReadModelAuthKey:
+    def test_reads_key_from_local_auth_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        (auth_dir / "api-key").write_text("my-secret-key\n")
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert read_model_auth_key("api-key") == "my-secret-key"
+
+    def test_returns_none_when_file_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert read_model_auth_key("api-key") is None
+
+    def test_returns_none_for_empty_key_name(self) -> None:
+        assert read_model_auth_key("") is None
+        assert read_model_auth_key("   ") is None
+
+    def test_returns_none_for_empty_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        (auth_dir / "api-key").write_text("")
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert read_model_auth_key("api-key") is None
+
+    def test_strips_whitespace(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        (auth_dir / "api-key").write_text("  key-with-whitespace  \n")
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert read_model_auth_key("api-key") == "key-with-whitespace"
+
+    def test_backward_compat_no_env_var(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(tmp_path / "missing.json"))
+        result = read_model_auth_key("api-key")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_model_credentials
+# ---------------------------------------------------------------------------
+
+
+class TestResolveModelCredentials:
+    def test_resolves_all_keys_local_mode(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        (auth_dir / "api-key").write_text("real-api-key")
+        (auth_dir / "hf-token").write_text("hf-abc123")
+        (auth_dir / "ca_cert").write_text("-----BEGIN CERTIFICATE-----")
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        creds = resolve_model_credentials()
+
+        assert creds.api_key == "real-api-key"
+        assert creds.hf_token == "hf-abc123"
+        assert creds.ca_cert_path == auth_dir / "ca_cert"
+
+    def test_missing_optional_keys(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        (auth_dir / "api-key").write_text("only-api-key")
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        creds = resolve_model_credentials()
+
+        assert creds.api_key == "only-api-key"
+        assert creds.hf_token is None
+        assert creds.ca_cert_path is None
+
+    def test_no_ca_cert_path_when_not_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        (auth_dir / "ca_cert").mkdir()
+        spec = _make_job_spec(str(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        creds = resolve_model_credentials()
+        assert creds.ca_cert_path is None
+
+    def test_backward_compat_no_job_spec(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(tmp_path / "missing.json"))
+        creds = resolve_model_credentials()
+        assert isinstance(creds, ModelCredentials)
+        assert creds.api_key is None
+        assert creds.hf_token is None
+        assert creds.ca_cert_path is None
+
+
+# ---------------------------------------------------------------------------
+# ModelCredentials
+# ---------------------------------------------------------------------------
+
+
+class TestModelCredentials:
+    def test_defaults(self) -> None:
+        creds = ModelCredentials()
+        assert creds.api_key is None
+        assert creds.hf_token is None
+        assert creds.ca_cert_path is None
+
+    def test_secrets_not_in_repr(self) -> None:
+        creds = ModelCredentials(api_key="secret", hf_token="token")
+        r = repr(creds)
+        assert "secret" not in r
+        assert "token" not in r
+
+    def test_ca_cert_path_in_repr(self) -> None:
+        creds = ModelCredentials(ca_cert_path=Path("/some/ca_cert"))
+        assert "ca_cert" in repr(creds)


### PR DESCRIPTION


## What and why

For local mode the functionality seen in k8s; were not applicable till now
```python
read_model_auth_key("api-key")
read_model_auth_key("hf-token")
# or simply
resolve_model_credentials()
```
k8s mount them as secret and the function listed above look them up in standard path.

For local, we have taken the approach of: `model.auth.secret_ref` now point to path in file-system , where this is available from job.json pointed by `EVALHUB_JOB_SPEC_PATH` env var in the adapter.
```yaml
name: math-job
model:
  url: https://vllm-sim2-evalhub-test.apps.rosa.gbn-dev.vqoo.p3.openshiftapps.com/v1
  name: ibm-granite/granite-3.3-2b-instruct
  auth:
    secret_ref: file:///Users/gnaulak/workspace/secret_ref/vllm-sim2-secret-all << filesystem path
benchmarks:
  - id: gsm8k
    provider_id: 436878b1-fc6c-49d2-98e6-1f9efe9eef3b
    parameters:
      num_examples: 3
      num_few_shot: 0
```

```text
╰─➤  tree /Users/gnaulak/workspace/secret_ref/vllm-sim2-secret-all
/Users/gnaulak/workspace/secret_ref/vllm-sim2-secret-all
├── api-key
├── ca_cert
└── hf-token

1 directory, 3 files
```
<img width="877" height="899" alt="Screenshot 2026-08-14 at 2 01 21 PM" src="https://github.com/user-attachments/assets/bc00645f-8457-4484-9d50-89ce0070650f" />
<img width="874" height="595" alt="Screenshot 2026-08-14 at 2 03 17 PM" src="https://github.com/user-attachments/assets/2c31c001-f4ed-4efb-9423-9d25c938bf5d" />



Closes # Part delivery of https://redhat.atlassian.net/browse/RHOAIENG-81188

Sidecar/Evalhub server updates here: https://github.com/eval-hub/eval-hub/pull/900
+ https://github.com/eval-hub/eval-hub/pull/910 `file:///` URI schema

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually
Tested E2E with local mode changes with lighteval in local

## Breaking changes

No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added support for resolving Hugging Face tokens and CA certificate paths alongside API keys.
* Authentication now automatically selects local credential directories or Kubernetes-mounted secrets.
* Credential files are handled more reliably, including missing, empty, malformed, and whitespace-padded values.

## Bug Fixes

* Improved warnings and fallback behavior when authentication files or job specifications cannot be read.
* Added protection against invalid credential file paths.

## Documentation

* Clarified that credentials can be supplied through a Kubernetes Secret or a local `file:///` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->