### PR TITLE
feat(cli): add eval logs command for viewing job logs

### DIFF
--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -866,6 +866,125 @@ def eval_results(ctx: click.Context, job_id: str, output_format: str) -> None:
         click.echo(f"\nMLflow experiment: {job.results.mlflow_experiment_url}")
 
 
+@eval.command("logs")
+@click.argument("job_id")
+@click.option(
+    "--follow",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Stream logs until the job completes.",
+)
+@click.option(
+    "--tail",
+    type=int,
+    default=1000,
+    help="Number of lines to show (1-10000, default: 1000).",
+)
+@click.option(
+    "--timestamps",
+    is_flag=True,
+    default=False,
+    help="Include timestamps in log output.",
+)
+@click.option(
+    "--since",
+    "since_seconds",
+    type=int,
+    default=None,
+    help="Show logs from the last N seconds.",
+)
+@click.option(
+    "--benchmark-index",
+    type=int,
+    default=None,
+    help="Show logs for a specific benchmark by index.",
+)
+@click.option(
+    "--poll-interval",
+    type=float,
+    default=2.0,
+    help="Seconds between polls when using --follow (default: 2.0).",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=None,
+    help="Stop streaming after N seconds (only with --follow).",
+)
+@click.pass_context
+@handle_api_errors
+def eval_logs(
+    ctx: click.Context,
+    job_id: str,
+    follow: bool,
+    tail: int,
+    timestamps: bool,
+    since_seconds: int | None,
+    benchmark_index: int | None,
+    poll_interval: float,
+    timeout: float | None,
+) -> None:
+    """View logs for an evaluation job.
+
+    \b
+    Examples:
+      evalhub eval logs eval-123
+      evalhub eval logs eval-123 --tail 100 --timestamps
+      evalhub eval logs eval-123 --follow
+      evalhub eval logs eval-123 --follow --timeout 300
+      evalhub eval logs eval-123 --benchmark-index 0
+    """
+    client = get_client(ctx)
+    options = JobLogOptions(
+        tail_lines=tail,
+        timestamps=timestamps,
+        since_seconds=since_seconds,
+    )
+
+    if follow:
+        final_state: JobStatus | None = None
+        click.echo(f"Streaming logs for job {job_id}...", err=True)
+        try:
+            for update in client.jobs.watch_logs(
+                job_id,
+                benchmark_index=benchmark_index,
+                options=options,
+                poll_interval=poll_interval,
+                timeout=timeout,
+            ):
+                if update.logs:
+                    click.echo(update.logs, nl=False)
+                final_state = update.job.effective_state
+        except TimeoutError:
+            click.echo(
+                f"\nTimed out after {timeout}s before job {job_id} "
+                "reached a terminal state.",
+                err=True,
+            )
+            ctx.exit(2)
+
+        click.echo(err=True)
+        if final_state not in TERMINAL_JOB_STATES:
+            click.echo(
+                f"Stream ended before completion " f"(last state: {final_state}).",
+                err=True,
+            )
+            ctx.exit(2)
+        click.echo(
+            f"Job {job_id} finished with state: {final_state.value}",
+            err=True,
+        )
+    else:
+        logs = client.jobs.get_logs(
+            job_id,
+            benchmark_index=benchmark_index,
+            options=options,
+        )
+        if logs:
+            click.echo(logs, nl=False)
+
+
 @eval.command("cancel")
 @click.argument("job_id")
 @click.option(

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -877,7 +877,7 @@ def eval_results(ctx: click.Context, job_id: str, output_format: str) -> None:
 )
 @click.option(
     "--tail",
-    type=int,
+    type=click.IntRange(min=1, max=10000),
     default=1000,
     help="Number of lines to show (1-10000, default: 1000).",
 )
@@ -890,13 +890,13 @@ def eval_results(ctx: click.Context, job_id: str, output_format: str) -> None:
 @click.option(
     "--since",
     "since_seconds",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help="Show logs from the last N seconds.",
 )
 @click.option(
     "--benchmark-index",
-    type=int,
+    type=click.IntRange(min=0),
     default=None,
     help="Show logs for a specific benchmark by index.",
 )
@@ -908,7 +908,7 @@ def eval_results(ctx: click.Context, job_id: str, output_format: str) -> None:
 )
 @click.option(
     "--timeout",
-    type=float,
+    type=click.FloatRange(min=0, min_open=True),
     default=None,
     help="Stop streaming after N seconds (only with --follow).",
 )

--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -902,7 +902,7 @@ def eval_results(ctx: click.Context, job_id: str, output_format: str) -> None:
 )
 @click.option(
     "--poll-interval",
-    type=float,
+    type=click.FloatRange(min=0, min_open=True),
     default=2.0,
     help="Seconds between polls when using --follow (default: 2.0).",
 )
@@ -935,6 +935,9 @@ def eval_logs(
       evalhub eval logs eval-123 --follow --timeout 300
       evalhub eval logs eval-123 --benchmark-index 0
     """
+    if timeout is not None and not follow:
+        raise click.UsageError("--timeout requires --follow")
+
     client = get_client(ctx)
     options = JobLogOptions(
         tail_lines=tail,

--- a/tests/unit/test_cli_eval.py
+++ b/tests/unit/test_cli_eval.py
@@ -1268,6 +1268,29 @@ class TestEvalLogs:
         assert result.exit_code == 0
         assert result.output == ""
 
+    def test_logs_timeout_without_follow_errors(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main, ["eval", "logs", "eval-123", "--timeout", "30"]
+            )
+        assert result.exit_code != 0
+        assert "--timeout requires --follow" in result.output
+
+    def test_logs_follow_incomplete_stream(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.jobs.watch_logs.return_value = iter(
+            [
+                JobLogUpdate(logs="partial\n", job=_make_job(state=JobStatus.PENDING)),
+            ]
+        )
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(main, ["eval", "logs", "eval-123", "--follow"])
+        assert result.exit_code == 2
+        assert "Stream ended before completion" in result.output
+
 
 # --- eval cancel ---
 

--- a/tests/unit/test_cli_eval.py
+++ b/tests/unit/test_cli_eval.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 from click.testing import CliRunner
 from evalhub.cli.main import main
-from evalhub.client.job_logs import JobLogUpdate
+from evalhub.client.job_logs import JobLogOptions, JobLogUpdate
 from evalhub.models.api import (
     BenchmarkConfig,
     BenchmarkResult,
@@ -1143,6 +1143,132 @@ class TestEvalResults:
         assert "hellaswag" in result.output
 
 
+# --- eval logs ---
+
+
+class TestEvalLogs:
+    def test_logs_snapshot(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.jobs.get_logs.return_value = "line1\nline2\n"
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(main, ["eval", "logs", "eval-123"])
+        assert result.exit_code == 0
+        assert "line1" in result.output
+        assert "line2" in result.output
+        mock_client.jobs.get_logs.assert_called_once_with(
+            "eval-123",
+            benchmark_index=None,
+            options=JobLogOptions(tail_lines=1000, timestamps=False),
+        )
+
+    def test_logs_with_tail(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.jobs.get_logs.return_value = "tail output\n"
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(main, ["eval", "logs", "eval-123", "--tail", "50"])
+        assert result.exit_code == 0
+        mock_client.jobs.get_logs.assert_called_once_with(
+            "eval-123",
+            benchmark_index=None,
+            options=JobLogOptions(tail_lines=50, timestamps=False),
+        )
+
+    def test_logs_with_timestamps(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.jobs.get_logs.return_value = "2026-01-01T00:00:00Z line\n"
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(main, ["eval", "logs", "eval-123", "--timestamps"])
+        assert result.exit_code == 0
+        mock_client.jobs.get_logs.assert_called_once_with(
+            "eval-123",
+            benchmark_index=None,
+            options=JobLogOptions(tail_lines=1000, timestamps=True),
+        )
+
+    def test_logs_with_since(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.jobs.get_logs.return_value = "recent log\n"
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(main, ["eval", "logs", "eval-123", "--since", "300"])
+        assert result.exit_code == 0
+        mock_client.jobs.get_logs.assert_called_once_with(
+            "eval-123",
+            benchmark_index=None,
+            options=JobLogOptions(tail_lines=1000, timestamps=False, since_seconds=300),
+        )
+
+    def test_logs_with_benchmark_index(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.jobs.get_logs.return_value = "benchmark 0 logs\n"
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main, ["eval", "logs", "eval-123", "--benchmark-index", "0"]
+            )
+        assert result.exit_code == 0
+        mock_client.jobs.get_logs.assert_called_once_with(
+            "eval-123",
+            benchmark_index=0,
+            options=JobLogOptions(tail_lines=1000, timestamps=False),
+        )
+
+    def test_logs_follow(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        completed = _make_job(state=JobStatus.COMPLETED)
+        mock_client.jobs.watch_logs.return_value = iter(
+            [
+                JobLogUpdate(logs="starting\n", job=_make_job(state=JobStatus.RUNNING)),
+                JobLogUpdate(logs="done\n", job=completed),
+            ]
+        )
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(main, ["eval", "logs", "eval-123", "--follow"])
+        assert result.exit_code == 0
+        assert "starting" in result.output
+        assert "done" in result.output
+        assert "finished with state: completed" in result.output
+        mock_client.jobs.watch_logs.assert_called_once_with(
+            "eval-123",
+            benchmark_index=None,
+            options=JobLogOptions(tail_lines=1000, timestamps=False),
+            poll_interval=2.0,
+            timeout=None,
+        )
+
+    def test_logs_follow_timeout(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.jobs.watch_logs.side_effect = TimeoutError
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main,
+                ["eval", "logs", "eval-123", "--follow", "--timeout", "10"],
+            )
+        assert result.exit_code == 2
+        assert "Timed out" in result.output
+        mock_client.jobs.watch_logs.assert_called_once_with(
+            "eval-123",
+            benchmark_index=None,
+            options=JobLogOptions(tail_lines=1000, timestamps=False),
+            poll_interval=2.0,
+            timeout=10.0,
+        )
+
+    def test_logs_empty(
+        self, runner: CliRunner, config_file: Path, mock_client: MagicMock
+    ) -> None:
+        mock_client.jobs.get_logs.return_value = ""
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(main, ["eval", "logs", "eval-123"])
+        assert result.exit_code == 0
+        assert result.output == ""
+
+
 # --- eval cancel ---
 
 
@@ -1188,6 +1314,7 @@ class TestEvalHelp:
         assert "run" in result.output
         assert "status" in result.output
         assert "results" in result.output
+        assert "logs" in result.output
         assert "cancel" in result.output
 
     def test_eval_run_help(self, runner: CliRunner) -> None:
@@ -1204,6 +1331,15 @@ class TestEvalHelp:
         assert result.exit_code == 0
         assert "--status" in result.output
         assert "--watch" in result.output
+
+    def test_eval_logs_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(main, ["eval", "logs", "--help"])
+        assert result.exit_code == 0
+        assert "--follow" in result.output
+        assert "--tail" in result.output
+        assert "--timestamps" in result.output
+        assert "--since" in result.output
+        assert "--benchmark-index" in result.output
 
     def test_eval_results_help(self, runner: CliRunner) -> None:
         result = runner.invoke(main, ["eval", "results", "--help"])


### PR DESCRIPTION
## Summary

- Adds `evalhub eval logs <job-id>` CLI command, exposing the existing client SDK `get_logs` and `watch_logs` capabilities that were previously inaccessible from the CLI
- Supports one-shot log retrieval (default) and streaming (`--follow`), with options for `--tail`, `--timestamps`, `--since`, `--benchmark-index`, `--poll-interval`, and `--timeout`
- Closes the last remaining gap from #125 — users can now view logs for any submitted job without needing `--watch` at submission time

## Test plan

- [x] 9 new unit tests added in `TestEvalLogs` covering: snapshot fetch, `--tail`, `--timestamps`, `--since`, `--benchmark-index`, `--follow` streaming, follow timeout (exit code 2), and empty logs
- [x] `test_eval_logs_help` validates all options appear in `--help`
- [x] `test_eval_help` updated to assert `logs` appears in `eval --help`
- [x] All 57 tests pass (`make test`)
- [x] Ruff clean (`make ruff`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `eval logs` command to retrieve evaluation job logs.
  * Supports one-time viewing or live follow mode.
  * Added options for tail length, timestamps, time filtering, benchmark selection, polling intervals, and timeouts.
  * Follow mode reports job completion and clearly handles timeouts or interrupted jobs.
* **Bug Fixes**
  * Added validation for log retrieval options, including numeric ranges and timeout usage.
* **Tests**
  * Added comprehensive coverage for log retrieval, filtering, follow mode, timeouts, empty output, validation, and command help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->