### PR TITLE
fix(cli): reject NaN and infinity for poll-interval and timeout options

### DIFF
--- a/src/evalhub/cli/main.py
+++ b/src/evalhub/cli/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import re
 import shutil
 import sys
@@ -43,6 +44,27 @@ from .completion import completion
 from .formatter import format_option, output
 from .mcp_cmd import mcp
 from .server_cmd import server
+
+
+class FiniteFloatRange(click.FloatRange):
+    """A FloatRange that additionally rejects NaN and infinity."""
+
+    name = "FINITE_FLOAT"
+
+    def convert(
+        self,
+        value: Any,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> Any:
+        rv = super().convert(value, param, ctx)
+        if not math.isfinite(rv):
+            self.fail(
+                f"{rv} is not a finite number.",
+                param,
+                ctx,
+            )
+        return rv
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -902,13 +924,13 @@ def eval_results(ctx: click.Context, job_id: str, output_format: str) -> None:
 )
 @click.option(
     "--poll-interval",
-    type=click.FloatRange(min=0, min_open=True),
+    type=FiniteFloatRange(min=0, min_open=True),
     default=2.0,
     help="Seconds between polls when using --follow (default: 2.0).",
 )
 @click.option(
     "--timeout",
-    type=click.FloatRange(min=0, min_open=True),
+    type=FiniteFloatRange(min=0, min_open=True),
     default=None,
     help="Stop streaming after N seconds (only with --follow).",
 )

--- a/tests/unit/test_cli_eval.py
+++ b/tests/unit/test_cli_eval.py
@@ -1278,6 +1278,31 @@ class TestEvalLogs:
         assert result.exit_code != 0
         assert "--timeout requires --follow" in result.output
 
+    @pytest.mark.parametrize(
+        "option,value",
+        [
+            ("--poll-interval", "nan"),
+            ("--poll-interval", "inf"),
+            ("--timeout", "nan"),
+            ("--timeout", "inf"),
+        ],
+    )
+    def test_logs_rejects_non_finite_floats(
+        self,
+        runner: CliRunner,
+        config_file: Path,
+        mock_client: MagicMock,
+        option: str,
+        value: str,
+    ) -> None:
+        with patch("evalhub.cli.main.get_client", return_value=mock_client):
+            result = runner.invoke(
+                main,
+                ["eval", "logs", "eval-123", "--follow", option, value],
+            )
+        assert result.exit_code != 0
+        assert "not a finite number" in result.output
+
     def test_logs_follow_incomplete_stream(
         self, runner: CliRunner, config_file: Path, mock_client: MagicMock
     ) -> None:


### PR DESCRIPTION
## Summary
- Adds `FiniteFloatRange`, a custom Click parameter type extending `FloatRange` that rejects non-finite values (`NaN`, `inf`) via `math.isfinite()`.
- Applies it to `--poll-interval` and `--timeout` on the `eval logs` command, preserving existing positive-value (`x > 0`) constraints and defaults.
- Adds 4 parametrized unit tests covering `nan` and `inf` for both options.

## Test plan
- [x] All 63 existing + new unit tests pass (`uv run pytest tests/unit/test_cli_eval.py`)
- [x] mypy strict passes on `src/evalhub/cli/main.py`
- [x] ruff lint clean
- [x] Pre-commit hooks pass


Made with [Cursor](https://cursor.com)