### PR TITLE
fix(adapter): reject symlinks in model auth file resolution

### DIFF
--- a/src/evalhub/adapter/auth.py
+++ b/src/evalhub/adapter/auth.py
@@ -44,6 +44,8 @@ def _resolve_auth_dir() -> Path:
     settings = AdapterSettings.from_env()
     if settings.mode == EvalHubMode.LOCAL and job_spec.model.auth is not None:
         ref = _parse_file_url(job_spec.model.auth.secret_ref)
+        if ref.is_symlink():
+            raise ValueError(f"secret_ref must not be a symlink: {ref}")
         if not ref.is_dir():
             raise ValueError(
                 f"secret_ref does not point to an existing directory: {ref}"
@@ -52,11 +54,15 @@ def _resolve_auth_dir() -> Path:
     return _MODEL_AUTH_DIR
 
 
+def _is_regular_file(path: Path) -> bool:
+    return path.is_file() and not path.is_symlink()
+
+
 def _read_key_from_dir(auth_dir: Path, key_name: str) -> str | None:
     if not key_name or "/" in key_name or "\\" in key_name or key_name in (".", ".."):
         return None
     path = auth_dir / key_name
-    if not path.is_file():
+    if not _is_regular_file(path):
         return None
     try:
         value = path.read_text(encoding="utf-8").strip()
@@ -108,5 +114,5 @@ def resolve_model_credentials() -> ModelCredentials:
     return ModelCredentials(
         api_key=_read_key_from_dir(auth_dir, "api-key"),
         hf_token=_read_key_from_dir(auth_dir, "hf-token"),
-        ca_cert_path=ca_cert if ca_cert.is_file() else None,
+        ca_cert_path=ca_cert if _is_regular_file(ca_cert) else None,
     )

--- a/tests/unit/test_adapter_auth.py
+++ b/tests/unit/test_adapter_auth.py
@@ -140,6 +140,21 @@ class TestResolveAuthDir:
         with pytest.raises(ValueError, match="file:///path, not file://path"):
             _resolve_auth_dir()
 
+    def test_local_mode_symlink_dir_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        real_dir = tmp_path / "real-auth"
+        real_dir.mkdir()
+        link = tmp_path / "link-auth"
+        link.symlink_to(real_dir)
+        spec = _make_job_spec(_file_url(link))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        with pytest.raises(ValueError, match="must not be a symlink"):
+            _resolve_auth_dir()
+
 
 # ---------------------------------------------------------------------------
 # read_model_auth_key
@@ -229,6 +244,21 @@ class TestReadModelAuthKey:
 
         assert read_model_auth_key(key_name) is None
 
+    def test_rejects_symlinked_key_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        real_key = tmp_path / "real-api-key"
+        real_key.write_text("secret-via-symlink")
+        (auth_dir / "api-key").symlink_to(real_key)
+        spec = _make_job_spec(_file_url(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        assert read_model_auth_key("api-key") is None
+
     def test_backward_compat_no_env_var(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -286,6 +316,22 @@ class TestResolveModelCredentials:
         auth_dir = tmp_path / "model-auth"
         auth_dir.mkdir()
         (auth_dir / "ca_cert").mkdir()
+        spec = _make_job_spec(_file_url(auth_dir))
+        job_json = _write_job_json(tmp_path, spec)
+        monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))
+
+        creds = resolve_model_credentials()
+        assert creds.ca_cert_path is None
+
+    def test_rejects_symlinked_ca_cert(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("EVALHUB_MODE", "local")
+        auth_dir = tmp_path / "model-auth"
+        auth_dir.mkdir()
+        real_cert = tmp_path / "real_ca_cert"
+        real_cert.write_text("-----BEGIN CERTIFICATE-----")
+        (auth_dir / "ca_cert").symlink_to(real_cert)
         spec = _make_job_spec(_file_url(auth_dir))
         job_json = _write_job_json(tmp_path, spec)
         monkeypatch.setenv("EVALHUB_JOB_SPEC_PATH", str(job_json))


### PR DESCRIPTION


## What and why

Prevent symlink-following in local-mode auth resolution to close a directory-escape vulnerability where symlinked secret_ref dirs or key files could read arbitrary files outside the intended config scope.

Closes # NA

## Type

- [ ] feat
- [x] fix
- [ ] docs
- [ ] refactor / chore
- [ ] test / ci

## Testing

- [x] Tests added or updated
- [x] Tested manually

## Breaking changes
No
<!-- If yes, describe migration path. Otherwise delete this section. -->
