### PR TITLE
feat(cli): add config create and delete profile commands

### DIFF
--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -52,7 +52,7 @@ def validate_profile_name(name: str) -> None:
     Raises ``click.ClickException`` if *name* contains path separators,
     traversal components, or characters outside a safe identifier set.
     """
-    if not name or not _PROFILE_NAME_RE.match(name) or ".." in name:
+    if not name or not _PROFILE_NAME_RE.fullmatch(name) or ".." in name:
         raise click.ClickException(
             f"Invalid profile name '{name}'. "
             "Names must be non-empty, use only [a-zA-Z0-9._-], "

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -237,6 +237,39 @@ def set_active_profile(data: dict[str, Any], profile: str) -> dict[str, Any]:
     return data
 
 
+def create_profile(data: dict[str, Any], name: str) -> dict[str, Any]:
+    """Explicitly create an empty profile.
+
+    Raises ``click.ClickException`` if a profile with *name* already exists.
+    """
+    profiles = data.setdefault("profiles", {})
+    if name in profiles:
+        raise click.ClickException(f"Profile '{name}' already exists.")
+    profiles[name] = {}
+    return data
+
+
+def delete_profile(data: dict[str, Any], name: str) -> dict[str, Any]:
+    """Remove a profile and its stored file-key artefacts.
+
+    Raises ``click.ClickException`` if *name* is the active profile or does
+    not exist.
+    """
+    active = get_active_profile(data)
+    if name == active:
+        raise click.ClickException(
+            f"Cannot delete the active profile '{name}'. "
+            f"Switch to another profile first with 'config use'."
+        )
+    profiles = data.get("profiles", {})
+    if name not in profiles:
+        raise click.ClickException(f"Profile '{name}' does not exist.")
+    del profiles[name]
+    for key in FILE_KEYS:
+        remove_file_key(key, name)
+    return data
+
+
 def parse_bool(value: Any, *, default: bool = False) -> bool:
     """Parse a config value as a boolean."""
     if value is None:

--- a/src/evalhub/cli/config.py
+++ b/src/evalhub/cli/config.py
@@ -17,6 +17,7 @@ Config is stored at ~/.config/evalhub/config.yaml with structure:
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import stat
 from pathlib import Path
@@ -41,6 +42,36 @@ SENSITIVE_KEYS = frozenset({"token"})
 FILE_KEYS = frozenset({"mcp_config_file", "server_config_file"})
 
 DEFAULT_PROFILE = "default"
+
+_PROFILE_NAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$")
+
+
+def validate_profile_name(name: str) -> None:
+    """Reject profile names that could escape filesystem boundaries.
+
+    Raises ``click.ClickException`` if *name* contains path separators,
+    traversal components, or characters outside a safe identifier set.
+    """
+    if not name or not _PROFILE_NAME_RE.match(name) or ".." in name:
+        raise click.ClickException(
+            f"Invalid profile name '{name}'. "
+            "Names must be non-empty, use only [a-zA-Z0-9._-], "
+            "start and end with an alphanumeric character, "
+            "and must not contain '..'."
+        )
+
+
+def _validate_path_within(path: Path, base: Path) -> None:
+    """Ensure *path* resolves inside *base*.
+
+    Raises ``click.ClickException`` if the resolved path escapes *base*.
+    """
+    try:
+        path.resolve().relative_to(base.resolve())
+    except ValueError:
+        raise click.ClickException(
+            f"Resolved path '{path}' escapes base directory '{base}'."
+        )
 
 
 def mask_value(
@@ -199,8 +230,10 @@ def store_file_key(key: str, src: Path, profile_name: str) -> str:
 
     Returns the absolute path of the stored copy.
     """
+    validate_profile_name(profile_name)
     base = _FILE_KEY_STORE_DIRS[key]
     dest_dir = base / profile_name
+    _validate_path_within(dest_dir, base)
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / "config.yaml"
     shutil.copy2(str(src), str(dest))
@@ -210,8 +243,10 @@ def store_file_key(key: str, src: Path, profile_name: str) -> str:
 
 def remove_file_key(key: str, profile_name: str) -> None:
     """Delete the stored file for *key* and clean up the directory if empty."""
+    validate_profile_name(profile_name)
     base = _FILE_KEY_STORE_DIRS[key]
     dest_dir = base / profile_name
+    _validate_path_within(dest_dir, base)
     dest = dest_dir / "config.yaml"
     if dest.exists():
         dest.unlink()
@@ -242,6 +277,7 @@ def create_profile(data: dict[str, Any], name: str) -> dict[str, Any]:
 
     Raises ``click.ClickException`` if a profile with *name* already exists.
     """
+    validate_profile_name(name)
     profiles = data.setdefault("profiles", {})
     if name in profiles:
         raise click.ClickException(f"Profile '{name}' already exists.")
@@ -255,6 +291,7 @@ def delete_profile(data: dict[str, Any], name: str) -> dict[str, Any]:
     Raises ``click.ClickException`` if *name* is the active profile or does
     not exist.
     """
+    validate_profile_name(name)
     active = get_active_profile(data)
     if name == active:
         raise click.ClickException(

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -1364,12 +1364,14 @@ def config(ctx: click.Context) -> None:
 
     \b
     Examples:
+      evalhub config create staging --activate
       evalhub config set base_url http://localhost:8080
       evalhub config set mcp_config_file mcp-config.yaml
       evalhub config set server_config_file myserver-config.yaml
       evalhub config get mcp_config_file --unfold
       evalhub config list
       evalhub config use prod
+      evalhub config delete staging
     """
 
 
@@ -1557,6 +1559,56 @@ def config_list(ctx: click.Context, *, show_all: bool = False) -> None:
         profile_name = profile or active
         prof = cfg.get_profile(data, profile=profile)
         _render_profile(profile_name, prof, data)
+        if len(data.get("profiles", {})) > 1:
+            click.echo("\n(use --all to see all profiles)")
+
+
+@config.command("create")
+@click.argument("name")
+@click.option(
+    "--activate",
+    is_flag=True,
+    default=False,
+    help="Set the new profile as the active profile.",
+)
+def config_create(name: str, *, activate: bool) -> None:
+    """Create a new configuration profile.
+
+    \b
+    Creates an empty profile that can then be populated with
+    'config set'. Use --activate to also switch to the new profile.
+
+    \b
+    Examples:
+      evalhub config create staging
+      evalhub config create prod --activate
+    """
+    data = cfg.load_config()
+    cfg.create_profile(data, name)
+    if activate:
+        cfg.set_active_profile(data, name)
+    cfg.save_config(data)
+    click.echo(f"Created profile '{name}'" + (" (active)" if activate else ""))
+
+
+@config.command("delete")
+@click.argument("name")
+def config_delete(name: str) -> None:
+    """Delete a configuration profile.
+
+    \b
+    Removes the profile and any stored file-key artefacts. The active
+    profile cannot be deleted — switch to another profile first.
+
+    \b
+    Examples:
+      evalhub config delete staging
+      evalhub config use default && evalhub config delete old-profile
+    """
+    data = cfg.load_config()
+    cfg.delete_profile(data, name)
+    cfg.save_config(data)
+    click.echo(f"Deleted profile '{name}'")
 
 
 @config.command("use")
@@ -1566,8 +1618,7 @@ def config_use(profile: str) -> None:
 
     \b
     Sets the given profile as the default for all subsequent commands.
-    The profile must already exist (create it by setting a value with
-    --profile).
+    The profile must already exist (create one with 'config create').
 
     \b
     Examples:

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -20,7 +20,6 @@ from evalhub.cli.config import (
     _validate_path_within,
     create_profile,
     delete_profile,
-    validate_profile_name,
     get_active_profile,
     get_profile,
     get_value,
@@ -34,6 +33,7 @@ from evalhub.cli.config import (
     set_active_profile,
     set_value,
     unset_value,
+    validate_profile_name,
 )
 from evalhub.cli.main import main
 
@@ -743,7 +743,6 @@ class TestValidatePathWithin:
         base.mkdir()
         with pytest.raises(Exception, match="escapes base directory"):
             _validate_path_within(base / ".." / "outside", base)
-
 
 
 # --- config create / delete CLI tests ---

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -17,8 +17,10 @@ from evalhub.cli.config import (
     OPTIONAL_KEYS,
     REQUIRED_KEYS,
     SENSITIVE_KEYS,
+    _validate_path_within,
     create_profile,
     delete_profile,
+    validate_profile_name,
     get_active_profile,
     get_profile,
     get_value,
@@ -663,6 +665,11 @@ class TestCreateProfile:
         create_profile(data, "new")
         assert data["active_profile"] == "default"
 
+    def test_rejects_traversal_name(self) -> None:
+        data: dict[str, Any] = {"active_profile": "default", "profiles": {}}
+        with pytest.raises(Exception, match="Invalid profile name"):
+            create_profile(data, "../escape")
+
 
 class TestDeleteProfile:
     def test_deletes_existing_profile(self) -> None:
@@ -689,6 +696,54 @@ class TestDeleteProfile:
         data: dict[str, Any] = {"active_profile": "default", "profiles": {}}
         with pytest.raises(Exception, match="does not exist"):
             delete_profile(data, "ghost")
+
+    def test_rejects_traversal_name(self) -> None:
+        data: dict[str, Any] = {
+            "active_profile": "default",
+            "profiles": {"default": {}},
+        }
+        with pytest.raises(Exception, match="Invalid profile name"):
+            delete_profile(data, "../escape")
+
+
+class TestValidateProfileName:
+    @pytest.mark.parametrize("name", ["default", "prod", "my-profile", "v1.2", "a"])
+    def test_accepts_valid_names(self, name: str) -> None:
+        validate_profile_name(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "",
+            "..",
+            "../etc",
+            "foo/../bar",
+            "/absolute",
+            "has/slash",
+            "has space",
+            ".leading-dot",
+            "-leading-dash",
+            "trailing-dot.",
+            "trailing-dash-",
+        ],
+    )
+    def test_rejects_unsafe_names(self, name: str) -> None:
+        with pytest.raises(Exception, match="Invalid profile name"):
+            validate_profile_name(name)
+
+
+class TestValidatePathWithin:
+    def test_accepts_path_within_base(self, tmp_path: Path) -> None:
+        base = tmp_path / "base"
+        base.mkdir()
+        _validate_path_within(base / "child", base)
+
+    def test_rejects_path_escaping_base(self, tmp_path: Path) -> None:
+        base = tmp_path / "base"
+        base.mkdir()
+        with pytest.raises(Exception, match="escapes base directory"):
+            _validate_path_within(base / ".." / "outside", base)
+
 
 
 # --- config create / delete CLI tests ---

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -17,6 +17,8 @@ from evalhub.cli.config import (
     OPTIONAL_KEYS,
     REQUIRED_KEYS,
     SENSITIVE_KEYS,
+    create_profile,
+    delete_profile,
     get_active_profile,
     get_profile,
     get_value,
@@ -636,3 +638,178 @@ class TestConfigUnsetCommand:
         assert "profile 'prod'" in result.output
         data = load_config()
         assert "token" not in data["profiles"]["prod"]
+
+
+# --- create / delete profile unit tests ---
+
+
+class TestCreateProfile:
+    def test_creates_empty_profile(self) -> None:
+        data: dict[str, Any] = {"active_profile": "default", "profiles": {}}
+        create_profile(data, "staging")
+        assert "staging" in data["profiles"]
+        assert data["profiles"]["staging"] == {}
+
+    def test_errors_on_duplicate(self) -> None:
+        data: dict[str, Any] = {
+            "active_profile": "default",
+            "profiles": {"staging": {"base_url": "http://localhost"}},
+        }
+        with pytest.raises(Exception, match="already exists"):
+            create_profile(data, "staging")
+
+    def test_does_not_change_active_profile(self) -> None:
+        data: dict[str, Any] = {"active_profile": "default", "profiles": {}}
+        create_profile(data, "new")
+        assert data["active_profile"] == "default"
+
+
+class TestDeleteProfile:
+    def test_deletes_existing_profile(self) -> None:
+        data: dict[str, Any] = {
+            "active_profile": "default",
+            "profiles": {
+                "default": {"base_url": "http://localhost"},
+                "staging": {"base_url": "http://staging"},
+            },
+        }
+        delete_profile(data, "staging")
+        assert "staging" not in data["profiles"]
+        assert "default" in data["profiles"]
+
+    def test_errors_on_active_profile(self) -> None:
+        data: dict[str, Any] = {
+            "active_profile": "default",
+            "profiles": {"default": {}},
+        }
+        with pytest.raises(Exception, match="Cannot delete the active profile"):
+            delete_profile(data, "default")
+
+    def test_errors_on_nonexistent_profile(self) -> None:
+        data: dict[str, Any] = {"active_profile": "default", "profiles": {}}
+        with pytest.raises(Exception, match="does not exist"):
+            delete_profile(data, "ghost")
+
+
+# --- config create / delete CLI tests ---
+
+
+class TestConfigCreateCommand:
+    def test_create_new_profile(self, runner: CliRunner, config_file: Path) -> None:
+        result = runner.invoke(main, ["config", "create", "staging"])
+        assert result.exit_code == 0
+        assert "Created profile 'staging'" in result.output
+        data = load_config()
+        assert "staging" in data["profiles"]
+        assert data["profiles"]["staging"] == {}
+
+    def test_create_with_activate(self, runner: CliRunner, config_file: Path) -> None:
+        result = runner.invoke(main, ["config", "create", "prod", "--activate"])
+        assert result.exit_code == 0
+        assert "(active)" in result.output
+        data = load_config()
+        assert data["active_profile"] == "prod"
+
+    def test_create_without_activate_keeps_active(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        result = runner.invoke(main, ["config", "create", "staging"])
+        assert result.exit_code == 0
+        data = load_config()
+        assert data["active_profile"] == DEFAULT_PROFILE
+
+    def test_create_duplicate_errors(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "create", "staging"])
+        result = runner.invoke(main, ["config", "create", "staging"])
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+    def test_create_then_set_values(self, runner: CliRunner, config_file: Path) -> None:
+        runner.invoke(main, ["config", "create", "staging", "--activate"])
+        runner.invoke(main, ["config", "set", "base_url", "http://staging:8080"])
+        data = load_config()
+        assert data["profiles"]["staging"]["base_url"] == "http://staging:8080"
+
+    def test_create_then_use(self, runner: CliRunner, config_file: Path) -> None:
+        runner.invoke(main, ["config", "create", "staging"])
+        result = runner.invoke(main, ["config", "use", "staging"])
+        assert result.exit_code == 0
+        assert "Active profile set to 'staging'" in result.output
+
+
+class TestConfigDeleteCommand:
+    def test_delete_inactive_profile(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "create", "staging"])
+        result = runner.invoke(main, ["config", "delete", "staging"])
+        assert result.exit_code == 0
+        assert "Deleted profile 'staging'" in result.output
+        data = load_config()
+        assert "staging" not in data["profiles"]
+
+    def test_delete_active_profile_errors(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "create", "staging", "--activate"])
+        result = runner.invoke(main, ["config", "delete", "staging"])
+        assert result.exit_code != 0
+        assert "Cannot delete the active profile" in result.output
+
+    def test_delete_nonexistent_profile_errors(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        result = runner.invoke(main, ["config", "delete", "ghost"])
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+
+    def test_delete_preserves_other_profiles(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://default:8080"])
+        runner.invoke(main, ["config", "create", "staging"])
+        runner.invoke(
+            main,
+            [
+                "--profile",
+                "staging",
+                "config",
+                "set",
+                "base_url",
+                "http://staging:8080",
+            ],
+        )
+        runner.invoke(main, ["config", "delete", "staging"])
+        data = load_config()
+        assert "default" in data["profiles"]
+        assert data["profiles"]["default"]["base_url"] == "http://default:8080"
+
+
+class TestConfigListHint:
+    def test_hint_shown_when_multiple_profiles(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://default:8080"])
+        runner.invoke(main, ["config", "create", "staging"])
+        result = runner.invoke(main, ["config", "list"])
+        assert result.exit_code == 0
+        assert "(use --all to see all profiles)" in result.output
+
+    def test_hint_not_shown_for_single_profile(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://default:8080"])
+        result = runner.invoke(main, ["config", "list"])
+        assert result.exit_code == 0
+        assert "--all" not in result.output
+
+    def test_hint_not_shown_with_all_flag(
+        self, runner: CliRunner, config_file: Path
+    ) -> None:
+        runner.invoke(main, ["config", "set", "base_url", "http://default:8080"])
+        runner.invoke(main, ["config", "create", "staging"])
+        result = runner.invoke(main, ["config", "list", "--all"])
+        assert result.exit_code == 0
+        assert "(use --all to see all profiles)" not in result.output

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -725,6 +725,7 @@ class TestValidateProfileName:
             "-leading-dash",
             "trailing-dot.",
             "trailing-dash-",
+            "staging\n",
         ],
     )
     def test_rejects_unsafe_names(self, name: str) -> None:


### PR DESCRIPTION


## What and why

Add explicit profile lifecycle management with 'config create' and 'config delete' subcommands, replacing the implicit profile creation via --profile flag. Includes --activate flag for create, protection against deleting the active profile, and a hint for --all on list.
```
evalhub config create test1 --activate # To create and active ; without "--activate" it does not activate only creates
evalhub config delete test1 # To delete
evalhub config list  <<< -- Gives this additional information "(use --all to see all profiles)" for profile discovery
```


Closes # https://redhat.atlassian.net/browse/RHOAIENG-82710

## Type

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

Help reflects the changes
```
╰─➤  evalhub config --help
Usage: evalhub config [OPTIONS] COMMAND [ARGS]...

  View and update CLI configuration.

  Configuration is stored in ~/.config/evalhub/config.yaml and
  supports multiple profiles. Use 'config set' to store values,
  'config get' to read them, 'config list' to see the full
  profile, 'config list --all' to list all profiles, and
  'config use' to switch profiles.

  File-based keys (e.g. mcp_config_file, server_config_file) store
  a path to a YAML file. Use 'config get <key> --unfold' to view
  the file contents.

  Examples:
    evalhub config create staging --activate
    evalhub config set base_url http://localhost:8080
    evalhub config set mcp_config_file mcp-config.yaml
    evalhub config set server_config_file myserver-config.yaml
    evalhub config get mcp_config_file --unfold
    evalhub config list
    evalhub config use prod
    evalhub config delete staging

Options:
  -h, --help  Show this message and exit.

Commands:
  create  Create a new configuration profile.
  delete  Delete a configuration profile.
  get     Get a configuration value from the active profile.
  list    List configuration values in the active profile.
  set     Set a configuration value in the active profile.
  unset   Remove a configuration key from the active profile.
  use     Switch the active configuration profile.
```

```
╰─➤  evalhub config create --help
Usage: evalhub config create [OPTIONS] NAME

  Create a new configuration profile.

  Creates an empty profile that can then be populated with
  'config set'. Use --activate to also switch to the new profile.

  Examples:
    evalhub config create staging
    evalhub config create prod --activate

Options:
  --activate  Set the new profile as the active profile.
  -h, --help  Show this message and exit.
```

```
╰─➤  evalhub config delete --help
Usage: evalhub config delete [OPTIONS] NAME

  Delete a configuration profile.

  Removes the profile and any stored file-key artefacts. The active
  profile cannot be deleted — switch to another profile first.

  Examples:
    evalhub config delete staging
    evalhub config use default && evalhub config delete old-profile

Options:
  -h, --help  Show this message and exit.
```

Create and activate
```
╰─➤  evalhub config create test2 --activate
Created profile 'test2' (active)
```

To delete a profile:
```
╰─➤  evalhub config use test1
Active profile set to 'test1'

╰─➤  evalhub config delete test2
Deleted profile 'test2'
```
`evalhub config list` shows updated message to discover profiles
```
╰─➤  evalhub config list
Profile: test1
  (no configuration values)

  Missing required keys: base_url, token, tenant

(use --all to see all profiles)
```


## Breaking changes
No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to create and delete configuration profiles.
  * Profiles can be optionally activated when created.
  * Deleting a profile removes its associated configuration artifacts.
  * Added validation for unsafe, duplicate, or missing profiles and prevented deletion of the active profile.
  * Improved configuration help and profile-listing guidance.

* **Tests**
  * Added coverage for profile creation, deletion, activation, switching, validation, and list guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->