### PR TITLE
feat(cli): auto-generate default server config on first run

### DIFF
--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -99,24 +99,25 @@ def _wait_for_healthy(port: int, timeout: float, *, tls: bool = False) -> bool:
     return _health_check(port, tls=tls)
 
 
-def _resolve_config_dir(ctx: click.Context) -> Path:
+def _resolve_config_dir(ctx: click.Context) -> tuple[Path, bool]:
+    """Return (config_dir, user_provided) for the active profile."""
     data = cfg.load_config()
-    return cfg.resolve_component_config_dir(
+    profile = ctx.obj.get("profile")
+    profile_data = cfg.get_profile(data, profile)
+    user_provided = "server_config_file" in profile_data
+    config_dir = cfg.resolve_component_config_dir(
         data,
         SERVER_STATE_DIR,
-        profile=ctx.obj.get("profile"),
+        profile=profile,
     )
+    return config_dir, user_provided
 
 
 def _ensure_config(config_dir: Path) -> None:
     config_path = config_dir / "config.yaml"
     config_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        with open(config_path, "x") as f:
-            f.write(_DEFAULT_SERVER_CONFIG)
-    except FileExistsError:
-        return
-    click.echo(f"No server config found. Writing defaults to {config_path}.")
+    config_path.write_text(_DEFAULT_SERVER_CONFIG)
+    click.echo(f"Using default server config at {config_path}.")
 
 
 @click.group()
@@ -135,8 +136,9 @@ def server_run(ctx: click.Context) -> None:
       evalhub --profile staging server run
     """
     binary = find_binary("eval-hub-server", "EVALHUB_SERVER_BIN")
-    cfg_dir = _resolve_config_dir(ctx)
-    _ensure_config(cfg_dir)
+    cfg_dir, user_provided = _resolve_config_dir(ctx)
+    if not user_provided:
+        _ensure_config(cfg_dir)
 
     run_foreground([binary, "-local", "-configdir", str(cfg_dir)], ctx)
 
@@ -154,8 +156,9 @@ def server_start(ctx: click.Context) -> None:
     require_not_running(PID_FILE, "Server", "evalhub server stop")
 
     binary = find_binary("eval-hub-server", "EVALHUB_SERVER_BIN")
-    cfg_dir = _resolve_config_dir(ctx)
-    _ensure_config(cfg_dir)
+    cfg_dir, user_provided = _resolve_config_dir(ctx)
+    if not user_provided:
+        _ensure_config(cfg_dir)
 
     port, tls = _read_server_config(cfg_dir)
     scheme = "https" if tls else "http"
@@ -211,7 +214,7 @@ def server_status(ctx: click.Context) -> None:
     Examples:
       evalhub server status
     """
-    cfg_dir = _resolve_config_dir(ctx)
+    cfg_dir, _ = _resolve_config_dir(ctx)
     port, tls = _read_server_config(cfg_dir)
     scheme = "https" if tls else "http"
 

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -110,10 +110,12 @@ def _resolve_config_dir(ctx: click.Context) -> Path:
 
 def _ensure_config(config_dir: Path) -> None:
     config_path = config_dir / "config.yaml"
-    if config_path.exists():
-        return
     config_dir.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(_DEFAULT_SERVER_CONFIG)
+    try:
+        with open(config_path, "x") as f:
+            f.write(_DEFAULT_SERVER_CONFIG)
+    except FileExistsError:
+        return
     click.echo(f"No server config found. Writing defaults to {config_path}.")
 
 

--- a/src/evalhub/cli/server_cmd.py
+++ b/src/evalhub/cli/server_cmd.py
@@ -31,6 +31,15 @@ _STARTUP_POLL = 0.5
 _STOP_TIMEOUT = 5.0
 _DEFAULT_PORT = 8080
 
+_DEFAULT_SERVER_CONFIG = """\
+service:
+  port: 8080
+
+database:
+  driver: sqlite
+  url: "file::eval_hub:?mode=memory&cache=shared"
+"""
+
 
 def _read_server_config(config_dir: Path) -> tuple[int, bool]:
     config_path = config_dir / "config.yaml"
@@ -99,12 +108,13 @@ def _resolve_config_dir(ctx: click.Context) -> Path:
     )
 
 
-def _require_config(config_dir: Path) -> None:
-    if not (config_dir / "config.yaml").exists():
-        raise click.ClickException(
-            f"No server config found at {config_dir / 'config.yaml'}.\n"
-            "Set one first with: evalhub config set server_config_file <path>"
-        )
+def _ensure_config(config_dir: Path) -> None:
+    config_path = config_dir / "config.yaml"
+    if config_path.exists():
+        return
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(_DEFAULT_SERVER_CONFIG)
+    click.echo(f"No server config found. Writing defaults to {config_path}.")
 
 
 @click.group()
@@ -124,7 +134,7 @@ def server_run(ctx: click.Context) -> None:
     """
     binary = find_binary("eval-hub-server", "EVALHUB_SERVER_BIN")
     cfg_dir = _resolve_config_dir(ctx)
-    _require_config(cfg_dir)
+    _ensure_config(cfg_dir)
 
     run_foreground([binary, "-local", "-configdir", str(cfg_dir)], ctx)
 
@@ -143,7 +153,7 @@ def server_start(ctx: click.Context) -> None:
 
     binary = find_binary("eval-hub-server", "EVALHUB_SERVER_BIN")
     cfg_dir = _resolve_config_dir(ctx)
-    _require_config(cfg_dir)
+    _ensure_config(cfg_dir)
 
     port, tls = _read_server_config(cfg_dir)
     scheme = "https" if tls else "http"

--- a/tests/unit/test_cli_server.py
+++ b/tests/unit/test_cli_server.py
@@ -147,23 +147,32 @@ def test_server_run_foreground(
     assert "-configdir" in cmd
 
 
+@patch("evalhub.cli._process.subprocess.run")
 @patch(
     "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
-def test_server_run_no_config_errors(
+def test_server_run_generates_default_config_when_missing(
     mock_find: MagicMock,
+    mock_run: MagicMock,
     runner: CliRunner,
     tmp_path: Path,
     config_file: Path,
 ) -> None:
     _seed_profile(config_file)
+    mock_run.return_value = MagicMock(returncode=0)
 
     with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path):
         result = runner.invoke(main, ["server", "run"])
 
-    assert result.exit_code != 0
-    assert "No server config found" in result.output
+    assert result.exit_code == 0, result.output
+    assert "Writing defaults" in result.output
+
+    generated = tmp_path / "default" / "config.yaml"
+    assert generated.exists()
+    loaded = yaml.safe_load(generated.read_text())
+    assert loaded["service"]["port"] == 8080
+    assert loaded["database"]["driver"] == "sqlite"
 
 
 def test_server_run_binary_not_found(
@@ -358,25 +367,42 @@ def test_server_start_tls_uses_https_scheme(
     mock_healthy.assert_called_once_with(8080, 30.0, tls=True)
 
 
+@patch("evalhub.cli.server_cmd._wait_for_healthy", return_value=True)
+@patch("evalhub.cli._process.subprocess.Popen")
 @patch(
     "evalhub.cli.server_cmd.find_binary",
     return_value="/usr/bin/eval-hub-server",
 )
-def test_server_start_no_config_errors(
+def test_server_start_generates_default_config_when_missing(
     mock_find: MagicMock,
+    mock_popen: MagicMock,
+    mock_healthy: MagicMock,
     runner: CliRunner,
     tmp_path: Path,
     config_file: Path,
 ) -> None:
     _seed_profile(config_file)
 
+    mock_proc = MagicMock()
+    mock_proc.pid = 12345
+    mock_proc.poll.return_value = None
+    mock_popen.return_value = mock_proc
+
+    pid_file = tmp_path / "pid"
     with patch("evalhub.cli.server_cmd.SERVER_STATE_DIR", tmp_path), patch(
-        "evalhub.cli.server_cmd.PID_FILE", tmp_path / "pid"
+        "evalhub.cli.server_cmd.PID_FILE", pid_file
     ), patch("evalhub.cli.server_cmd.LOG_FILE", tmp_path / "server.log"):
         result = runner.invoke(main, ["server", "start"])
 
-    assert result.exit_code != 0
-    assert "No server config found" in result.output
+    assert result.exit_code == 0, result.output
+    assert "Writing defaults" in result.output
+    assert "12345" in result.output
+
+    generated = tmp_path / "default" / "config.yaml"
+    assert generated.exists()
+    loaded = yaml.safe_load(generated.read_text())
+    assert loaded["service"]["port"] == 8080
+    assert loaded["database"]["driver"] == "sqlite"
 
 
 # ---------------------------------------------------------------------------
@@ -847,3 +873,38 @@ def test_config_set_then_unfold_roundtrip(
     assert unfold_result.exit_code == 0, unfold_result.output
     loaded = yaml.safe_load(unfold_result.output)
     assert loaded == original
+
+
+# ---------------------------------------------------------------------------
+# _ensure_config
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_config_writes_default(tmp_path: Path) -> None:
+    from evalhub.cli.server_cmd import _DEFAULT_SERVER_CONFIG, _ensure_config
+
+    config_dir = tmp_path / "profile"
+    _ensure_config(config_dir)
+
+    config_path = config_dir / "config.yaml"
+    assert config_path.exists()
+    assert config_path.read_text() == _DEFAULT_SERVER_CONFIG
+
+    loaded = yaml.safe_load(config_path.read_text())
+    assert loaded["service"]["port"] == 8080
+    assert loaded["database"]["driver"] == "sqlite"
+    assert "eval_hub" in loaded["database"]["url"]
+
+
+def test_ensure_config_preserves_existing(tmp_path: Path) -> None:
+    from evalhub.cli.server_cmd import _ensure_config
+
+    config_dir = tmp_path / "profile"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.yaml"
+    custom = yaml.safe_dump({"service": {"port": 9999}})
+    config_path.write_text(custom)
+
+    _ensure_config(config_dir)
+
+    assert config_path.read_text() == custom

--- a/tests/unit/test_cli_server.py
+++ b/tests/unit/test_cli_server.py
@@ -166,7 +166,7 @@ def test_server_run_generates_default_config_when_missing(
         result = runner.invoke(main, ["server", "run"])
 
     assert result.exit_code == 0, result.output
-    assert "Writing defaults" in result.output
+    assert "Using default server config" in result.output
 
     generated = tmp_path / "default" / "config.yaml"
     assert generated.exists()
@@ -395,7 +395,7 @@ def test_server_start_generates_default_config_when_missing(
         result = runner.invoke(main, ["server", "start"])
 
     assert result.exit_code == 0, result.output
-    assert "Writing defaults" in result.output
+    assert "Using default server config" in result.output
     assert "12345" in result.output
 
     generated = tmp_path / "default" / "config.yaml"
@@ -896,15 +896,14 @@ def test_ensure_config_writes_default(tmp_path: Path) -> None:
     assert loaded["database"]["url"] == "file::eval_hub:?mode=memory&cache=shared"
 
 
-def test_ensure_config_preserves_existing(tmp_path: Path) -> None:
-    from evalhub.cli.server_cmd import _ensure_config
+def test_ensure_config_overwrites_existing(tmp_path: Path) -> None:
+    from evalhub.cli.server_cmd import _DEFAULT_SERVER_CONFIG, _ensure_config
 
     config_dir = tmp_path / "profile"
     config_dir.mkdir(parents=True)
     config_path = config_dir / "config.yaml"
-    custom = yaml.safe_dump({"service": {"port": 9999}})
-    config_path.write_text(custom)
+    config_path.write_text(yaml.safe_dump({"service": {"port": 9999}}))
 
     _ensure_config(config_dir)
 
-    assert config_path.read_text() == custom
+    assert config_path.read_text() == _DEFAULT_SERVER_CONFIG

--- a/tests/unit/test_cli_server.py
+++ b/tests/unit/test_cli_server.py
@@ -893,7 +893,7 @@ def test_ensure_config_writes_default(tmp_path: Path) -> None:
     loaded = yaml.safe_load(config_path.read_text())
     assert loaded["service"]["port"] == 8080
     assert loaded["database"]["driver"] == "sqlite"
-    assert "eval_hub" in loaded["database"]["url"]
+    assert loaded["database"]["url"] == "file::eval_hub:?mode=memory&cache=shared"
 
 
 def test_ensure_config_preserves_existing(tmp_path: Path) -> None:


### PR DESCRIPTION

## What and why

Replace _require_config with _ensure_config so that `evalhub server run` and `evalhub server start` write a minimal default config (SQLite in-memory, port 8080) when no server_config_file has been set, removing the mandatory `evalhub config set server_config_file` prerequisite.


Closes # https://redhat.atlassian.net/browse/RHOAIENG-84414

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [x] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually
```
╰─➤  evalhub server start
Using default server config at /Users/gnaulak/.config/evalhub/server/server-defaults/config.yaml.
Server started (PID 42816).
  URL:  http://localhost:8080
  Logs: /Users/gnaulak/.config/evalhub/server/server.log
```
```
╰─➤  cat /Users/gnaulak/.config/evalhub/server/server-defaults/config.yaml
service:
  port: 8080

database:
  driver: sqlite
  url: "file::eval_hub:?mode=memory&cache=shared"
```
```
╰─➤  evalhub server run
Using default server config at /Users/gnaulak/.config/evalhub/server/server-defaults/config.yaml.
{"level":"info","ts":"2026-08-17T12:04:15.722+0530","caller":"config/loader.go:344","msg":"Start reading configuration","version":"1.0.1","build":"1.0.1","build_date":"2026-08-16T18:43:28+0530","dirs":["/Users/gnaulak/.config/evalhub/server/server-defaults"]}
```

## Breaking changes
No
<!-- If yes, describe migration path. Otherwise delete this section. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Server commands now automatically create a default configuration when no configuration file is found.
- The default setup uses port 8080 and an in-memory SQLite database.
- Both foreground `server run` and background `server start` support automatic configuration creation.
- Server status handling works with the generated default configuration.
- Existing custom configuration files are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->