### PR TITLE
fix(models): allow empty model URL for pre-recorded evaluation jobs

### DIFF
--- a/examples/simple_adapter/simple_adapter.py
+++ b/examples/simple_adapter/simple_adapter.py
@@ -212,7 +212,7 @@ class ExampleAdapter(FrameworkAdapter):
             raise ValueError("benchmark_id is required")
 
         if not config.model.url:
-            raise ValueError("model.url is required")
+            logger.warning("model.url is empty; skipping live inference")
 
         if not config.model.name:
             raise ValueError("model.name is required")

--- a/src/evalhub/models/api.py
+++ b/src/evalhub/models/api.py
@@ -126,12 +126,14 @@ class ModelConfig(BaseModel):
     """Configuration for the model being evaluated.
 
     This matches the eval-hub API's ModelRef schema:
-    - url: The model endpoint URL (e.g., vLLM, OpenAI-compatible endpoint)
+    - url: The model endpoint URL (e.g., vLLM, OpenAI-compatible endpoint).
+      Empty string is valid for pre-recorded evaluation jobs that do not
+      require a live model endpoint.
     - name: Model name/identifier
     - auth: Optional model authentication (secret_ref)
     """
 
-    url: str = Field(..., description="Model endpoint URL")
+    url: str = Field(default="", description="Model endpoint URL")
     name: str = Field(..., description="Model name or identifier")
     auth: ModelAuth | None = Field(
         default=None, description="Authentication configuration for the model endpoint"
@@ -142,13 +144,6 @@ class ModelConfig(BaseModel):
     def validate_name(cls, v: str) -> str:
         if not v.strip():
             raise ValueError("Model name cannot be empty")
-        return v
-
-    @field_validator("url")
-    @classmethod
-    def validate_url(cls, v: str) -> str:
-        if not v.strip():
-            raise ValueError("Model URL cannot be empty")
         return v
 
 

--- a/tests/unit/test_models_api.py
+++ b/tests/unit/test_models_api.py
@@ -59,8 +59,17 @@ class TestModelConfig:
             ModelConfig(
                 url="http://localhost:8000/v1", name=""
             )  # Empty name should fail
-        with pytest.raises(ValidationError):
-            ModelConfig(url="", name="test-model")  # Empty URL should fail
+
+    def test_model_config_empty_url_for_prerecorded(self) -> None:
+        """Test ModelConfig accepts empty URL for pre-recorded evaluation jobs."""
+        config = ModelConfig(url="", name="test-model")
+        assert config.url == ""
+        assert config.name == "test-model"
+
+    def test_model_config_default_url_is_empty(self) -> None:
+        """Test ModelConfig defaults url to empty string when omitted."""
+        config = ModelConfig(name="test-model")
+        assert config.url == ""
 
 
 class TestBenchmarkInfo:


### PR DESCRIPTION
## Summary

- **Make `ModelConfig.url` optional** (default `""`) and remove the `validate_url` field validator that rejected empty strings, fixing pre-recorded evaluation jobs that don't require a live model endpoint (server-side validation in eval-hub#888 already handles the conditional requirement).
- **Update unit tests** to cover the empty-URL case and verify `ModelConfig` accepts it for pre-recorded mode.
- **Relax the example adapter** guard from a hard `ValueError` to a warning log when `model.url` is empty.

Resolves: [RHOAIENG-87581](https://redhat.atlassian.net/browse/RHOAIENG-87581)

## Test plan

- [x] `make test` — all 747 unit tests pass
- [x] `make ruff` — linter and formatter pass
- [x] New tests: `test_model_config_empty_url_for_prerecorded`, `test_model_config_default_url_is_empty`
- [ ] Verify pre-recorded evaluation job completes in a staging cluster after SDK release


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Model configurations can now omit the URL or use an empty URL for evaluations that don’t connect to a live model endpoint.
  - Existing model name validation remains unchanged.

- **Bug Fixes**
  - Empty model URLs are no longer rejected during configuration validation; a warning is logged and validation continues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->